### PR TITLE
fix: propagate Basecamp profile to UI hosts

### DIFF
--- a/app/main.cpp
+++ b/app/main.cpp
@@ -161,6 +161,14 @@ int main(int argc, char *argv[])
         }
     }
 
+    // Make the owning Basecamp profile explicit for out-of-process UI
+    // backends. ViewModuleHost starts ui-host with an inherited environment;
+    // without this export, an ordinary launch lets the child derive a
+    // machine-wide `ui-host` AppDataLocation from its own application name.
+    // This must happen before any ViewModuleHost can be constructed.
+    const QString resolvedBaseDirectory =
+        LogosBasecampPaths::resolveAndExportBaseDirectory();
+
     // Redirect stdout/stderr to a rotating per-session log file under
     // <baseDirectory>/logs. Must happen after setOrganizationName/setApplicationName
     // and after the --user-dir override is applied so baseDirectory() resolves
@@ -175,7 +183,7 @@ int main(int argc, char *argv[])
     // Print build metadata (version, dev/portable, commit hashes) so the
     // per-session log captures exactly which sources produced this binary.
     LogosBasecampBuildInfo::logStartupBanner();
-    qInfo().noquote() << "Base data directory:" << LogosBasecampPaths::baseDirectory();
+    qInfo().noquote() << "Base data directory:" << resolvedBaseDirectory;
 
     // Set up module directories for logos core.
     // 1. Embedded modules directory (pre-installed at build time, read-only)

--- a/app/utils/LogosBasecampPaths.h
+++ b/app/utils/LogosBasecampPaths.h
@@ -48,6 +48,23 @@ inline QString baseDirectory()
     return isPortableBuild() ? portableBaseDirectory() : nonPortableBaseDirectory();
 }
 
+// Resolve Basecamp's owning profile once, then make that exact root explicit
+// for every child process. Out-of-process UI backends run in `ui-host`, whose
+// QStandardPaths::AppDataLocation would otherwise be based on the child
+// application name and collapse ordinary Basecamp launches into a shared
+// `.../Logos/ui-host` tree.
+//
+// QProcess inherits the current process environment by default. Calling this
+// before any ViewModuleHost can spawn therefore gives default-profile and
+// --user-dir launches the same explicit, application-name-independent
+// contract. Existing LOGOS_USER_DIR overrides are preserved verbatim.
+inline QString resolveAndExportBaseDirectory()
+{
+    const QString resolved = baseDirectory();
+    qputenv("LOGOS_USER_DIR", resolved.toUtf8());
+    return resolved;
+}
+
 // Plugin and module install directories
 inline QString pluginsDirectory()
 {

--- a/tests/basecamp_paths_test.cpp
+++ b/tests/basecamp_paths_test.cpp
@@ -1,0 +1,100 @@
+#include <QtTest/QtTest>
+
+#include <QCoreApplication>
+#include <QProcessEnvironment>
+#include <QStandardPaths>
+#include <QTemporaryDir>
+
+#include "../app/utils/LogosBasecampPaths.h"
+
+class BasecampPathsTest : public QObject
+{
+    Q_OBJECT
+
+private:
+    QByteArray m_originalUserDir;
+    bool m_hadOriginalUserDir = false;
+    QString m_originalOrganizationName;
+    QString m_originalApplicationName;
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void init();
+    void cleanup();
+
+    void defaultRootIsExportedForUiHost();
+    void explicitOverrideIsExportedVerbatim();
+};
+
+void BasecampPathsTest::initTestCase()
+{
+    m_hadOriginalUserDir = qEnvironmentVariableIsSet("LOGOS_USER_DIR");
+    m_originalUserDir = qgetenv("LOGOS_USER_DIR");
+    m_originalOrganizationName = QCoreApplication::organizationName();
+    m_originalApplicationName = QCoreApplication::applicationName();
+
+    // Keep the default-root regression hermetic: Qt redirects standard paths
+    // to its test tree instead of touching the developer's real app data.
+    QStandardPaths::setTestModeEnabled(true);
+}
+
+void BasecampPathsTest::cleanupTestCase()
+{
+    QCoreApplication::setOrganizationName(m_originalOrganizationName);
+    QCoreApplication::setApplicationName(m_originalApplicationName);
+    if (m_hadOriginalUserDir)
+        qputenv("LOGOS_USER_DIR", m_originalUserDir);
+    else
+        qunsetenv("LOGOS_USER_DIR");
+}
+
+void BasecampPathsTest::init()
+{
+    qunsetenv("LOGOS_USER_DIR");
+    QCoreApplication::setOrganizationName(QStringLiteral("LogosProfileTest"));
+    QCoreApplication::setApplicationName(QStringLiteral("LogosBasecamp"));
+}
+
+void BasecampPathsTest::cleanup()
+{
+    qunsetenv("LOGOS_USER_DIR");
+}
+
+void BasecampPathsTest::defaultRootIsExportedForUiHost()
+{
+    const QString parentRoot = LogosBasecampPaths::baseDirectory();
+    QVERIFY2(!parentRoot.isEmpty(), "Qt must resolve a test-mode Basecamp root");
+    QVERIFY(!qEnvironmentVariableIsSet("LOGOS_USER_DIR"));
+
+    QCOMPARE(LogosBasecampPaths::resolveAndExportBaseDirectory(), parentRoot);
+    QCOMPARE(qEnvironmentVariable("LOGOS_USER_DIR"), parentRoot);
+    QCOMPARE(QProcessEnvironment::systemEnvironment().value(
+                 QStringLiteral("LOGOS_USER_DIR")),
+             parentRoot);
+
+    // Model the child process changing Qt's application identity to ui-host.
+    // The inherited explicit root must win over its own AppDataLocation.
+    QCoreApplication::setApplicationName(QStringLiteral("ui-host"));
+    QCOMPARE(LogosBasecampPaths::baseDirectory(), parentRoot);
+}
+
+void BasecampPathsTest::explicitOverrideIsExportedVerbatim()
+{
+    QTemporaryDir profile;
+    QVERIFY(profile.isValid());
+    const QString explicitRoot = profile.path() + QStringLiteral("/profile-a");
+    qputenv("LOGOS_USER_DIR", explicitRoot.toUtf8());
+
+    QCOMPARE(LogosBasecampPaths::resolveAndExportBaseDirectory(), explicitRoot);
+    QCOMPARE(qEnvironmentVariable("LOGOS_USER_DIR"), explicitRoot);
+    QCOMPARE(QProcessEnvironment::systemEnvironment().value(
+                 QStringLiteral("LOGOS_USER_DIR")),
+             explicitRoot);
+
+    QCoreApplication::setApplicationName(QStringLiteral("ui-host"));
+    QCOMPARE(LogosBasecampPaths::baseDirectory(), explicitRoot);
+}
+
+QTEST_GUILESS_MAIN(BasecampPathsTest)
+#include "basecamp_paths_test.moc"


### PR DESCRIPTION
## Summary

- resolve the owning Basecamp persistence root once after `--user-dir` parsing
- export that exact root as `LOGOS_USER_DIR` before any out-of-process UI backend can spawn
- preserve explicit `--user-dir` / `LOGOS_USER_DIR` overrides verbatim
- add hermetic regressions for both the default root and an explicit override, including a simulated `ui-host` application-name change

`ViewModuleHost` uses a plain `QProcess`, so its child inherits this explicit root. The child no longer derives profile identity from its own Qt application name. This does not read or migrate data from the old generic `Logos/ui-host` tree; that requires a separate explicit policy.

## Linked issues

Fixes #315
Refs logos-co/eth-lez-atomic-swaps#99

## Test plan

- [x] `nix build .#unit-tests -L` (9/9 test executables passed)
- [ ] `nix build .#app` (attempted locally; blocked before Basecamp compilation by the pinned `logos-view-module-runtime` dependency failing its Qt/CMake atomic probe with `SOURCE_FROM_VAR failed to open "src.cxx" for writing`)
- [ ] `nix build .#smoke-test -L`
- [ ] CI on Linux and macOS

No user-visible UI changes.

## Release notes

fix: keep out-of-process UI module persistence inside the owning Basecamp profile

## Checklist

- [x] Branch uses the `fix/` prefix
- [x] No unrelated changes bundled
- [x] No generated binaries or screenshots committed
- [x] Documentation remains accurate; this changes internal child-process propagation only