### PR TITLE
feat: notify when a newer Basecamp release is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,19 @@ Prebuilt binaries for Linux (AppImage) and macOS (DMG):
 
 Release candidates are marked as pre-release, so `/releases/latest` skips them. If the stable release is significantly older than the RCs on the releases page, you probably want an RC.
 
+### Updating
+
+Released builds check GitHub for a newer stable release shortly after launch. When one
+exists, an **Update** badge appears under the version in the sidebar and a marker on the
+Settings button; **Settings → Dashboard → Updates** then shows the new version, offers to
+download the right AppImage/DMG for your platform, and tells you what to do with it.
+Basecamp does not install the update itself — you replace your existing copy.
+
+The check is a single unauthenticated `GET` to the GitHub releases API. It sends no
+identifiers beyond a `LogosBasecamp/<version>` user agent, and it never runs on dev or
+pre-release builds (there is no version to compare). Set `LOGOS_DISABLE_UPDATE_CHECK=1` to
+turn it off entirely.
+
 ## How to Build
 
 ### Using Nix (Recommended)

--- a/nix/integration-test.nix
+++ b/nix/integration-test.nix
@@ -19,6 +19,19 @@ pkgs.runCommand "logos-basecamp-integration-test" {
   mkdir -p "$LOGOS_USER_DIR"
 
   export QT_QPA_PLATFORM=offscreen
+  # Pin the update check at a file:// stub rather than disabling it.
+  #
+  # Hermeticity comes from the stub, not from the kill switch -- no socket is
+  # opened either way. Disabling would instead unregister the two update tests
+  # in ui-tests.mjs (they self-skip on LOGOS_DISABLE_UPDATE_CHECK), so this --
+  # the ONLY automated runner of that suite -- would print a green skip forever
+  # and the feature's UI coverage would never actually execute in CI.
+  #
+  # Without an override the check would be eligible on a release/** branch
+  # (VERSION present) and hit api.github.com, which succeeds on a sandbox=false
+  # host and DNS-fails on Linux CI: the same derivation behaving two ways.
+  export LOGOS_UPDATE_CHECK_URL="file://${src}/tests/fixtures/update-release-stub.json"
+  export LOGOS_UPDATE_CURRENT_VERSION=0.0.1
   export QT_FORCE_STDERR_LOGGING=1
   export QT_LOGGING_RULES="qt.*.debug=false;default.debug=true"
 

--- a/nix/shutdown-test.nix
+++ b/nix/shutdown-test.nix
@@ -20,6 +20,12 @@ pkgs.runCommand "logos-basecamp-shutdown-test" {
   mkdir -p "$LOGOS_USER_DIR"
 
   export QT_QPA_PLATFORM=offscreen
+  # Keep the derivation hermetic. On a release/** branch VERSION is present,
+  # so UpdateChecker would consider itself eligible and hit api.github.com --
+  # which succeeds on a sandbox=false host and DNS-fails on Linux CI, i.e. the
+  # same derivation behaving two ways. It would also float an "Update" badge
+  # into the sidebar under the UI tests.
+  export LOGOS_DISABLE_UPDATE_CHECK=1
   export QT_FORCE_STDERR_LOGGING=1
   export QT_LOGGING_RULES="qt.*.debug=false;default.debug=true"
 

--- a/nix/smoke-test.nix
+++ b/nix/smoke-test.nix
@@ -32,6 +32,12 @@ pkgs.runCommand "logos-basecamp-smoke-test" {
   mkdir -p "$LOGOS_USER_DIR"
 
   export QT_QPA_PLATFORM=offscreen
+  # Keep the derivation hermetic. On a release/** branch VERSION is present,
+  # so UpdateChecker would consider itself eligible and hit api.github.com --
+  # which succeeds on a sandbox=false host and DNS-fails on Linux CI, i.e. the
+  # same derivation behaving two ways. It would also float an "Update" badge
+  # into the sidebar under the UI tests.
+  export LOGOS_DISABLE_UPDATE_CHECK=1
   export QT_FORCE_STDERR_LOGGING=1
   export QT_LOGGING_RULES="qt.*.debug=false;default.debug=true"
 

--- a/src/Basecamp/Settings/DashboardView.qml
+++ b/src/Basecamp/Settings/DashboardView.qml
@@ -2,6 +2,11 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Logos.Controls
+import Logos.Icons
+import Logos.Theme
+
+// UpdateCheckState / UpdateDownloadStage.
+import Basecamp.Backend 1.0
 
 Item {
     id: root
@@ -55,6 +60,455 @@ Item {
                     font.pixelSize: 14
                     color: "#a0a0a0"
                 }
+            }
+
+            // Host-app update checker. The whole section collapses on builds
+            // where the check never runs (dev / pre-release / non-nix), which
+            // report Skipped — those users must see nothing at all here, not
+            // an "unknown" row.
+            ColumnLayout {
+                id: updateSection
+
+                objectName: "dashboard.updateSection"
+
+                // Cached so the nested stage rows read as a state machine
+                // rather than a wall of repeated backend lookups.
+                readonly property int checkState: backend.updateCheckState
+                readonly property int stage: backend.updateDownloadStage
+                // A stage still parked at Idle on a platform with no matching
+                // release asset is presented as Unsupported, not as a download
+                // offer that would fail the moment it is clicked.
+                readonly property bool offersDownload: stage === UpdateDownloadStage.Idle
+                                                       && backend.downloadSupported
+
+                Layout.fillWidth: true
+                Layout.topMargin: 10
+                spacing: 8
+                visible: checkState !== UpdateCheckState.Skipped
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 8
+
+                    LogosText {
+                        text: "Updates"
+                        font.pixelSize: 18
+                        font.weight: Font.Bold
+                        color: "#ffffff"
+                    }
+                }
+
+                // ── Checking ──────────────────────────────────────────────
+                RowLayout {
+                    id: updateCheckingRow
+
+                    objectName: "dashboard.updateChecking"
+                    Layout.fillWidth: true
+                    spacing: 10
+                    visible: updateSection.checkState === UpdateCheckState.Checking
+
+                    LogosSpinner {
+                        Layout.preferredWidth: 16
+                        Layout.preferredHeight: 16
+                        running: updateCheckingRow.visible
+                    }
+
+                    LogosText {
+                        Layout.fillWidth: true
+                        text: "Checking for updates…"
+                        font.pixelSize: 14
+                        color: "#a0a0a0"
+                    }
+                }
+
+                // ── Up to date ────────────────────────────────────────────
+                RowLayout {
+                    objectName: "dashboard.updateUpToDate"
+                    Layout.fillWidth: true
+                    spacing: 16
+                    visible: updateSection.checkState === UpdateCheckState.UpToDate
+
+                    LogosText {
+                        text: "You're on the latest version."
+                        font.pixelSize: 14
+                        color: "#a0a0a0"
+                    }
+
+                    LogosButton {
+                        objectName: "dashboard.updateCheckButton"
+                        text: "Check for updates"
+                        leadingIcon.source: LogosIcons.refresh
+                        leadingIcon.brightness: 1.0
+                        onClicked: backend.checkForUpdates()
+                    }
+
+                    Item { Layout.fillWidth: true }
+                }
+
+                // ── Check failed ──────────────────────────────────────────
+                // Deliberately distinct from "up to date": a failed check must
+                // never read as a clean bill of health.
+                ColumnLayout {
+                    objectName: "dashboard.updateCheckFailed"
+                    Layout.fillWidth: true
+                    spacing: 8
+                    visible: updateSection.checkState === UpdateCheckState.Failed
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        LogosIcon {
+                            source: LogosIcons.warning
+                            color: Theme.palette.warning
+                            Layout.preferredWidth: 16
+                            Layout.preferredHeight: 16
+                            Layout.alignment: Qt.AlignVCenter
+                        }
+
+                        LogosText {
+                            Layout.fillWidth: true
+                            text: "Couldn't check for updates."
+                            font.pixelSize: 14
+                            color: "#a0a0a0"
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 16
+
+                        LogosButton {
+                            objectName: "dashboard.updateRetryCheckButton"
+                            text: "Check for updates"
+                            leadingIcon.source: LogosIcons.refresh
+                            leadingIcon.brightness: 1.0
+                            onClicked: backend.checkForUpdates()
+                        }
+
+                        LogosLink {
+                            objectName: "dashboard.updateCheckFailedLink"
+                            text: "View releases"
+                            href: backend.releaseUrl
+                            onActivated: backend.openReleasePage()
+                        }
+
+                        Item { Layout.fillWidth: true }
+                    }
+                }
+
+                // ── Update available ──────────────────────────────────────
+                //
+                // The only actionable thing on an otherwise read-only page, so
+                // it gets a card while the flat "Commits" list stays flat. That
+                // contrast is the point: without it the notice reads as one more
+                // paragraph of build metadata and is easy to scroll past — which
+                // is the exact failure (#319) this feature exists to fix.
+                Rectangle {
+                    objectName: "dashboard.updateAvailable"
+                    Layout.fillWidth: true
+                    Layout.bottomMargin: 8
+                    visible: updateSection.checkState === UpdateCheckState.UpdateAvailable
+                    // Hug the content rather than reserving room for every state.
+                    implicitHeight: updateCard.implicitHeight + 2 * updateCard.anchors.margins
+                    color: Theme.palette.surfaceRaised
+                    border.color: Theme.palette.borderSubtle
+                    border.width: 1
+                    radius: 8
+
+                ColumnLayout {
+                    id: updateCard
+
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.top: parent.top
+                    anchors.margins: 16
+                    spacing: 10
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        // Leads with the version rather than a bare "Update
+                        // available" + badge: the number is the information the
+                        // user actually needs, and the old phrasing buried it in
+                        // a chip beside the label.
+                        LogosText {
+                            text: "Basecamp " + backend.latestVersion + " is available"
+                            font.pixelSize: 15
+                            font.weight: Font.Bold
+                            color: "#ffffff"
+                        }
+
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    LogosText {
+                        Layout.fillWidth: true
+                        visible: backend.buildVersion.length > 0
+                        text: "You're on " + backend.buildVersion
+                        font.pixelSize: 13
+                        color: "#a0a0a0"
+                    }
+
+                    // ── Download: idle ────────────────────────────────────
+                    RowLayout {
+                        objectName: "dashboard.updateDownloadIdle"
+                        Layout.fillWidth: true
+                        spacing: 16
+                        visible: updateSection.offersDownload
+
+                        LogosButton {
+                            objectName: "dashboard.updateDownloadButton"
+                            text: "Download update"
+                            variant: LogosButton.Variant.Primary
+                            leadingIcon.source: LogosIcons.install
+                            // LogosIcon tints via MultiEffect colorization, which
+                            // leaves a dark source silhouette essentially untouched —
+                            // the glyph renders as its raw asset color instead of the
+                            // button's foreground. brightness 1.0 normalizes it first.
+                            // Same reason as ConfirmationDialog.qml's warning icon.
+                            leadingIcon.brightness: 1.0
+                            onClicked: backend.startUpdateDownload()
+                        }
+
+                        LogosLink {
+                            objectName: "dashboard.updateReleaseLink"
+                            text: "View release notes"
+                            href: backend.releaseUrl
+                            onActivated: backend.openReleasePage()
+                        }
+
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    // ── Download: unsupported on this platform ────────────
+                    ColumnLayout {
+                        objectName: "dashboard.updateDownloadUnsupported"
+                        Layout.fillWidth: true
+                        spacing: 6
+                        visible: updateSection.stage === UpdateDownloadStage.Unsupported
+                                 || (updateSection.stage === UpdateDownloadStage.Idle
+                                     && !backend.downloadSupported)
+
+                        LogosLink {
+                            objectName: "dashboard.updateUnsupportedLink"
+                            text: "View release notes"
+                            href: backend.releaseUrl
+                            onActivated: backend.openReleasePage()
+                        }
+
+                        LogosText {
+                            Layout.fillWidth: true
+                            text: "No automatic download for this platform."
+                            font.pixelSize: 13
+                            color: "#a0a0a0"
+                            wrapMode: Text.WordWrap
+                        }
+                    }
+
+                    // ── Download: starting ────────────────────────────────
+                    RowLayout {
+                        id: updateStartingRow
+
+                        objectName: "dashboard.updateStarting"
+                        Layout.fillWidth: true
+                        spacing: 16
+                        visible: updateSection.stage === UpdateDownloadStage.Starting
+
+                        LogosSpinner {
+                            Layout.preferredWidth: 16
+                            Layout.preferredHeight: 16
+                            running: updateStartingRow.visible
+                        }
+
+                        LogosText {
+                            text: "Starting download…"
+                            font.pixelSize: 13
+                            color: "#a0a0a0"
+                        }
+
+                        LogosButton {
+                            objectName: "dashboard.updateCancelStartButton"
+                            text: "Cancel"
+                            onClicked: backend.cancelUpdateDownload()
+                        }
+
+                        Item { Layout.fillWidth: true }
+                    }
+
+                    // ── Download: in progress ─────────────────────────────
+                    ColumnLayout {
+                        objectName: "dashboard.updateDownloading"
+                        Layout.fillWidth: true
+                        spacing: 8
+                        visible: updateSection.stage === UpdateDownloadStage.Downloading
+
+                        LogosProgressBar {
+                            objectName: "dashboard.updateProgressBar"
+                            Layout.fillWidth: true
+                            from: 0
+                            to: 1
+                            value: backend.downloadProgress
+                            // -1 means the server sent no Content-Length.
+                            indeterminate: backend.downloadProgress < 0
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 16
+
+                            LogosText {
+                                objectName: "dashboard.updateProgressText"
+                                Layout.fillWidth: true
+                                text: backend.downloadProgressText
+                                font.pixelSize: 13
+                                color: "#a0a0a0"
+                            }
+
+                            LogosButton {
+                                objectName: "dashboard.updateCancelButton"
+                                text: "Cancel"
+                                onClicked: backend.cancelUpdateDownload()
+                            }
+                        }
+                    }
+
+                    // ── Download: verifying ───────────────────────────────
+                    RowLayout {
+                        id: updateVerifyingRow
+
+                        objectName: "dashboard.updateVerifying"
+                        Layout.fillWidth: true
+                        spacing: 10
+                        visible: updateSection.stage === UpdateDownloadStage.Verifying
+
+                        LogosSpinner {
+                            Layout.preferredWidth: 16
+                            Layout.preferredHeight: 16
+                            running: updateVerifyingRow.visible
+                        }
+
+                        LogosText {
+                            Layout.fillWidth: true
+                            text: "Checking download…"
+                            font.pixelSize: 13
+                            color: "#a0a0a0"
+                        }
+                    }
+
+                    // ── Download: done ────────────────────────────────────
+                    ColumnLayout {
+                        objectName: "dashboard.updateDownloadDone"
+                        Layout.fillWidth: true
+                        spacing: 8
+                        visible: updateSection.stage === UpdateDownloadStage.Done
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            LogosIcon {
+                                source: LogosIcons.check
+                                color: Theme.palette.success
+                                Layout.preferredWidth: 16
+                                Layout.preferredHeight: 16
+                                Layout.alignment: Qt.AlignTop
+                            }
+
+                            // "Saved to" stays a plain label so a drag-select
+                            // copies the bare path, not the prefix.
+                            LogosText {
+                                text: "Saved to"
+                                font.pixelSize: 13
+                                color: "#a0a0a0"
+                                Layout.alignment: Qt.AlignTop
+                            }
+
+                            LogosSelectableText {
+                                objectName: "dashboard.updateDownloadPath"
+                                Layout.fillWidth: true
+                                text: backend.downloadedFilePath
+                                font.pixelSize: 13
+                                color: "#d0d0d0"
+                                wrapMode: TextEdit.WrapAnywhere
+                            }
+                        }
+
+                        LogosText {
+                            objectName: "dashboard.updateInstallHint"
+                            Layout.fillWidth: true
+                            visible: backend.updateInstallHint.length > 0
+                            text: backend.updateInstallHint
+                            font.pixelSize: 13
+                            color: "#a0a0a0"
+                            wrapMode: Text.WordWrap
+                        }
+
+                        LogosButton {
+                            objectName: "dashboard.updateRevealButton"
+                            text: Qt.platform.os === "osx" ? "Show in Finder"
+                                                           : "Show in Folder"
+                            onClicked: backend.revealUpdateDownload()
+                        }
+                    }
+
+                    // ── Download: failed ──────────────────────────────────
+                    ColumnLayout {
+                        objectName: "dashboard.updateDownloadFailed"
+                        Layout.fillWidth: true
+                        spacing: 8
+                        visible: updateSection.stage === UpdateDownloadStage.Failed
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 8
+
+                            LogosIcon {
+                                source: LogosIcons.warning
+                                color: Theme.palette.error
+                                Layout.preferredWidth: 16
+                                Layout.preferredHeight: 16
+                                Layout.alignment: Qt.AlignTop
+                            }
+
+                            LogosText {
+                                objectName: "dashboard.updateDownloadError"
+                                Layout.fillWidth: true
+                                text: backend.downloadError.length > 0
+                                    ? backend.downloadError
+                                    : "Download failed."
+                                font.pixelSize: 13
+                                color: "#a0a0a0"
+                                wrapMode: Text.WordWrap
+                            }
+                        }
+
+                        RowLayout {
+                            Layout.fillWidth: true
+                            spacing: 16
+
+                            LogosButton {
+                                objectName: "dashboard.updateRetryDownloadButton"
+                                text: "Retry"
+                                leadingIcon.source: LogosIcons.refresh
+                                leadingIcon.brightness: 1.0
+                                onClicked: backend.startUpdateDownload()
+                            }
+
+                            LogosLink {
+                                objectName: "dashboard.updateDownloadFailedLink"
+                                text: "View release notes"
+                                href: backend.releaseUrl
+                                onActivated: backend.openReleasePage()
+                            }
+
+                            Item { Layout.fillWidth: true }
+                        }
+                    }
+                }
+                }  // update-available card
             }
 
             // Commit hashes for basecamp + all flake dependencies.

--- a/src/Basecamp/Sidebar/SidebarCircleButton.qml
+++ b/src/Basecamp/Sidebar/SidebarCircleButton.qml
@@ -6,6 +6,12 @@ import Logos.Controls
 AbstractButton {
     id: root
 
+    // Corner marker for an informational, non-blocking state — currently an
+    // available host-app update on the Settings button. Same shape as
+    // SidebarAppDelegate's missing-deps marker minus the ✕ glyph, in the
+    // primary accent rather than red so it never reads as an error.
+    property bool showNotificationDot: false
+
     implicitHeight: 38
     implicitWidth: 38
 
@@ -43,6 +49,22 @@ AbstractButton {
             font.weight: Theme.typography.weightBold
             color: Theme.palette.textSecondary
             visible: !appIcon.visible
+        }
+
+        // The -2 corner margins put the dot's centre at (33, 5), which lands
+        // on the 38px pill's own 45° edge point (32.4, 5.6) — so it hugs the
+        // circle rather than floating in the empty bounding-box corner.
+        Rectangle {
+            id: notificationDot
+            visible: root.showNotificationDot
+            width: 14
+            height: 14
+            radius: 7
+            color: Theme.palette.primary
+            anchors.right: parent.right
+            anchors.top: parent.top
+            anchors.rightMargin: -2
+            anchors.topMargin: -2
         }
     }
 }

--- a/src/Basecamp/Sidebar/SidebarPanel.qml
+++ b/src/Basecamp/Sidebar/SidebarPanel.qml
@@ -179,6 +179,10 @@ Control {
                     checked: backend.currentActiveSectionIndex -1 === index
                     text: modelData.name
                     icon.source: modelData.icon
+                    // Settings hosts the Dashboard's Updates section, so it is
+                    // the only entry that carries the update marker.
+                    showNotificationDot: modelData.name === "Settings"
+                                         && backend.updateAvailable
                     onClicked: root.updateLauncherIndex(_d.workspaceSections.length + index)
                     onTooltipRequested: (text, y) => root.tooltipRequested(text, y)
                 }
@@ -186,19 +190,35 @@ Control {
         }
 
         // Version footer — falls back to the build-type label
-        // ("Dev build" / "Portable build"). Selectable so the release tag can
-        // be copied out of the sidebar.
-        LogosSelectableText {
+        // ("Dev build" / "Portable build"). The badge stacks above the version
+        // rather than sitting beside it: the sidebar column is only 80px wide
+        // (see MainContainer.cpp), too narrow for both on one row.
+        ColumnLayout {
             Layout.fillWidth: true
-            Layout.alignment: Qt.AlignHCenter
-            horizontalAlignment: TextEdit.AlignHCenter
-            text: backend.buildVersion.length > 0
-                ? backend.buildVersion
-                : (backend.isPortableBuild ? qsTr("Portable build")
-                                           : qsTr("Dev build"))
-            color: Theme.palette.textSecondary
-            font.pixelSize: Theme.typography.badgeText
-            wrapMode: TextEdit.WrapAnywhere
+            spacing: Theme.spacing.tiny
+
+            LogosBadge {
+                objectName: "sidebar.updateBadge"
+                Layout.alignment: Qt.AlignHCenter
+                visible: backend.updateAvailable
+                // LogosBadge uppercases its own label.
+                text: qsTr("Update")
+                color: Theme.palette.primary
+            }
+
+            // Selectable so the release tag can be copied out of the sidebar.
+            LogosSelectableText {
+                Layout.fillWidth: true
+                Layout.alignment: Qt.AlignHCenter
+                horizontalAlignment: TextEdit.AlignHCenter
+                text: backend.buildVersion.length > 0
+                    ? backend.buildVersion
+                    : (backend.isPortableBuild ? qsTr("Portable build")
+                                               : qsTr("Dev build"))
+                color: Theme.palette.textSecondary
+                font.pixelSize: Theme.typography.badgeText
+                wrapMode: TextEdit.WrapAnywhere
+            }
         }
     }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,10 @@ set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
 # Find Qt packages
-find_package(Qt6 REQUIRED COMPONENTS Core Widgets RemoteObjects Quick Qml QuickWidgets QuickControls2)
+# Network is used by UpdateChecker (the host-app update check). It already
+# arrived transitively via Qt6::Qml — which is why restricted/DenyAll*.cpp
+# compiles today — but depending on that is a latent breakage.
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets RemoteObjects Quick Qml QuickWidgets QuickControls2 Network)
 
 # Allow override from environment or command line (for nix builds)
 if(NOT DEFINED LOGOS_CPP_SDK_ROOT)
@@ -132,6 +135,7 @@ set(SOURCES
     PluginLoader.cpp
     WorkspaceArea.cpp
     ShortcutBridge.cpp
+    UpdateChecker.cpp
     restricted/DenyAllReply.cpp
     restricted/DenyAllNetworkAccessManager.cpp
     restricted/DenyAllNAMFactory.cpp
@@ -229,6 +233,8 @@ qt_add_qml_module(basecamp_backend_qml
         AppsFilterProxy.cpp
         ModulesFilterProxy.h
         ModulesFilterProxy.cpp
+        UpdateEnums.h
+        UpdateEnums.cpp
 )
 
 qt_add_qml_module(basecamp_common_qml
@@ -408,6 +414,7 @@ target_link_libraries(main_ui
         Qt6::Qml
         Qt6::QuickWidgets
         Qt6::QuickControls2
+        Qt6::Network
         component-interfaces
         ${LOGOS_VIEW_MODULE_RUNTIME_LIB}
         Logos::DesignSystem

--- a/src/MainUIBackend.cpp
+++ b/src/MainUIBackend.cpp
@@ -5,6 +5,7 @@
 #include "ModuleInstanceModel.h"
 #include "UIPluginManager.h"
 #include "PackageCoordinator.h"
+#include "UpdateChecker.h"
 #include "BuildInfo.h"
 
 #include <QDebug>
@@ -20,6 +21,7 @@ MainUIBackend::MainUIBackend(LogosAPI* logosAPI, QObject* parent)
     , m_packageCoordinator(nullptr)
     , m_uiModulesModel(new ModuleInstanceModel(this))
     , m_coreModulesModel(new ModuleInstanceModel(this))
+    , m_updateChecker(nullptr)
 {
     if (!m_logosAPI) {
         m_logosAPI = new LogosAPI("core", this);
@@ -58,6 +60,15 @@ MainUIBackend::MainUIBackend(LogosAPI* logosAPI, QObject* parent)
     // metadata cache. See UIPluginManager::setPackageCoordinator for the signal
     // connections it sets up internally.
     m_uiPluginManager->setPackageCoordinator(m_packageCoordinator);
+
+    // Independent of the three managers above: no logos_core_* calls, no
+    // package_manager IPC. Kicks off its own deferred check (or skips silently
+    // on dev/pre-release builds) — see UpdateChecker's ctor.
+    m_updateChecker = new UpdateChecker(this);
+    connect(m_updateChecker, &UpdateChecker::checkStateChanged,
+            this,            &MainUIBackend::updateCheckStateChanged);
+    connect(m_updateChecker, &UpdateChecker::downloadStateChanged,
+            this,            &MainUIBackend::updateDownloadStateChanged);
 
     // Forward manager signals into our own signals of the same name. QML
     // binds to these; by funneling through the facade we keep a stable
@@ -348,4 +359,27 @@ QString MainUIBackend::callCoreModuleMethod(const QString& n,
 QString      MainUIBackend::buildVersion() const    { return LogosBasecampBuildInfo::version(); }
 bool         MainUIBackend::isPortableBuild() const { return LogosBasecampBuildInfo::isPortableBuild(); }
 QVariantList MainUIBackend::buildCommits() const    { return LogosBasecampBuildInfo::commits(); }
+
+// --- Host-app update check (issue #319) -----------------------------------
+//
+// Delegations to UpdateChecker. The enums cross into QML as ints; QML compares
+// against UpdateCheckState.* / UpdateDownloadStage.* from Basecamp.Backend.
+
+int     MainUIBackend::updateCheckState() const     { return static_cast<int>(m_updateChecker->checkState()); }
+bool    MainUIBackend::updateAvailable() const      { return m_updateChecker->updateAvailable(); }
+QString MainUIBackend::latestVersion() const        { return m_updateChecker->latestVersion(); }
+QString MainUIBackend::releaseUrl() const           { return m_updateChecker->releaseUrl(); }
+bool    MainUIBackend::downloadSupported() const    { return m_updateChecker->downloadSupported(); }
+int     MainUIBackend::updateDownloadStage() const  { return static_cast<int>(m_updateChecker->downloadStage()); }
+qreal   MainUIBackend::downloadProgress() const     { return m_updateChecker->downloadProgress(); }
+QString MainUIBackend::downloadProgressText() const { return m_updateChecker->progressText(); }
+QString MainUIBackend::downloadedFilePath() const   { return m_updateChecker->downloadedFilePath(); }
+QString MainUIBackend::downloadError() const        { return m_updateChecker->downloadError(); }
+QString MainUIBackend::updateInstallHint() const    { return m_updateChecker->installHint(); }
+
+void MainUIBackend::checkForUpdates()        { m_updateChecker->checkForUpdates(); }
+void MainUIBackend::startUpdateDownload()    { m_updateChecker->startDownload(); }
+void MainUIBackend::cancelUpdateDownload()   { m_updateChecker->cancelDownload(); }
+void MainUIBackend::revealUpdateDownload()   { m_updateChecker->revealDownload(); }
+void MainUIBackend::openReleasePage()        { m_updateChecker->openReleasePage(); }
 

--- a/src/MainUIBackend.h
+++ b/src/MainUIBackend.h
@@ -15,6 +15,7 @@ class CoreModuleManager;
 class PackageCoordinator;
 class QWidget;
 class UIPluginManager;
+class UpdateChecker;
 
 // MainUIBackend — thin QML-facing facade.
 //
@@ -86,6 +87,23 @@ class MainUIBackend : public QObject {
     Q_PROPERTY(bool isPortableBuild READ isPortableBuild CONSTANT)
     Q_PROPERTY(QVariantList buildCommits READ buildCommits CONSTANT)
 
+    // Host-app update check (issue #319). The build-info properties above are
+    // CONSTANT and so can't carry this — update state changes at runtime.
+    // All of these are Skipped/empty on dev and pre-release builds, where the
+    // checker makes no network request at all. See UpdateChecker.
+    Q_PROPERTY(int     updateCheckState  READ updateCheckState  NOTIFY updateCheckStateChanged)
+    Q_PROPERTY(bool    updateAvailable   READ updateAvailable   NOTIFY updateCheckStateChanged)
+    Q_PROPERTY(QString latestVersion     READ latestVersion     NOTIFY updateCheckStateChanged)
+    Q_PROPERTY(QString releaseUrl        READ releaseUrl        NOTIFY updateCheckStateChanged)
+    Q_PROPERTY(bool    downloadSupported READ downloadSupported NOTIFY updateCheckStateChanged)
+
+    Q_PROPERTY(int     updateDownloadStage READ updateDownloadStage NOTIFY updateDownloadStateChanged)
+    Q_PROPERTY(qreal   downloadProgress    READ downloadProgress    NOTIFY updateDownloadStateChanged)
+    Q_PROPERTY(QString downloadProgressText READ downloadProgressText NOTIFY updateDownloadStateChanged)
+    Q_PROPERTY(QString downloadedFilePath  READ downloadedFilePath  NOTIFY updateDownloadStateChanged)
+    Q_PROPERTY(QString downloadError       READ downloadError       NOTIFY updateDownloadStateChanged)
+    Q_PROPERTY(QString updateInstallHint   READ updateInstallHint   NOTIFY updateDownloadStateChanged)
+
     // Package repositories
     Q_PROPERTY(QVariantList repositories READ repositories NOTIFY repositoriesChanged)
     Q_PROPERTY(bool repositoriesLoading READ repositoriesLoading NOTIFY repositoriesLoadingChanged)
@@ -119,6 +137,19 @@ public:
     QString buildVersion() const;
     bool isPortableBuild() const;
     QVariantList buildCommits() const;
+
+    // Update-check accessors — all delegate to UpdateChecker.
+    int     updateCheckState() const;
+    bool    updateAvailable() const;
+    QString latestVersion() const;
+    QString releaseUrl() const;
+    bool    downloadSupported() const;
+    int     updateDownloadStage() const;
+    qreal   downloadProgress() const;
+    QString downloadProgressText() const;
+    QString downloadedFilePath() const;
+    QString downloadError() const;
+    QString updateInstallHint() const;
 
     QVariantList repositories() const;
     bool repositoriesLoading() const;
@@ -213,8 +244,17 @@ public slots:
     Q_INVOKABLE void removeRepository(const QString& url);
     Q_INVOKABLE void setRepositoryEnabled(const QString& url, bool enabled);
 
+    // Host-app update operations — delegated to UpdateChecker.
+    Q_INVOKABLE void checkForUpdates();
+    Q_INVOKABLE void startUpdateDownload();
+    Q_INVOKABLE void cancelUpdateDownload();
+    Q_INVOKABLE void revealUpdateDownload();
+    Q_INVOKABLE void openReleasePage();
+
 signals:
     void currentActiveSectionIndexChanged();
+    void updateCheckStateChanged();
+    void updateDownloadStateChanged();
 
     // App-Manager dialog + install lifecycle. See PackageCoordinator for
     // the contract — these are pure re-emits.
@@ -311,6 +351,9 @@ private:
     PackageCoordinator*    m_packageCoordinator;
     ModuleInstanceModel* m_uiModulesModel;
     ModuleInstanceModel* m_coreModulesModel;
+    // Independent of the three managers above — talks to GitHub, not to
+    // liblogos or package_manager. See UpdateChecker.
+    UpdateChecker*     m_updateChecker;
 
     // Settings → Modules Reload overlay (see modulesLoading Q_PROPERTY).
     int  m_modulesLoadingCount = 0;

--- a/src/UpdateChecker.cpp
+++ b/src/UpdateChecker.cpp
@@ -1,0 +1,637 @@
+#include "UpdateChecker.h"
+
+#include "BuildInfo.h"
+
+#include <QCoreApplication>
+#include <QDateTime>
+#include <QDebug>
+#include <QDesktopServices>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QSysInfo>
+#include <QNetworkAccessManager>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QSslSocket>
+#include <QStandardPaths>
+#include <QStorageInfo>
+#include <QTimer>
+#include <QUrl>
+
+#ifdef Q_OS_MACOS
+#  include <sys/xattr.h>
+#endif
+
+namespace {
+
+// GitHub's "latest" endpoint deliberately skips drafts and pre-releases, so it
+// returns the stable tag (0.2.3) and never the CI `pre-release-<sha>` tags that
+// .github/workflows/build.yml publishes.
+constexpr auto kDefaultApiUrl =
+    "https://api.github.com/repos/logos-co/logos-basecamp/releases/latest";
+
+constexpr auto kFallbackReleasesUrl =
+    "https://github.com/logos-co/logos-basecamp/releases/latest";
+
+// Both are *idle* timeouts, not total deadlines — QNetworkRequest restarts the
+// timer on every chunk. 10s of silence on a 10KB JSON body means something is
+// wrong; 10s of silence mid-transfer is routine on tethering, and throwing away
+// 250MB over a hiccup is a bad trade. No total deadline: a slow link legitimately
+// takes an hour for a 271MB asset.
+constexpr int kApiTimeoutMs      = 10 * 1000;
+constexpr int kDownloadTimeoutMs = 60 * 1000;
+
+// Bound Qt's in-memory buffer so TCP back-pressure kicks in when the disk is
+// slower than the network. Without it Qt buffers the whole body in RAM.
+constexpr qint64 kReadBufferBytes = 1LL << 20;
+
+// Must not exceed kReadBufferBytes.
+constexpr qint64 kChunkBytes = 256LL * 1024;
+
+// Give up rather than overwrite once this many candidate names are taken.
+constexpr int kMaxDedupAttempts = 50;
+
+// Keeps the check off the module-load critical path, and clear of
+// shutdown-tests.mjs, which quits the app ~2s after launch.
+constexpr int kStartupCheckDelayMs = 5 * 1000;
+
+bool updateCheckDisabled()
+{
+    return qEnvironmentVariableIsSet("LOGOS_DISABLE_UPDATE_CHECK");
+}
+
+QString apiUrl()
+{
+    // Test-only override so ui-tests can point at a local stub instead of the
+    // live API. Never set in production.
+    const QString override = qEnvironmentVariable("LOGOS_UPDATE_CHECK_URL");
+    return override.isEmpty() ? QString::fromLatin1(kDefaultApiUrl) : override;
+}
+
+void applyCommonHeaders(QNetworkRequest& req, const QString& version)
+{
+    // Qt injects a Mozilla/5.0 UA when none is set and GitHub only rejects a
+    // *missing* one, but identify ourselves properly anyway.
+    req.setRawHeader("User-Agent",
+                     QStringLiteral("LogosBasecamp/%1")
+                         .arg(version.isEmpty() ? QStringLiteral("dev") : version)
+                         .toUtf8());
+    // Deliberately NO Authorization header. Qt copies headers verbatim across a
+    // redirect, so it would leak to the CDN host — which then rejects the signed
+    // URL it was given. This is a public repo; unauthenticated GET is correct.
+    req.setAttribute(QNetworkRequest::RedirectPolicyAttribute,
+                     QNetworkRequest::NoLessSafeRedirectPolicy);
+    req.setMaximumRedirectsAllowed(5);
+}
+
+}  // namespace
+
+UpdateChecker::UpdateChecker(QObject* parent)
+    : QObject(parent)
+{
+    // Test-only override of the "installed" side of the comparison, so the
+    // feature can be exercised without cutting a release. Setting it also waives
+    // the portable-build requirement below — that is the entire point of it.
+    const QString versionOverride = qEnvironmentVariable("LOGOS_UPDATE_CURRENT_VERSION");
+    const bool    forced          = !versionOverride.isEmpty();
+    m_currentVersion = forced ? versionOverride : LogosBasecampBuildInfo::version();
+
+    // Skip silently — and make no network request at all — unless this build is
+    // something we can meaningfully compare and offer an artifact for:
+    //
+    //  * VERSION is only checked in on release/** branches. Master CI builds are
+    //    stamped "pre-release-<sha7>" and dirty local builds get "", neither of
+    //    which is semver. Without this gate logos::semver::compare would sort the
+    //    unparseable string BELOW every real version and tell every developer
+    //    they were out of date.
+    //  * A non-portable nix build has no AppImage/DMG to replace, so offering a
+    //    download would be misleading.
+    if (UpdateInfo::shouldSkipCheck(updateCheckDisabled(), m_currentVersion,
+                                    forced, LogosBasecampBuildInfo::isPortableBuild())) {
+        m_checkState = UpdateCheckState::Skipped;
+        return;
+    }
+
+    connect(qApp, &QCoreApplication::aboutToQuit, this, [this] { abortAll(); });
+
+    // Deferred so the check stays off the module-load critical path, mirroring
+    // the deferred first catalog scan in MainUIBackend. Also keeps it clear of
+    // shutdown-tests.mjs, which quits the app ~2s after launch.
+    QTimer::singleShot(kStartupCheckDelayMs, this, &UpdateChecker::checkForUpdates);
+}
+
+UpdateChecker::~UpdateChecker()
+{
+    abortAll();
+}
+
+void UpdateChecker::abortAll()
+{
+    // Disconnect before aborting: abort() synthesizes finished(), and we must not
+    // re-enter a half-destroyed object.
+    if (m_checkReply) {
+        m_checkReply->disconnect(this);
+        m_checkReply->abort();
+        m_checkReply->deleteLater();
+        m_checkReply = nullptr;
+    }
+    if (m_downloadReply) {
+        m_downloadReply->disconnect(this);
+        m_downloadReply->abort();
+        m_downloadReply->deleteLater();
+        m_downloadReply = nullptr;
+    }
+    if (m_downloadFile) {
+        m_downloadFile->close();
+        delete m_downloadFile;
+        m_downloadFile = nullptr;
+    }
+    // Never leave a partial multi-hundred-megabyte file behind.
+    if (!m_partFilePath.isEmpty()) {
+        QFile::remove(m_partFilePath);
+        m_partFilePath.clear();
+    }
+}
+
+void UpdateChecker::setCheckState(UpdateCheckState::Value s)
+{
+    if (m_checkState == s) return;
+    m_checkState = s;
+    emit checkStateChanged();
+}
+
+void UpdateChecker::setDownloadStage(UpdateDownloadStage::Value s)
+{
+    if (m_downloadStage == s) return;
+    m_downloadStage = s;
+    emit downloadStateChanged();
+}
+
+// ── version check ───────────────────────────────────────────────────────────
+
+void UpdateChecker::checkForUpdates()
+{
+    if (m_checkState == UpdateCheckState::Skipped) return;
+    if (m_checkReply) return;   // already in flight; QML buttons double-fire
+
+    if (!m_nam) {
+        m_nam = new QNetworkAccessManager(this);
+        // One-time diagnostics. This is the first code in a shipped bundle that
+        // ever loads a Qt TLS backend, so if the plugin is missing from an
+        // AppImage/DMG we want it in the session log rather than showing up as a
+        // permanent silent "no update".
+        qInfo().noquote() << QStringLiteral("UpdateChecker: TLS available=%1 backend=%2 (%3)")
+                                 .arg(QSslSocket::supportsSsl() ? "yes" : "no",
+                                      QSslSocket::activeBackend(),
+                                      QSslSocket::sslLibraryVersionString());
+    }
+
+    setCheckState(UpdateCheckState::Checking);
+
+    QNetworkRequest req{QUrl(apiUrl())};
+    applyCommonHeaders(req, m_currentVersion);
+    req.setRawHeader("Accept", "application/vnd.github+json");
+    req.setRawHeader("X-GitHub-Api-Version", "2022-11-28");
+    req.setTransferTimeout(kApiTimeoutMs);
+
+    m_checkReply = m_nam->get(req);
+    // The release JSON is a few KB. Bound it anyway: the URL is overridable via
+    // LOGOS_UPDATE_CHECK_URL, and setTransferTimeout is an IDLE timeout, so a
+    // server that streams slowly but continuously would never trip it while the
+    // readAll() below grew the heap.
+    m_checkReply->setReadBufferSize(64 * 1024);
+    connect(m_checkReply, &QNetworkReply::finished, this, &UpdateChecker::onCheckFinished);
+}
+
+void UpdateChecker::onCheckFinished()
+{
+    QNetworkReply* reply = m_checkReply;
+    if (!reply) return;
+    m_checkReply = nullptr;
+    reply->deleteLater();
+
+    if (reply->error() != QNetworkReply::NoError) {
+        // Rate limiting (60/hr per IP, tight behind corporate NAT), a TLS
+        // failure, DNS failure in a sandboxed nix build — all land here, and all
+        // must read as "unknown", never as "you're on the latest".
+        qInfo().noquote() << "UpdateChecker: check failed:" << reply->errorString();
+        setCheckState(UpdateCheckState::Failed);
+        return;
+    }
+
+    const int status = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    if (!UpdateInfo::isAcceptableHttpStatus(status) && status != 404) {
+        // Same policy as the download reply. Without this a 204, or a 200-with-
+        // HTML from a captive portal, falls through to parseRelease untested.
+        qInfo().noquote() << "UpdateChecker: check returned HTTP" << status;
+        setCheckState(UpdateCheckState::Failed);
+        return;
+    }
+    if (status == 404) {
+        // Happens when the repo has no non-prerelease release at all. Since the
+        // real releases are cut outside .github/workflows/build.yml (which only
+        // ever publishes prerelease:true), this log line is the only clue if
+        // someone forgets to un-check "pre-release" on a release.
+        qWarning() << "UpdateChecker: /releases/latest returned 404 — is the newest "
+                      "release still marked as a pre-release?";
+        setCheckState(UpdateCheckState::Failed);
+        return;
+    }
+
+    const UpdateInfo::Release rel = UpdateInfo::parseRelease(reply->readAll());
+    if (!rel.ok) {
+        qWarning() << "UpdateChecker: could not parse release payload";
+        setCheckState(UpdateCheckState::Failed);
+        return;
+    }
+    // Unconditional: parseRelease guarantees html_url is present, so there is no
+    // "absent means fine" path through this gate.
+    if (!UpdateInfo::isTrustedReleaseUrl(rel.htmlUrl)) {
+        qWarning() << "UpdateChecker: release url is not on logos-basecamp:" << rel.htmlUrl;
+        setCheckState(UpdateCheckState::Failed);
+        return;
+    }
+
+    m_latestVersion = UpdateInfo::normalizeVersion(rel.tag);
+    m_releaseUrl    = rel.htmlUrl;
+
+    if (!UpdateInfo::isNewer(m_currentVersion, m_latestVersion)) {
+        setCheckState(UpdateCheckState::UpToDate);
+        return;
+    }
+
+    // Resolve the artifact for this platform. No match (Intel Mac has no x86_64
+    // dmg; Windows has nothing) is a UI state, not an error — the notice still
+    // shows, only the Download button is replaced by the link-out.
+    const QString wanted = UpdateInfo::selectAssetName(
+        rel.assets, UpdateInfo::hostOs(), QSysInfo::currentCpuArchitecture());
+    m_assetUrl.clear();
+    m_assetName.clear();
+    m_assetSize = 0;
+    for (const UpdateInfo::Asset& a : rel.assets) {
+        if (a.name != wanted) continue;
+        // Reject an off-allowlist asset URL here rather than at click time, so
+        // the UI shows the release-page link instead of a Download button that
+        // would fail. selectAssetName has already vetted the name itself.
+        const QUrl assetUrl(a.url);
+        if (!UpdateInfo::isAllowedDownloadUrl(assetUrl.scheme(), assetUrl.host())) {
+            qWarning() << "UpdateChecker: release asset is hosted off-allowlist:" << a.url;
+            break;
+        }
+        m_assetName = a.name;
+        m_assetUrl  = a.url;
+        m_assetSize = a.size;
+        break;
+    }
+
+    if (m_assetUrl.isEmpty()) {
+        qInfo().noquote() << QStringLiteral("UpdateChecker: %1 available, no asset for %2/%3")
+                                 .arg(m_latestVersion, UpdateInfo::hostOs(),
+                                      QSysInfo::currentCpuArchitecture());
+        setDownloadStage(UpdateDownloadStage::Unsupported);
+    } else {
+        m_installHint = UpdateInfo::installHint(UpdateInfo::hostOs(), m_assetName);
+        setDownloadStage(UpdateDownloadStage::Idle);
+    }
+
+    qInfo().noquote() << QStringLiteral("UpdateChecker: update available %1 → %2")
+                             .arg(m_currentVersion, m_latestVersion);
+    setCheckState(UpdateCheckState::UpdateAvailable);
+}
+
+// ── download ────────────────────────────────────────────────────────────────
+
+void UpdateChecker::startDownload()
+{
+    if (m_downloadReply) {
+        qWarning() << "UpdateChecker: download already in flight";
+        return;
+    }
+    if (m_assetUrl.isEmpty()) return;
+
+    // Gate the INITIAL url, not just the redirect hops. browser_download_url
+    // comes from the release payload, so without this an asset entry pointing at
+    // https://evil.example/payload.dmg would be fetched directly — the redirect
+    // handler never sees it, because no redirect occurs.
+    const QUrl url(m_assetUrl);
+    if (!UpdateInfo::isAllowedDownloadUrl(url.scheme(), url.host())) {
+        failDownload(QStringLiteral("Refusing to download from an untrusted host."));
+        return;
+    }
+
+    QString dir = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    if (dir.isEmpty())
+        dir = QStandardPaths::writableLocation(QStandardPaths::HomeLocation);
+    if (dir.isEmpty()) {
+        failDownload(QStringLiteral("Couldn't find a folder to download into."));
+        return;
+    }
+    if (!QDir().mkpath(dir)) {
+        failDownload(QStringLiteral("Couldn't create %1.").arg(dir));
+        return;
+    }
+
+    // Defense in depth: selectAssetName already rejected anything that isn't a
+    // bare filename, but m_assetName is network-derived and about to become a
+    // filesystem path, so re-check at the point of use.
+    if (!UpdateInfo::isSafeAssetFileName(m_assetName)) {
+        failDownload(QStringLiteral("Release asset has an unsafe filename."));
+        return;
+    }
+
+    // Already have exactly this artifact? Don't re-download 271 MB.
+    const QString finalPath = QDir(dir).filePath(m_assetName);
+    if (QFileInfo::exists(finalPath)
+        && m_assetSize > 0
+        && QFileInfo(finalPath).size() == m_assetSize) {
+        m_downloadedFilePath = finalPath;
+        m_downloadError.clear();
+        setDownloadStage(UpdateDownloadStage::Done);
+        return;
+    }
+
+    // Otherwise pick a free name rather than clobbering whatever is there.
+    // Bail out rather than overwrite if every candidate is taken. Note this is
+    // best-effort at start-of-download: finalizeDownload() does overwrite the
+    // chosen target at rename time, so anything that lands there during the
+    // (multi-minute) transfer is replaced.
+    QString target = finalPath;
+    for (int i = 1; i <= kMaxDedupAttempts && QFileInfo::exists(target); ++i)
+        target = QDir(dir).filePath(UpdateInfo::dedupedFileName(m_assetName, i));
+    if (QFileInfo::exists(target)) {
+        failDownload(QStringLiteral("Too many copies of %1 already in %2.")
+                         .arg(m_assetName, dir));
+        return;
+    }
+
+    const QStorageInfo storage{dir};
+    if (storage.isValid()
+        && !UpdateInfo::hasEnoughSpaceFor(m_assetSize, storage.bytesAvailable())) {
+        failDownload(QStringLiteral("Needs %1 free in %2; only %3 available.")
+                         .arg(UpdateInfo::formatBytes(m_assetSize + UpdateInfo::kDiskHeadroomBytes),
+                              dir,
+                              UpdateInfo::formatBytes(storage.bytesAvailable())));
+        return;
+    }
+
+    // Write to <final>.part and rename on success, so an interrupted download
+    // never leaves something that looks like a usable installer.
+    m_partFilePath = target + QStringLiteral(".part");
+    QFile::remove(m_partFilePath);
+    m_downloadFile = new QFile(m_partFilePath, this);
+    if (!m_downloadFile->open(QIODevice::WriteOnly)) {
+        const QString err = m_downloadFile->errorString();
+        delete m_downloadFile;
+        m_downloadFile = nullptr;
+        m_partFilePath.clear();
+        failDownload(QStringLiteral("Couldn't write to %1: %2").arg(target, err));
+        return;
+    }
+
+    m_downloadedFilePath = target;
+    m_downloadCancelled  = false;
+    m_bytesWritten       = 0;
+    m_downloadProgress   = -1.0;
+    m_progressText.clear();
+    m_downloadError.clear();
+    setDownloadStage(UpdateDownloadStage::Starting);
+
+    if (!m_nam) m_nam = new QNetworkAccessManager(this);
+
+    QNetworkRequest req{url};
+    applyCommonHeaders(req, m_currentVersion);
+    req.setTransferTimeout(kDownloadTimeoutMs);
+
+    m_downloadReply = m_nam->get(req);
+    m_downloadReply->setReadBufferSize(kReadBufferBytes);
+
+    // GitHub 302s to a signed CDN URL. Allow the githubusercontent/S3 family
+    // rather than today's exact host, or this breaks the next time they rotate.
+    connect(m_downloadReply, &QNetworkReply::redirected, this,
+            [this](const QUrl& to) {
+                if (!UpdateInfo::isAllowedDownloadUrl(to.scheme(), to.host())) {
+                    qWarning() << "UpdateChecker: refusing redirect to" << to.toString();
+                    m_downloadCancelled = true;
+                    if (m_downloadReply) m_downloadReply->abort();
+                }
+            });
+
+    // Validate before a single byte hits the disk — otherwise a 404 HTML page
+    // gets happily written out under a .dmg name.
+    connect(m_downloadReply, &QNetworkReply::metaDataChanged, this, [this] {
+        if (!m_downloadReply) return;
+        const int status =
+            m_downloadReply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+        if (!UpdateInfo::isAcceptableHttpStatus(status)) {
+            m_downloadCancelled = true;
+            m_downloadReply->abort();
+            failDownload(QStringLiteral("Download failed (HTTP %1).").arg(status));
+            return;
+        }
+        const QVariant len = m_downloadReply->header(QNetworkRequest::ContentLengthHeader);
+        const bool encoded = !m_downloadReply->rawHeader("Content-Encoding").isEmpty();
+        if (UpdateInfo::isDeclaredSizeMismatch(status,
+                                               len.isValid() ? len.toLongLong() : -1,
+                                               m_assetSize, encoded)) {
+            m_downloadCancelled = true;
+            m_downloadReply->abort();
+            failDownload(QStringLiteral("Download size didn't match the published release."));
+        }
+    });
+
+    connect(m_downloadReply, &QNetworkReply::downloadProgress, this,
+            [this](qint64 received, qint64 total) {
+                const qint64 denom = total > 0 ? total : m_assetSize;
+                m_downloadProgress = UpdateInfo::downloadFraction(received, total, m_assetSize);
+                m_progressText     = UpdateInfo::progressText(received, denom);
+                if (m_downloadStage != UpdateDownloadStage::Downloading)
+                    setDownloadStage(UpdateDownloadStage::Downloading);
+                else
+                    emit downloadStateChanged();
+            });
+
+    connect(m_downloadReply, &QNetworkReply::readyRead, this,
+            &UpdateChecker::onDownloadReadyRead);
+    connect(m_downloadReply, &QNetworkReply::finished, this,
+            &UpdateChecker::onDownloadFinished);
+}
+
+void UpdateChecker::onDownloadReadyRead()
+{
+    if (!m_downloadReply || !m_downloadFile) return;
+    // Stream in chunks. Never readAll() — that would hold 271 MB resident.
+    while (m_downloadReply->bytesAvailable() > 0) {
+        const QByteArray chunk = m_downloadReply->read(kChunkBytes);
+        if (chunk.isEmpty()) break;
+        const qint64 written = m_downloadFile->write(chunk);
+        if (written != chunk.size()) {
+            m_downloadCancelled = true;
+            m_downloadReply->abort();
+            failDownload(QStringLiteral("Couldn't write to %1: %2")
+                             .arg(m_downloadedFilePath, m_downloadFile->errorString()));
+            return;
+        }
+        m_bytesWritten += written;
+    }
+}
+
+void UpdateChecker::onDownloadFinished()
+{
+    QNetworkReply* reply = m_downloadReply;
+    if (!reply) return;
+    m_downloadReply = nullptr;
+    reply->deleteLater();
+
+    const bool cancelled = m_downloadCancelled;
+    const QNetworkReply::NetworkError err = reply->error();
+
+    if (cancelled) {
+        // A deliberate user action is not a failure — go back to Idle, no red.
+        // (failDownload() may already have set Failed for the abort-on-bad-header
+        // paths; those set m_downloadError, so don't stomp them.)
+        teardownDownload();
+        if (m_downloadError.isEmpty())
+            setDownloadStage(UpdateDownloadStage::Idle);
+        return;
+    }
+    if (err != QNetworkReply::NoError) {
+        teardownDownload();
+        failDownload(reply->errorString());
+        return;
+    }
+
+    finalizeDownload();
+}
+
+void UpdateChecker::finalizeDownload()
+{
+    if (!m_downloadFile) return;
+
+    m_downloadFile->flush();
+    m_downloadFile->close();
+    const QString part = m_partFilePath;
+    delete m_downloadFile;
+    m_downloadFile = nullptr;
+
+    if (!UpdateInfo::isCompleteDownload(m_bytesWritten, m_assetSize)) {
+        QFile::remove(part);
+        m_partFilePath.clear();
+        failDownload(QStringLiteral("Download was incomplete (%1 of %2).")
+                         .arg(UpdateInfo::formatBytes(m_bytesWritten),
+                              UpdateInfo::formatBytes(m_assetSize)));
+        return;
+    }
+
+    QFile::remove(m_downloadedFilePath);
+    if (!QFile::rename(part, m_downloadedFilePath)) {
+        QFile::remove(part);
+        m_partFilePath.clear();
+        failDownload(QStringLiteral("Couldn't save to %1.").arg(m_downloadedFilePath));
+        return;
+    }
+    m_partFilePath.clear();
+
+#ifdef Q_OS_LINUX
+    // A Qt-written file is 0644, and a double-clicked non-executable AppImage
+    // does nothing at all — silently.
+    QFile::setPermissions(m_downloadedFilePath,
+                          QFileDevice::ReadOwner | QFileDevice::WriteOwner
+                              | QFileDevice::ExeOwner | QFileDevice::ReadGroup
+                              | QFileDevice::ExeGroup | QFileDevice::ReadOther
+                              | QFileDevice::ExeOther);
+#endif
+
+#ifdef Q_OS_MACOS
+    // Downloading it ourselves would otherwise REMOVE a safety net: Gatekeeper
+    // only assesses a file that carries com.apple.quarantine, and QFile writes
+    // none. The .app inside the DMG is Developer-ID signed, notarized and
+    // stapled, so restoring the xattr gives the user the same one-time
+    // "downloaded from the Internet" prompt a browser download would.
+    const QByteArray path = QFile::encodeName(m_downloadedFilePath);
+    const QByteArray value = QStringLiteral("0083;%1;LogosBasecamp;")
+                                 .arg(QDateTime::currentSecsSinceEpoch(), 0, 16)
+                                 .toUtf8();
+    if (setxattr(path.constData(), "com.apple.quarantine",
+                 value.constData(), static_cast<size_t>(value.size()), 0, 0) != 0) {
+        qWarning() << "UpdateChecker: could not set quarantine attribute on"
+                   << m_downloadedFilePath;
+    }
+#endif
+
+    m_downloadError.clear();
+    qInfo().noquote() << "UpdateChecker: saved" << m_downloadedFilePath;
+    setDownloadStage(UpdateDownloadStage::Done);
+}
+
+void UpdateChecker::teardownDownload()
+{
+    if (m_downloadFile) {
+        m_downloadFile->close();
+        delete m_downloadFile;
+        m_downloadFile = nullptr;
+    }
+    if (!m_partFilePath.isEmpty()) {
+        QFile::remove(m_partFilePath);
+        m_partFilePath.clear();
+    }
+}
+
+void UpdateChecker::failDownload(const QString& message)
+{
+    m_downloadError = message;
+    qWarning().noquote() << "UpdateChecker: download failed:" << message;
+    setDownloadStage(UpdateDownloadStage::Failed);
+}
+
+void UpdateChecker::cancelDownload()
+{
+    if (!m_downloadReply) return;
+    m_downloadCancelled = true;
+    m_downloadError.clear();
+    m_downloadReply->abort();   // synthesizes finished(); one teardown path
+}
+
+QString UpdateChecker::downloadedFileDir() const
+{
+    if (m_downloadedFilePath.isEmpty()) return QString();
+    return QFileInfo(m_downloadedFilePath).absolutePath();
+}
+
+void UpdateChecker::revealDownload()
+{
+    const QString dir = downloadedFileDir();
+    if (dir.isEmpty()) return;
+    // The directory, not the file: openUrl on a .dmg/.AppImage would launch it.
+    openExternally(QUrl::fromLocalFile(dir).toString());
+}
+
+void UpdateChecker::openReleasePage()
+{
+    openExternally(m_releaseUrl.isEmpty() ? QString::fromLatin1(kFallbackReleasesUrl)
+                                          : m_releaseUrl);
+}
+
+void UpdateChecker::openExternally(const QString& url)
+{
+    if (url.isEmpty()) return;
+
+#ifdef Q_OS_LINUX
+    // In an AppImage, AppRun exports LD_LIBRARY_PATH pointing at the bundle's
+    // own Qt/glibc. xdg-open inherits it and then tries to run *host* binaries
+    // against those libraries — the classic "clicking a link does nothing"
+    // AppImage failure. Hand it a scrubbed environment instead.
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.remove(QStringLiteral("LD_LIBRARY_PATH"));
+    QProcess p;
+    p.setProgram(QStringLiteral("xdg-open"));
+    p.setArguments({url});
+    p.setProcessEnvironment(env);
+    if (p.startDetached()) return;
+    qWarning() << "UpdateChecker: xdg-open failed, falling back to QDesktopServices";
+#endif
+
+    QDesktopServices::openUrl(QUrl(url));
+}

--- a/src/UpdateChecker.h
+++ b/src/UpdateChecker.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include "UpdateEnums.h"
+#include "UpdateInfo.h"
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+class QFile;
+class QNetworkAccessManager;
+class QNetworkReply;
+
+// UpdateChecker — the host app's own staleness signal (issue #319).
+//
+// Basecamp's package manager already tells you when a *module* is out of date
+// (AppsModel::recomputeInstallStatus); nothing told you when Basecamp itself was.
+// A user on 0.2.1 with 0.2.3 out shipped a stale bundled delivery_module, which
+// presented as a runtime bug rather than "you're three versions behind".
+//
+// Two jobs, in order:
+//   1. Compare the baked-in VERSION against GitHub's latest release, and say so.
+//   2. Optionally download the matching platform asset and tell the user what to
+//      do with it. It does NOT self-install — no relaunch, no execve, no writing
+//      into the app bundle. That's tier (c) and wants code signing first.
+//
+// Constructed as a fourth child of MainUIBackend, deliberately outside the
+// CoreModuleManager/UIPluginManager/PackageCoordinator triangle: it touches no
+// logos_core_* C API and no package_manager IPC. All state reaches QML via
+// one-line delegations on MainUIBackend.
+//
+// NOTE this is the first outbound network request the host process makes. The
+// deny-all QNetworkAccessManager in src/restricted/ applies only to sandboxed
+// *plugin* QML engines (QmlSandbox::configure) and does not constrain this class.
+class UpdateChecker : public QObject {
+    Q_OBJECT
+
+public:
+    explicit UpdateChecker(QObject* parent = nullptr);
+    ~UpdateChecker() override;
+
+    UpdateCheckState::Value    checkState() const    { return m_checkState; }
+    UpdateDownloadStage::Value downloadStage() const { return m_downloadStage; }
+
+    bool    updateAvailable() const { return m_checkState == UpdateCheckState::UpdateAvailable; }
+    QString currentVersion() const  { return m_currentVersion; }
+    QString latestVersion() const   { return m_latestVersion; }
+    QString releaseUrl() const      { return m_releaseUrl; }
+    bool    downloadSupported() const { return !m_assetUrl.isEmpty(); }
+
+    qreal   downloadProgress() const  { return m_downloadProgress; }
+    QString progressText() const      { return m_progressText; }
+    QString downloadedFilePath() const { return m_downloadedFilePath; }
+    QString downloadedFileDir() const;
+    QString downloadError() const     { return m_downloadError; }
+    QString installHint() const       { return m_installHint; }
+
+public slots:
+    // Idempotent while a check is in flight. Safe to call from QML repeatedly.
+    void checkForUpdates();
+    void startDownload();
+    void cancelDownload();
+    // Opens the *containing directory*, not the file — openUrl on the file would
+    // launch the DMG/AppImage instead of revealing it.
+    void revealDownload();
+    void openReleasePage();
+
+signals:
+    void checkStateChanged();
+    void downloadStateChanged();
+
+private:
+    void setCheckState(UpdateCheckState::Value s);
+    void setDownloadStage(UpdateDownloadStage::Value s);
+    void failDownload(const QString& message);
+    void onCheckFinished();
+    void onDownloadReadyRead();
+    void onDownloadFinished();
+    void finalizeDownload();
+    void teardownDownload();
+    // Cancels in-flight work and removes the partial file. Called from both the
+    // destructor and QCoreApplication::aboutToQuit, because plugin teardown is
+    // not guaranteed to run before process exit.
+    void abortAll();
+    void openExternally(const QString& url);
+
+    // Destroying a QNetworkAccessManager that still owns live replies is
+    // unsupported by Qt and crashes intermittently inside QNetworkReplyHttpImpl
+    // — and shutdown-tests.mjs quits the app after only 2s, so this path is
+    // exercised on every run.
+    //
+    // The guarantee comes from abortAll() (called from both ~UpdateChecker and
+    // aboutToQuit), NOT from member declaration order: QPointer is non-owning
+    // and m_nam is a raw pointer, so neither destructor frees anything here —
+    // the QNAM is freed later, by QObject child destruction.
+    QNetworkAccessManager* m_nam = nullptr;
+
+    QPointer<QNetworkReply> m_checkReply;
+    QPointer<QNetworkReply> m_downloadReply;
+    QFile*  m_downloadFile = nullptr;
+    bool    m_downloadCancelled = false;
+    qint64  m_bytesWritten = 0;
+
+    UpdateCheckState::Value    m_checkState    = UpdateCheckState::Idle;
+    UpdateDownloadStage::Value m_downloadStage = UpdateDownloadStage::Idle;
+
+    QString m_currentVersion;
+    QString m_latestVersion;
+    QString m_releaseUrl;
+
+    // Resolved once from the release payload; empty when no asset fits this
+    // platform, which is what downloadSupported() reports.
+    QString m_assetUrl;
+    QString m_assetName;
+    qint64  m_assetSize = 0;
+
+    qreal   m_downloadProgress = -1.0;   // -1 = indeterminate
+    QString m_progressText;
+    QString m_downloadedFilePath;
+    QString m_partFilePath;
+    QString m_downloadError;
+    QString m_installHint;
+};

--- a/src/UpdateEnums.cpp
+++ b/src/UpdateEnums.cpp
@@ -1,0 +1,1 @@
+#include "UpdateEnums.h"

--- a/src/UpdateEnums.h
+++ b/src/UpdateEnums.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <QObject>
+#include <QtQml/qqml.h>
+
+// Host-app update state, exposed to QML so DashboardView can switch on it by
+// name instead of magic ints. Same Q_ENUM + QML_UNCREATABLE shape as
+// InstallStage/InstallStatus in InstallEnums.h.
+
+// Result of the version check itself.
+class UpdateCheckState : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("Use UpdateCheckState.Checking etc.; not instantiable.")
+public:
+    enum Value {
+        Idle = 0,
+        // Terminal, set without any network call: this build has no comparable
+        // version (dev / pre-release / non-nix) or the check is disabled.
+        Skipped,
+        Checking,
+        UpToDate,
+        UpdateAvailable,
+        // Network, TLS, rate-limit or parse failure. Deliberately distinct from
+        // UpToDate — a failed check must never read as "you're on the latest".
+        Failed,
+    };
+    Q_ENUM(Value)
+};
+
+// Progress of the optional asset download.
+class UpdateDownloadStage : public QObject {
+    Q_OBJECT
+    QML_ELEMENT
+    QML_UNCREATABLE("Use UpdateDownloadStage.Downloading etc.; not instantiable.")
+public:
+    enum Value {
+        Idle = 0,
+        // No release asset matches this platform (Intel Mac ships no x86_64 dmg,
+        // Windows ships nothing). Renders the link-out, not an error.
+        Unsupported,
+        Starting,
+        Downloading,
+        // Dormant until the .sha256 follow-up. Kept so that lands as a C++-only
+        // change with no QML edit.
+        Verifying,
+        Done,
+        Failed,
+    };
+    Q_ENUM(Value)
+};

--- a/src/UpdateInfo.h
+++ b/src/UpdateInfo.h
@@ -1,0 +1,380 @@
+#pragma once
+
+// Pure logic behind the host-app update check (issue #319).
+//
+// Everything here is a free function over plain values — no QNetworkAccessManager,
+// no BuildInfo.h, no Qt GUI. That is deliberate: `tests/CMakeLists.txt` links only
+// Core/Qml/Test/Widgets/Quick/QuickWidgets and does NOT put `app/utils` on the include
+// path, so a unit test that pulled in either of those would fail to build. Keeping the
+// interesting logic here means UpdateChecker is a thin I/O shell around tested code.
+//
+// Header-only for the same reason: no `// srcdeps:` line is needed in the test.
+
+#include <QByteArray>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QList>
+#include <QString>
+
+#include <logos/semver.hpp>
+
+namespace UpdateInfo {
+
+// One entry from the release's `assets[]`.
+struct Asset {
+    QString name;
+    QString url;    // browser_download_url
+    qint64  size = 0;
+    QString state;  // "uploaded" once GitHub has finished ingesting it
+};
+
+struct Release {
+    bool         ok = false;
+    QString      tag;      // raw tag_name, e.g. "0.2.3"
+    QString      htmlUrl;
+    QList<Asset> assets;
+};
+
+// ── version handling ────────────────────────────────────────────────────────
+
+// Release tags are bare ("0.2.3") but asset filenames carry a `v`
+// ("…-v0.2.3-aa2377-…"). Strict semver rejects the prefix, so peel it first.
+inline QString normalizeVersion(const QString& v)
+{
+    QString s = v.trimmed();
+    if (s.startsWith(QLatin1Char('v')) || s.startsWith(QLatin1Char('V')))
+        s = s.mid(1);
+    return s;
+}
+
+// Is the *running* build something we can meaningfully compare?
+//
+// Load-bearing. `logos::semver::compare` sorts unparseable strings BELOW every
+// parseable one, so without this gate `compare("pre-release-aa23776", "0.2.3")`
+// returns -1 and every dev build would be told it is out of date. VERSION is only
+// checked in on release/** branches; master CI builds get "pre-release-<sha7>" and
+// dirty local builds get "".
+inline bool isComparableVersion(const QString& current)
+{
+    return logos::semver::valid(normalizeVersion(current).toStdString());
+}
+
+// The single decision that determines whether this whole feature runs.
+//
+// Extracted from UpdateChecker's constructor because the composition is subtler
+// than any of its parts: a non-empty LOGOS_UPDATE_CURRENT_VERSION (`forced`)
+// WAIVES the portable-build requirement, which is what lets the UI tests drive
+// the feature from a dev build. If that rule regresses the tests fail with an
+// opaque 20s timeout rather than a named assertion.
+inline bool shouldSkipCheck(bool disabled, const QString& currentVersion,
+                            bool versionForced, bool portableBuild)
+{
+    if (disabled) return true;
+    // Dev/pre-release builds have nothing comparable to compare against.
+    if (!isComparableVersion(currentVersion)) return true;
+    // A non-portable build has no AppImage/DMG to replace, so offering one is
+    // misleading — unless the version was explicitly forced for testing.
+    return !versionForced && !portableBuild;
+}
+
+// Strictly newer, never a downgrade.
+//
+// `/releases/latest` is ordered by creation date, NOT semver precedence, so a
+// hotfix cut from an old branch can legitimately be "latest". Requiring a strict
+// `>` means we stay quiet in that case rather than offering a downgrade.
+inline bool isNewer(const QString& current, const QString& latest)
+{
+    const QString cur = normalizeVersion(current);
+    const QString lat = normalizeVersion(latest);
+    if (!logos::semver::valid(cur.toStdString()))
+        return false;
+    // The fetched tag is checked leniently: it is upstream data, and `1.2` or
+    // `v1.2.3` are unambiguous even though strict semver rejects them.
+    if (!logos::semver::parse_lenient(lat.toStdString()).has_value())
+        return false;
+    return logos::semver::compare(lat.toStdString(), cur.toStdString()) > 0;
+}
+
+// ── release payload ─────────────────────────────────────────────────────────
+
+inline Release parseRelease(const QByteArray& json)
+{
+    Release r;
+    QJsonParseError err{};
+    const QJsonDocument doc = QJsonDocument::fromJson(json, &err);
+    if (err.error != QJsonParseError::NoError || !doc.isObject())
+        return r;
+
+    const QJsonObject obj = doc.object();
+    r.tag     = obj.value(QStringLiteral("tag_name")).toString();
+    r.htmlUrl = obj.value(QStringLiteral("html_url")).toString();
+    // Both are required. html_url in particular: the caller gates trust on it
+    // (isTrustedReleaseUrl), so treating an absent one as acceptable would let a
+    // payload skip that check simply by omitting the field — failing open.
+    if (r.tag.isEmpty() || r.htmlUrl.isEmpty())
+        return r;
+
+    for (const QJsonValue& v : obj.value(QStringLiteral("assets")).toArray()) {
+        const QJsonObject a = v.toObject();
+        Asset asset;
+        asset.name  = a.value(QStringLiteral("name")).toString();
+        asset.url   = a.value(QStringLiteral("browser_download_url")).toString();
+        asset.size  = static_cast<qint64>(a.value(QStringLiteral("size")).toDouble());
+        asset.state = a.value(QStringLiteral("state")).toString();
+        if (!asset.name.isEmpty())
+            r.assets.append(asset);
+    }
+
+    r.ok = true;
+    return r;
+}
+
+// Only ever trust a release page that lives on our own repo.
+inline bool isTrustedReleaseUrl(const QString& url)
+{
+    return url.startsWith(QStringLiteral("https://github.com/logos-co/logos-basecamp/"));
+}
+
+// ── asset selection ─────────────────────────────────────────────────────────
+
+// The single most likely way this feature ships silently broken:
+// QSysInfo::currentCpuArchitecture() returns "arm64", while the release assets
+// are named "-aarch64". Map explicitly and return empty for anything unknown so
+// the caller degrades to the link-out rather than guessing.
+inline QString archToken(const QString& cpuArchitecture)
+{
+    const QString a = cpuArchitecture.toLower();
+    if (a == QStringLiteral("arm64") || a == QStringLiteral("aarch64"))
+        return QStringLiteral("aarch64");
+    if (a == QStringLiteral("x86_64") || a == QStringLiteral("amd64"))
+        return QStringLiteral("x86_64");
+    return QString();
+}
+
+// "macos" → .dmg, "linux" → .AppImage. Anything else is unsupported.
+inline QString assetExtension(const QString& os)
+{
+    if (os == QStringLiteral("macos")) return QStringLiteral("dmg");
+    if (os == QStringLiteral("linux")) return QStringLiteral("AppImage");
+    return QString();
+}
+
+// The asset name arrives from the network and is used to build a path under the
+// user's Downloads directory, so it must be a bare filename — nothing that can
+// climb out of that directory or desynchronise the path seen by different APIs.
+//
+// The prefix/suffix checks in selectAssetName are NOT sufficient on their own:
+// "LogosBasecamp-Desktop-v9.9.9/../../../../tmp/pwn-aarch64.dmg" satisfies both,
+// and QDir::filePath is a plain join. On Linux the result would then be chmod
+// +x'd. Embedded NUL/newline are rejected too: QFile::encodeName truncates at
+// NUL, so the path QFile opens could differ from the one passed to setxattr.
+inline bool isSafeAssetFileName(const QString& name)
+{
+    if (name.isEmpty() || name.size() > 255)
+        return false;
+    if (name.contains(QLatin1Char('/')) || name.contains(QLatin1Char('\\')))
+        return false;
+    if (name.contains(QStringLiteral("..")))
+        return false;
+    if (name.startsWith(QLatin1Char('.')))       // no dotfiles
+        return false;
+    for (const QChar c : name) {
+        if (c.unicode() < 0x20 || c.unicode() == 0x7F)
+            return false;
+    }
+    // Belt and braces: the name must already be its own leaf.
+    return QFileInfo(name).fileName() == name;
+}
+
+// Assets are named LogosBasecamp-Desktop-v<VERSION>-<sha6>-<arch>.<ext>. Never
+// match on the version or the short hash — the hash is unpredictable. Never match
+// on content_type either: all three assets report application/octet-stream.
+//
+// Returns an empty name when nothing fits (Intel Mac has no x86_64 dmg, Windows
+// has nothing at all). That is a UI state, not an error.
+inline QString selectAssetName(const QList<Asset>& assets,
+                               const QString& os,
+                               const QString& cpuArchitecture)
+{
+    const QString arch = archToken(cpuArchitecture);
+    const QString ext  = assetExtension(os);
+    if (arch.isEmpty() || ext.isEmpty())
+        return QString();
+
+    const QString suffix = QStringLiteral("-%1.%2").arg(arch, ext);
+    for (const Asset& a : assets) {
+        // A half-uploaded asset reports state "starting"; downloading it yields a
+        // truncated file.
+        if (!a.state.isEmpty() && a.state != QStringLiteral("uploaded"))
+            continue;
+        if (!isSafeAssetFileName(a.name))
+            continue;
+        if (!a.name.startsWith(QStringLiteral("LogosBasecamp-Desktop-v")))
+            continue;
+        if (a.name.endsWith(suffix, Qt::CaseInsensitive))
+            return a.name;
+    }
+    return QString();
+}
+
+// ── transport safety ────────────────────────────────────────────────────────
+
+// GitHub has served release assets from objects.githubusercontent.com, S3, and
+// today release-assets.githubusercontent.com. Allow the family rather than the
+// single host of the day, or this breaks the next time they rotate CDNs.
+//
+// The leading dot matters: it defeats "evil-githubusercontent.com", while
+// endsWith defeats "githubusercontent.com.evil.com".
+//
+// S3 is scoped to GitHub's own release-asset bucket family. A bare
+// "*.s3.amazonaws.com" would admit ANY bucket, and bucket names are
+// self-service — an attacker could register one and satisfy the only host gate
+// standing between the user and a 271 MB executable.
+inline bool isAllowedDownloadHost(const QString& host)
+{
+    const QString h = host.toLower();
+    return h == QStringLiteral("github.com")
+        || h.endsWith(QStringLiteral(".githubusercontent.com"))
+        || (h.startsWith(QStringLiteral("github-production-release-asset"))
+            && h.endsWith(QStringLiteral(".s3.amazonaws.com")));
+}
+
+// Scheme AND host. Qt's NoLessSafeRedirectPolicy already blocks https→http, but
+// this hop ends in an executable the user is told to run, so don't rely on a
+// single layer for that.
+inline bool isAllowedDownloadUrl(const QString& scheme, const QString& host)
+{
+    return scheme.toLower() == QStringLiteral("https") && isAllowedDownloadHost(host);
+}
+
+// Accept the 200 we want, the 3xx we're about to follow, and 0 — which is what
+// QNetworkRequest::HttpStatusCodeAttribute reports for a non-HTTP reply such as
+// the file:// stub the UI tests point at.
+inline bool isAcceptableHttpStatus(int status)
+{
+    if (status == 0 || status == 200) return true;
+    return status >= 300 && status <= 399;
+}
+
+// Compare the server's declared Content-Length against the size the release API
+// published. A zero-cost detector for a swapped artifact or an injecting proxy.
+// Only meaningful on a final 200 with no transfer encoding: a 3xx body is the
+// redirect stub, and a compressed body legitimately differs from the asset size.
+inline bool isDeclaredSizeMismatch(int status, qint64 declaredLength,
+                                   qint64 expectedSize, bool contentEncoded)
+{
+    if (status != 200 || contentEncoded) return false;
+    if (declaredLength < 0 || expectedSize <= 0) return false;   // nothing to compare
+    return declaredLength != expectedSize;
+}
+
+// Final gate before the .part file is renamed into place. An unknown expected
+// size can't be checked, so it passes — TLS is the only guarantee there.
+inline bool isCompleteDownload(qint64 bytesWritten, qint64 expectedSize)
+{
+    if (expectedSize <= 0) return true;
+    return bytesWritten == expectedSize;
+}
+
+// ── destination naming / capacity ───────────────────────────────────────────
+
+// Leave headroom so a download never fills the volume to the last byte.
+inline constexpr qint64 kDiskHeadroomBytes = 64LL * 1024 * 1024;
+
+inline bool hasEnoughSpaceFor(qint64 assetSize, qint64 bytesAvailable)
+{
+    if (assetSize <= 0) return true;   // unknown size — nothing to pre-check
+    return bytesAvailable >= assetSize + kDiskHeadroomBytes;
+}
+
+// "foo.dmg" + 1 → "foo (1).dmg". Used to pick a free name rather than clobbering
+// a file the user already has. Note completeBaseName/suffix split on the LAST
+// dot, so the version dots in LogosBasecamp-Desktop-v0.2.3-... survive intact.
+inline QString dedupedFileName(const QString& fileName, int index)
+{
+    const QFileInfo fi(fileName);
+    const QString base = fi.completeBaseName();
+    const QString ext  = fi.suffix();
+    if (base.isEmpty()) return fileName;
+    return ext.isEmpty()
+        ? QStringLiteral("%1 (%2)").arg(base).arg(index)
+        : QStringLiteral("%1 (%2).%3").arg(base).arg(index).arg(ext);
+}
+
+// ── presentation helpers (here so QML never does byte arithmetic) ───────────
+
+inline QString formatBytes(qint64 bytes)
+{
+    if (bytes < 0) return QString();
+    constexpr double kMB = 1000.0 * 1000.0;
+    constexpr double kGB = kMB * 1000.0;
+    if (bytes >= static_cast<qint64>(kGB))
+        return QStringLiteral("%1 GB").arg(bytes / kGB, 0, 'f', 1);
+    if (bytes >= static_cast<qint64>(kMB))
+        return QStringLiteral("%1 MB").arg(bytes / kMB, 0, 'f', 1);
+    if (bytes >= 1000)
+        return QStringLiteral("%1 KB").arg(bytes / 1000.0, 0, 'f', 0);
+    return QStringLiteral("%1 B").arg(bytes);
+}
+
+// Fraction for the progress bar, 0..1, or -1 when the total is unknown
+// (indeterminate). Clamped for the same reason progressText is: a server may
+// send more than it advertised, and a bar past 1.0 next to a label reading
+// "100%" is the kind of disagreement that only shows up in front of a user.
+inline qreal downloadFraction(qint64 received, qint64 total, qint64 assetSize)
+{
+    const qint64 denom = total > 0 ? total : assetSize;
+    if (denom <= 0) return -1.0;
+    const qreal f = static_cast<qreal>(received) / static_cast<qreal>(denom);
+    return f > 1.0 ? 1.0 : (f < 0.0 ? 0.0 : f);
+}
+
+inline QString progressText(qint64 received, qint64 total)
+{
+    if (total <= 0)
+        return formatBytes(received);
+    // Clamped: a server that sends more than it advertised should not render
+    // "113%".
+    const int pct = static_cast<int>(qMin<qint64>(100, (received * 100) / total));
+    return QStringLiteral("%1 / %2 · %3%")
+        .arg(formatBytes(received), formatBytes(total))
+        .arg(pct);
+}
+
+// Post-download instructions. Deliberately lead with "Quit Basecamp first" —
+// the app cannot replace its own running binary, and replacing a running .app is
+// exactly what produces "the application is damaged" reports.
+inline QString installHint(const QString& os, const QString& fileName)
+{
+    if (os == QStringLiteral("macos")) {
+        return QStringLiteral(
+            "Quit Basecamp, then open %1 and drag LogosBasecamp onto Applications, "
+            "replacing the existing copy. Eject the disk image when you're done.")
+            .arg(fileName);
+    }
+    if (os == QStringLiteral("linux")) {
+        return QStringLiteral(
+            "Quit Basecamp, then run the new AppImage — it has already been made "
+            "executable. Your existing AppImage is left untouched; delete or replace "
+            "it once you're happy with %1.")
+            .arg(fileName);
+    }
+    return QString();
+}
+
+// Compile-time host OS. Kept apart from selectAssetName() so the selection logic
+// stays testable for every platform from any build host.
+inline QString hostOs()
+{
+#if defined(Q_OS_MACOS)
+    return QStringLiteral("macos");
+#elif defined(Q_OS_LINUX)
+    return QStringLiteral("linux");
+#else
+    return QString();
+#endif
+}
+
+}  // namespace UpdateInfo

--- a/tests/fixtures/update-release-stub.json
+++ b/tests/fixtures/update-release-stub.json
@@ -1,0 +1,22 @@
+{
+  "tag_name": "9.9.9",
+  "name": "9.9.9",
+  "html_url": "https://github.com/logos-co/logos-basecamp/releases/tag/9.9.9",
+  "prerelease": false,
+  "assets": [
+    {
+      "name": "LogosBasecamp-Desktop-v9.9.9-abc123-riscv64.AppImage",
+      "browser_download_url": "https://github.com/logos-co/logos-basecamp/releases/download/9.9.9/LogosBasecamp-Desktop-v9.9.9-abc123-riscv64.AppImage",
+      "size": 271104520,
+      "state": "uploaded",
+      "content_type": "application/octet-stream"
+    },
+    {
+      "name": "LogosBasecamp-Desktop-v9.9.9-abc123-s390x.dmg",
+      "browser_download_url": "https://github.com/logos-co/logos-basecamp/releases/download/9.9.9/LogosBasecamp-Desktop-v9.9.9-abc123-s390x.dmg",
+      "size": 98701839,
+      "state": "uploaded",
+      "content_type": "application/octet-stream"
+    }
+  ]
+}

--- a/tests/ui-tests.mjs
+++ b/tests/ui-tests.mjs
@@ -661,6 +661,151 @@ test("window: tray toggle hides a shown window", async (app) => {
   }
 });
 
+// --- Host-app update notice (issue #319) ---
+//
+// Hermetic: no network. Two env overrides make a dev build exercise the
+// feature deterministically, and they are defaulted here so these tests run as
+// part of the normal suite rather than only when someone remembers to set them:
+//
+//   LOGOS_UPDATE_CURRENT_VERSION — forges the installed version AND waives the
+//     isPortableBuild() gate (a dev build has no AppImage/DMG to replace, so
+//     the checker otherwise skips outright).
+//   LOGOS_UPDATE_CHECK_URL — points the check at a file:// stub, so the
+//     assertions don't depend on whatever GitHub currently calls "latest".
+//
+// Deliberately `||=`: an explicit value from the caller still wins.
+//
+// nix/integration-test.nix sets LOGOS_DISABLE_UPDATE_CHECK=1 to keep that
+// derivation hermetic on every machine, which parks the checker in Skipped —
+// so these two tests don't apply there and are not registered.
+const updateChecksDisabled = !!process.env.LOGOS_DISABLE_UPDATE_CHECK;
+if (!updateChecksDisabled) {
+  process.env.LOGOS_UPDATE_CURRENT_VERSION ||= "0.0.1";
+  process.env.LOGOS_UPDATE_CHECK_URL ||=
+    `file://${resolve(__dirname, "fixtures/update-release-stub.json")}`;
+}
+
+// UpdateCheckState::Skipped — mirrors src/UpdateEnums.h.
+const UPDATE_CHECK_SKIPPED = 1;
+
+// The env vars above only reach the app when THIS process spawned it (--ci).
+// In the documented default mode (`node tests/ui-tests.mjs` against an
+// already-running app) the app never saw them, so the checker parked itself in
+// Skipped and these assertions would burn their full 20s timeout before failing
+// with an opaque message. Detect that and skip honestly instead.
+async function skipIfCheckerInactive(app, anchorId) {
+  const state = await backendProp(app, anchorId, "backend.updateCheckState");
+  if (state === UPDATE_CHECK_SKIPPED) {
+    console.log("  \x1b[33m○\x1b[0m update checker is Skipped in this app instance " +
+                "— run with --ci so the stub env reaches it");
+    return true;
+  }
+  return false;
+}
+
+async function dashboardAnchor(app) {
+  await app.click("Settings");
+  await app.waitFor(
+    async () => { await app.expectTexts(["Dashboard", "Apps Inspector", "Module Inspector"]); },
+    { timeout: 10000, interval: 500, description: "Settings entries to render" }
+  );
+  await app.click("Dashboard", { type: "LogosItemDelegate" });
+  const anchor = await app.findByProperty("objectName", "dashboard.updateSection");
+  if (!anchor.matches.length) throw new Error("dashboard.updateSection not found");
+  return anchor.matches[0].id;
+}
+
+// One property per call: evaluate returns primitives, and object literals come
+// back as an opaque <QJSValue> (see the note on the repositories helpers above).
+async function backendProp(app, anchorId, expr) {
+  return (await app.inspector.send("evaluate", { objectId: anchorId, expression: expr })).result;
+}
+
+if (updateChecksDisabled) {
+  console.log('  \x1b[33m\u25cb\x1b[0m updates: skipped (LOGOS_DISABLE_UPDATE_CHECK is set)');
+} else {
+  test("updates: stale build surfaces an update notice", async (app) => {
+    const anchorId = await dashboardAnchor(app);
+    if (await skipIfCheckerInactive(app, anchorId)) return;
+
+    // The check is deferred ~5s after construction, so poll rather than assume.
+    await app.waitFor(
+      async () => {
+        if (await backendProp(app, anchorId, "backend.updateAvailable") !== true) {
+          throw new Error("backend.updateAvailable still false");
+        }
+      },
+      { timeout: 20000, interval: 500, description: "update check to report an update" }
+    );
+
+    const latest = await backendProp(app, anchorId, "backend.latestVersion");
+    if (latest !== "9.9.9") throw new Error(`latestVersion=${latest} (expected 9.9.9)`);
+
+    const url = await backendProp(app, anchorId, "backend.releaseUrl");
+    if (!String(url).startsWith("https://github.com/logos-co/logos-basecamp/")) {
+      throw new Error(`releaseUrl not on the basecamp repo: ${url}`);
+    }
+
+    // Assert on the update-available BLOCK, not the outer section. The outer
+    // section is visible for Checking/UpToDate/Failed too, so asserting there
+    // only restates that the checker isn't Skipped — which the poll above
+    // already proved.
+    const availBlock = await app.findByProperty("objectName", "dashboard.updateAvailable");
+    if (!availBlock.matches.length) throw new Error("dashboard.updateAvailable not found");
+    const availVisible = (await app.inspector.send("evaluate", {
+      objectId: availBlock.matches[0].id, expression: "visible",
+    })).result;
+    if (availVisible !== true) throw new Error("dashboard.updateAvailable is not visible");
+
+    // And the sidebar badge — the part a user actually notices.
+    //
+    // Read `visible` through evaluate, not getProperties: the latter returns
+    // `properties` as an ARRAY of {name, type, value} records, so indexing it
+    // like an object silently yields undefined and the assertion never fails
+    // honestly.
+    const badge = await app.findByProperty("objectName", "sidebar.updateBadge");
+    if (!badge.matches.length) throw new Error("sidebar.updateBadge not found");
+    const badgeId = badge.matches[0].id;
+    const badgeVisible = (await app.inspector.send("evaluate", {
+      objectId: badgeId, expression: "visible",
+    })).result;
+    if (badgeVisible !== true) throw new Error("sidebar update badge is not visible");
+
+    // The sidebar column is a fixed 80px (MainContainer.cpp), so a badge that
+    // renders wider than that is clipped in the real UI even though `visible`
+    // is true.
+    const badgeWidth = (await app.inspector.send("evaluate", {
+      objectId: badgeId, expression: "width",
+    })).result;
+    if (!(badgeWidth > 0 && badgeWidth <= 80)) {
+      throw new Error(`sidebar badge width ${badgeWidth} does not fit the 80px column`);
+    }
+  });
+
+  test("updates: unknown platform degrades to the link-out, not an error", async (app) => {
+    const anchorId = await dashboardAnchor(app);
+    if (await skipIfCheckerInactive(app, anchorId)) return;
+    await app.waitFor(
+      async () => {
+        if (await backendProp(app, anchorId, "backend.updateAvailable") !== true) {
+          throw new Error("backend.updateAvailable still false");
+        }
+      },
+      { timeout: 20000, interval: 500, description: "update check to report an update" }
+    );
+
+    // The stub release publishes no assets at all, so no artifact can match this
+    // platform. That must present as Unsupported (release-page link only), never
+    // as a Failed/error state — the notice is still useful without a download.
+    const supported = await backendProp(app, anchorId, "backend.downloadSupported");
+    if (supported !== false) throw new Error("expected downloadSupported=false for an assetless release");
+    const stage = await backendProp(app, anchorId, "backend.updateDownloadStage");
+    if (stage !== 1) throw new Error(`updateDownloadStage=${stage} (expected 1 = Unsupported)`);
+    const err = await backendProp(app, anchorId, "backend.downloadError");
+    if (err) throw new Error(`downloadError should be empty, got: ${err}`);
+  });
+}
+
 // --- Run ---
 
 run();

--- a/tests/update_info_test.cpp
+++ b/tests/update_info_test.cpp
@@ -1,0 +1,1006 @@
+// Unit tests for src/UpdateInfo.h — the pure logic behind the host-app update
+// check (issue #319).
+//
+// This file deliberately declares no extra production sources (see the
+// first-line directive tests/CMakeLists.txt greps for). UpdateInfo.h is
+// header-only by design, precisely so this test needs neither Qt6::Network nor
+// app/utils — tests/CMakeLists.txt links and includes neither. If a future
+// change here forces one to be added, that is a signal the logic has drifted
+// back into the I/O shell.
+//
+//   nix build .#unit-tests -L
+
+#include "UpdateInfo.h"
+
+#include <QtTest/QtTest>
+
+#include <logos/semver.hpp>
+
+using namespace UpdateInfo;
+
+namespace {
+
+// ── Fixture: the real v0.2.3 release's assets[] ──────────────────────────────
+//
+// Verbatim from https://github.com/logos-co/logos-basecamp/releases/tag/0.2.3.
+// Three assets, two architectures, two package formats — and crucially NO
+// x86_64 .dmg. The names carry "-aarch64" while QSysInfo::currentCpuArchitecture()
+// reports "arm64" on Apple Silicon; that mismatch is the whole reason
+// archToken() exists.
+Asset makeAsset(const QString& name, qint64 size,
+                const QString& state = QStringLiteral("uploaded"))
+{
+    Asset a;
+    a.name  = name;
+    a.url   = QStringLiteral(
+                  "https://github.com/logos-co/logos-basecamp/releases/download/0.2.3/%1")
+                  .arg(name);
+    a.size  = size;
+    a.state = state;
+    return a;
+}
+
+QList<Asset> release023Assets()
+{
+    return {
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.AppImage"),
+                  271104520),
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg"),
+                  98701839),
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage"),
+                  278084088),
+    };
+}
+
+const char* kAarch64AppImage = "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.AppImage";
+const char* kAarch64Dmg      = "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg";
+const char* kX86AppImage     = "LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage";
+
+// moc constraint — do NOT rewrite these JSON fixtures as R"json(...)json" raw
+// string literals, however much more readable that would be.
+//
+// moc does not understand raw string literals. It sees the "//" in every
+// "https://" URL below as the start of a line comment, discards the rest of the
+// line including the closing )json" delimiter, and then reports a bewildering
+// `missing ')' in macro usage` on some later line — or silently swallows the
+// rest of the translation unit, yielding an empty .moc and a link error about
+// UpdateInfoTest::staticMetaObject with nothing pointing at the JSON.
+//
+// It reproduces under nix/unit-tests.nix's moc invocation but NOT under a bare
+// `moc file.cpp`, so it will not show up in local spot-checks — only in CI.
+// Ordinary escaped literals lex correctly; keep them.
+
+// A trimmed but structurally faithful /releases/latest payload.
+QByteArray release023Json()
+{
+    return QByteArrayLiteral(
+        "{"
+        "  \"tag_name\": \"0.2.3\","
+        "  \"name\": \"0.2.3\","
+        "  \"html_url\": \"https://github.com/logos-co/logos-basecamp/releases/tag/0.2.3\","
+        "  \"assets\": ["
+        "    {"
+        "      \"name\": \"LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.AppImage\","
+        "      \"browser_download_url\": \"https://github.com/logos-co/logos-basecamp/releases/download/0.2.3/LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.AppImage\","
+        "      \"size\": 271104520,"
+        "      \"state\": \"uploaded\","
+        "      \"content_type\": \"application/octet-stream\""
+        "    },"
+        "    {"
+        "      \"name\": \"LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg\","
+        "      \"browser_download_url\": \"https://github.com/logos-co/logos-basecamp/releases/download/0.2.3/LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg\","
+        "      \"size\": 98701839,"
+        "      \"state\": \"uploaded\","
+        "      \"content_type\": \"application/octet-stream\""
+        "    },"
+        "    {"
+        "      \"name\": \"LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage\","
+        "      \"browser_download_url\": \"https://github.com/logos-co/logos-basecamp/releases/download/0.2.3/LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage\","
+        "      \"size\": 278084088,"
+        "      \"state\": \"uploaded\","
+        "      \"content_type\": \"application/octet-stream\""
+        "    }"
+        "  ]"
+        "}");
+}
+
+} // namespace
+
+class UpdateInfoTest : public QObject
+{
+    Q_OBJECT
+
+private slots:
+    // ── asset selection ──────────────────────────────────────────────────
+    void selectAssetName_realRelease_data();
+    void selectAssetName_realRelease();
+    void selectAssetName_skipsNonUploadedAssets();
+    void selectAssetName_emptyStateTreatedAsUploaded();
+    void selectAssetName_ignoresForeignFilenames();
+    void selectAssetName_emptyAssetList();
+    void archToken_mapsHostNamesToAssetNames_data();
+    void archToken_mapsHostNamesToAssetNames();
+
+    // ── version handling ─────────────────────────────────────────────────
+    void normalizeVersion_peelsLeadingV();
+    void isComparableVersion_data();
+    void isComparableVersion();
+    void rawComparatorWouldFalselyOfferUpdateToEveryDevBuild();
+    void isNewer_data();
+    void isNewer();
+
+    // ── release payload ──────────────────────────────────────────────────
+    void parseRelease_roundTripsRealPayload();
+    void parseRelease_rejectsBadInput_data();
+    void parseRelease_rejectsBadInput();
+    void parseRelease_skipsAssetsWithoutName();
+
+    // ── transport safety ─────────────────────────────────────────────────
+    void isTrustedReleaseUrl_data();
+    void isTrustedReleaseUrl();
+    void isAllowedDownloadHost_data();
+    void isAllowedDownloadHost();
+
+    // ── presentation ─────────────────────────────────────────────────────
+    void formatBytes_data();
+    void formatBytes();
+    void progressText_showsBothSizesAndPercent();
+    void progressText_unknownTotalFallsBackToReceivedOnly();
+    void installHint_data();
+    void installHint();
+
+    // ── download decisions (extracted from UpdateChecker's I/O shell) ────
+    void isAllowedDownloadUrl_requiresHttpsAndAllowedHost_data();
+    void isAllowedDownloadUrl_requiresHttpsAndAllowedHost();
+    void isAcceptableHttpStatus_data();
+    void isAcceptableHttpStatus();
+    void isDeclaredSizeMismatch_data();
+    void isDeclaredSizeMismatch();
+    void isCompleteDownload_data();
+    void isCompleteDownload();
+    void hasEnoughSpaceFor_data();
+    void hasEnoughSpaceFor();
+    void dedupedFileName_data();
+    void dedupedFileName();
+
+    // ── security regressions ────────────────────────────────────────────
+    void isSafeAssetFileName_data();
+    void isSafeAssetFileName();
+    void selectAssetName_rejectsPathTraversalDespiteMatchingPrefixAndSuffix();
+    void isAllowedDownloadHost_rejectsArbitraryS3Buckets();
+    void shouldSkipCheck_data();
+    void shouldSkipCheck();
+    void downloadFraction_data();
+    void downloadFraction();
+};
+
+// ── asset selection ─────────────────────────────────────────────────────────
+
+void UpdateInfoTest::selectAssetName_realRelease_data()
+{
+    QTest::addColumn<QString>("os");
+    QTest::addColumn<QString>("cpu");
+    QTest::addColumn<QString>("expected");
+
+    // THE trap: QSysInfo::currentCpuArchitecture() says "arm64", the asset
+    // says "aarch64". Without archToken() this returns empty on every Mac and
+    // every ARM Linux box — i.e. the feature ships silently doing nothing.
+    QTest::newRow("apple-silicon-mac -> dmg")
+        << "macos" << "arm64" << QString::fromLatin1(kAarch64Dmg);
+    QTest::newRow("arm64 linux -> aarch64 AppImage")
+        << "linux" << "arm64" << QString::fromLatin1(kAarch64AppImage);
+    // Defensive: some hosts/toolchains report the kernel spelling directly.
+    QTest::newRow("aarch64 linux -> aarch64 AppImage")
+        << "linux" << "aarch64" << QString::fromLatin1(kAarch64AppImage);
+    QTest::newRow("x86_64 linux -> x86_64 AppImage")
+        << "linux" << "x86_64" << QString::fromLatin1(kX86AppImage);
+    QTest::newRow("amd64 alias -> x86_64 AppImage")
+        << "linux" << "amd64" << QString::fromLatin1(kX86AppImage);
+
+    // Intel Mac: 0.2.3 genuinely publishes no x86_64 .dmg. Empty is the
+    // correct answer and a UI state (link out to the release page), not a bug.
+    QTest::newRow("intel-mac has no dmg published")
+        << "macos" << "x86_64" << QString();
+
+    // Windows ships nothing at all, on any arch.
+    QTest::newRow("windows arm64")  << "windows" << "arm64"  << QString();
+    QTest::newRow("windows x86_64") << "windows" << "x86_64" << QString();
+
+    // Unknown arch must not fall through to "pick something".
+    QTest::newRow("riscv64 linux")  << "linux"   << "riscv64" << QString();
+
+    // Empty inputs are the "we don't know the host" case.
+    QTest::newRow("empty os")   << QString() << "arm64"    << QString();
+    QTest::newRow("empty arch") << "linux"   << QString()  << QString();
+}
+
+void UpdateInfoTest::selectAssetName_realRelease()
+{
+    QFETCH(QString, os);
+    QFETCH(QString, cpu);
+    QFETCH(QString, expected);
+
+    const QString actual = selectAssetName(release023Assets(), os, cpu);
+    QCOMPARE(actual, expected);
+}
+
+void UpdateInfoTest::selectAssetName_skipsNonUploadedAssets()
+{
+    // GitHub reports state "starting" while it is still ingesting the upload.
+    // Downloading one yields a truncated file that fails to mount/run, so the
+    // only safe answer is "no asset yet".
+    QList<Asset> assets{
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg"),
+                  98701839, QStringLiteral("starting")),
+    };
+    QCOMPARE(selectAssetName(assets, QStringLiteral("macos"),
+                             QStringLiteral("arm64")),
+             QString());
+
+    // With an uploaded sibling present, selection resumes normally.
+    assets.append(makeAsset(
+        QStringLiteral("LogosBasecamp-Desktop-v0.2.3-bb1188-aarch64.dmg"),
+        98701839));
+    QCOMPARE(selectAssetName(assets, QStringLiteral("macos"),
+                             QStringLiteral("arm64")),
+             QStringLiteral("LogosBasecamp-Desktop-v0.2.3-bb1188-aarch64.dmg"));
+}
+
+void UpdateInfoTest::selectAssetName_emptyStateTreatedAsUploaded()
+{
+    // Not every producer of this struct fills `state` (e.g. a hand-built
+    // fixture, or a payload variant without the field). Empty must not be
+    // read as "not ready" — that would disable updates wholesale.
+    QList<Asset> assets{
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg"),
+                  98701839, QString()),
+    };
+    QCOMPARE(selectAssetName(assets, QStringLiteral("macos"),
+                             QStringLiteral("arm64")),
+             QStringLiteral("LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg"));
+}
+
+void UpdateInfoTest::selectAssetName_ignoresForeignFilenames()
+{
+    // Releases carry extra attachments (checksums, source archives, sidecar
+    // builds). Only LogosBasecamp-Desktop-v* is ours; matching purely on the
+    // "-<arch>.<ext>" suffix would happily hand back someone else's binary.
+    const QList<Asset> assets{
+        makeAsset(QStringLiteral("SomeOtherApp-v0.2.3-aa2377-aarch64.dmg"), 123),
+        makeAsset(QStringLiteral("LogosBasecamp-Server-v0.2.3-aa2377-aarch64.dmg"), 123),
+        makeAsset(QStringLiteral("aarch64.dmg"), 123),
+        makeAsset(QStringLiteral("LogosBasecamp-Desktop-0.2.3-aa2377-aarch64.dmg"), 123),
+    };
+    QVERIFY2(selectAssetName(assets, QStringLiteral("macos"),
+                             QStringLiteral("arm64")).isEmpty(),
+             "only assets named LogosBasecamp-Desktop-v* may be selected");
+}
+
+void UpdateInfoTest::selectAssetName_emptyAssetList()
+{
+    QCOMPARE(selectAssetName({}, QStringLiteral("macos"), QStringLiteral("arm64")),
+             QString());
+}
+
+void UpdateInfoTest::archToken_mapsHostNamesToAssetNames_data()
+{
+    QTest::addColumn<QString>("cpu");
+    QTest::addColumn<QString>("expected");
+
+    QTest::newRow("arm64")   << "arm64"   << "aarch64";
+    QTest::newRow("aarch64") << "aarch64" << "aarch64";
+    QTest::newRow("ARM64")   << "ARM64"   << "aarch64";   // case-insensitive
+    QTest::newRow("x86_64")  << "x86_64"  << "x86_64";
+    QTest::newRow("amd64")   << "amd64"   << "x86_64";
+    QTest::newRow("i386")    << "i386"    << QString();
+    QTest::newRow("riscv64") << "riscv64" << QString();
+    QTest::newRow("empty")   << QString() << QString();
+}
+
+void UpdateInfoTest::archToken_mapsHostNamesToAssetNames()
+{
+    QFETCH(QString, cpu);
+    QFETCH(QString, expected);
+    QCOMPARE(archToken(cpu), expected);
+}
+
+// ── version handling ────────────────────────────────────────────────────────
+
+void UpdateInfoTest::normalizeVersion_peelsLeadingV()
+{
+    // Tags are bare ("0.2.3"); asset filenames embed "v0.2.3". Both reach the
+    // comparator, and strict semver rejects the prefix.
+    QCOMPARE(normalizeVersion(QStringLiteral("v0.2.3")), QStringLiteral("0.2.3"));
+    QCOMPARE(normalizeVersion(QStringLiteral("V0.2.3")), QStringLiteral("0.2.3"));
+    QCOMPARE(normalizeVersion(QStringLiteral("0.2.3")),  QStringLiteral("0.2.3"));
+    QCOMPARE(normalizeVersion(QStringLiteral("  0.2.3  ")), QStringLiteral("0.2.3"));
+    QCOMPARE(normalizeVersion(QStringLiteral(" v0.2.3 ")), QStringLiteral("0.2.3"));
+    QCOMPARE(normalizeVersion(QString()), QString());
+}
+
+void UpdateInfoTest::isComparableVersion_data()
+{
+    QTest::addColumn<QString>("current");
+    QTest::addColumn<bool>("expected");
+
+    QTest::newRow("release tag")    << "0.2.3"    << true;
+    QTest::newRow("rc tag")         << "0.2.3-RC1" << true;
+    QTest::newRow("v-prefixed")     << "v0.2.3"   << true;
+    QTest::newRow("build metadata") << "0.2.3+aa2377" << true;
+
+    // The three shapes a non-release build actually takes:
+    //   master CI  → "pre-release-<sha7>"
+    //   dirty local build → ""
+    //   ad-hoc → anything unparseable
+    QTest::newRow("master CI build") << "pre-release-aa23776" << false;
+    QTest::newRow("dirty local")     << ""                    << false;
+    QTest::newRow("dev")             << "dev"                 << false;
+    QTest::newRow("partial 0.2")     << "0.2"                 << false;
+}
+
+void UpdateInfoTest::isComparableVersion()
+{
+    QFETCH(QString, current);
+    QFETCH(bool, expected);
+    QCOMPARE(UpdateInfo::isComparableVersion(current), expected);
+}
+
+void UpdateInfoTest::rawComparatorWouldFalselyOfferUpdateToEveryDevBuild()
+{
+    // THIS is why isComparableVersion() exists, pinned so nobody "simplifies"
+    // isNewer() down to a bare compare().
+    //
+    // logos::semver::compare sorts an UNPARSEABLE string BELOW every parseable
+    // one (see semver.hpp: `if (vb) return -1;`). So the raw comparator claims
+    // "pre-release-aa23776" < "0.2.3" — i.e. every master CI build and every
+    // dirty local build would be told, forever, that it is out of date.
+    QVERIFY2(logos::semver::compare("pre-release-aa23776", "0.2.3") < 0,
+             "precondition: the raw comparator ranks a dev build below 0.2.3");
+    QVERIFY2(logos::semver::compare("", "0.2.3") < 0,
+             "precondition: the raw comparator ranks an empty version below 0.2.3");
+
+    // The gate inside isNewer() suppresses both.
+    QVERIFY2(!UpdateInfo::isNewer(QStringLiteral("pre-release-aa23776"),
+                                  QStringLiteral("0.2.3")),
+             "a dev build must never be told an update is available");
+    QVERIFY2(!UpdateInfo::isNewer(QString(), QStringLiteral("0.2.3")),
+             "a dirty local build must never be told an update is available");
+}
+
+void UpdateInfoTest::isNewer_data()
+{
+    QTest::addColumn<QString>("current");
+    QTest::addColumn<QString>("latest");
+    QTest::addColumn<bool>("expected");
+
+    QTest::newRow("older -> newer")   << "0.2.1" << "0.2.3" << true;
+    QTest::newRow("same version")     << "0.2.3" << "0.2.3" << false;
+
+    // Never offer a downgrade: /releases/latest is ordered by creation date,
+    // not semver precedence, so a hotfix cut from an old branch can be
+    // "latest" while being older than what the user is running.
+    QTest::newRow("downgrade refused") << "0.2.4" << "0.2.3" << false;
+
+    // Prerelease precedence: 0.2.3-RC1 < 0.2.3.
+    QTest::newRow("rc -> release")     << "0.2.3-RC1" << "0.2.3"     << true;
+    QTest::newRow("release -> next rc")<< "0.2.3"     << "0.2.4-RC1" << true;
+    QTest::newRow("release -> same-version rc is a downgrade")
+        << "0.2.3" << "0.2.3-RC1" << false;
+
+    // The `v` prefix must be tolerated on either side or both.
+    QTest::newRow("v on latest")  << "0.2.1"  << "v0.2.3" << true;
+    QTest::newRow("v on current") << "v0.2.1" << "0.2.3"  << true;
+    QTest::newRow("v on both")    << "v0.2.1" << "v0.2.3" << true;
+
+    // Upstream data is parsed leniently: a partial tag is unambiguous.
+    QTest::newRow("lenient latest 1.0") << "0.2.3" << "1.0" << true;
+
+    // The running build is held to the strict standard — see the gate test.
+    QTest::newRow("dev current")   << "pre-release-aa23776" << "0.2.3" << false;
+    QTest::newRow("empty current") << ""                    << "0.2.3" << false;
+    // And junk upstream data must not be read as "newer" either.
+    QTest::newRow("junk latest")   << "0.2.3" << "banana" << false;
+    QTest::newRow("empty latest")  << "0.2.3" << ""       << false;
+}
+
+void UpdateInfoTest::isNewer()
+{
+    QFETCH(QString, current);
+    QFETCH(QString, latest);
+    QFETCH(bool, expected);
+    QCOMPARE(UpdateInfo::isNewer(current, latest), expected);
+}
+
+// ── release payload ─────────────────────────────────────────────────────────
+
+void UpdateInfoTest::parseRelease_roundTripsRealPayload()
+{
+    const Release r = parseRelease(release023Json());
+
+    QVERIFY2(r.ok, "a well-formed release payload must parse");
+    QCOMPARE(r.tag, QStringLiteral("0.2.3"));
+    QCOMPARE(r.htmlUrl,
+             QStringLiteral("https://github.com/logos-co/logos-basecamp/releases/tag/0.2.3"));
+    QCOMPARE(r.assets.size(), 3);
+
+    QCOMPARE(r.assets.at(0).name,  QString::fromLatin1(kAarch64AppImage));
+    QCOMPARE(r.assets.at(0).size,  Q_INT64_C(271104520));
+    QCOMPARE(r.assets.at(0).state, QStringLiteral("uploaded"));
+    QCOMPARE(r.assets.at(0).url,
+             QStringLiteral("https://github.com/logos-co/logos-basecamp/releases/"
+                            "download/0.2.3/") + QString::fromLatin1(kAarch64AppImage));
+
+    QCOMPARE(r.assets.at(1).name, QString::fromLatin1(kAarch64Dmg));
+    QCOMPARE(r.assets.at(1).size, Q_INT64_C(98701839));
+
+    QCOMPARE(r.assets.at(2).name, QString::fromLatin1(kX86AppImage));
+    QCOMPARE(r.assets.at(2).size, Q_INT64_C(278084088));
+
+    // The two halves compose: parse the payload, then pick for this host.
+    QCOMPARE(selectAssetName(r.assets, QStringLiteral("macos"),
+                             QStringLiteral("arm64")),
+             QString::fromLatin1(kAarch64Dmg));
+
+    // 271104520 is comfortably past the 2^31 boundary — assert it survived the
+    // double round-trip in parseRelease intact rather than truncating.
+    QVERIFY2(r.assets.at(2).size > Q_INT64_C(2147483647) / 8,
+             "sanity: sizes are large; they must not be parsed into an int");
+}
+
+void UpdateInfoTest::parseRelease_rejectsBadInput_data()
+{
+    QTest::addColumn<QByteArray>("json");
+
+    QTest::newRow("empty")           << QByteArray();
+    QTest::newRow("whitespace")      << QByteArrayLiteral("   ");
+    QTest::newRow("malformed json")  << QByteArrayLiteral("{ \"tag_name\": ");
+    QTest::newRow("not json at all") << QByteArrayLiteral("<html>404</html>");
+    // GitHub returns an ARRAY from /releases (plural). Hitting the wrong
+    // endpoint must fail closed, not half-parse.
+    QTest::newRow("array not object")
+        << QByteArrayLiteral("[{\"tag_name\":\"0.2.3\"}]");
+    QTest::newRow("empty array")  << QByteArrayLiteral("[]");
+    QTest::newRow("json null")    << QByteArrayLiteral("null");
+    // No tag_name → nothing to compare against, so there is no update to offer.
+    QTest::newRow("no tag_name")
+        << QByteArrayLiteral("{\"html_url\":\"https://example.com\",\"assets\":[]}");
+    QTest::newRow("empty tag_name")
+        << QByteArrayLiteral("{\"tag_name\":\"\",\"assets\":[]}");
+    // html_url is required for the same reason tag_name is: UpdateChecker gates
+    // trust on isTrustedReleaseUrl(), so accepting a payload that merely OMITS
+    // the field would let it skip that check entirely — failing open.
+    QTest::newRow("no html_url")
+        << QByteArrayLiteral("{\"tag_name\":\"0.2.3\",\"assets\":[]}");
+    QTest::newRow("empty html_url")
+        << QByteArrayLiteral("{\"tag_name\":\"0.2.3\",\"html_url\":\"\",\"assets\":[]}");
+}
+
+void UpdateInfoTest::parseRelease_rejectsBadInput()
+{
+    QFETCH(QByteArray, json);
+    const Release r = parseRelease(json);
+    QVERIFY2(!r.ok, "malformed or tagless payloads must not report ok");
+    QVERIFY2(r.assets.isEmpty(), "a failed parse must not leak partial assets");
+}
+
+void UpdateInfoTest::parseRelease_skipsAssetsWithoutName()
+{
+    // A nameless asset can't be matched or saved to disk, so it is dropped
+    // rather than carried through as an empty row.
+    // Adjacent single-line raw literals — see the moc note above the fixtures.
+    const Release r = parseRelease(QByteArrayLiteral(
+        "{"
+        "  \"tag_name\": \"0.2.3\","
+        "  \"html_url\": \"https://github.com/logos-co/logos-basecamp/releases/tag/0.2.3\","
+        "  \"assets\": ["
+        "    {\"browser_download_url\": \"https://example.com/x\", \"size\": 10, \"state\": \"uploaded\"},"
+        "    {\"name\": \"LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg\","
+        "     \"browser_download_url\": \"https://example.com/y\", \"size\": 98701839,"
+        "     \"state\": \"uploaded\"}"
+        "  ]"
+        "}"));
+
+    QVERIFY(r.ok);
+    QCOMPARE(r.assets.size(), 1);
+    QCOMPARE(r.assets.at(0).name, QString::fromLatin1(kAarch64Dmg));
+}
+
+// ── transport safety ────────────────────────────────────────────────────────
+
+void UpdateInfoTest::isTrustedReleaseUrl_data()
+{
+    QTest::addColumn<QString>("url");
+    QTest::addColumn<bool>("expected");
+
+    QTest::newRow("real release page")
+        << "https://github.com/logos-co/logos-basecamp/releases/tag/0.2.3" << true;
+    QTest::newRow("real download url")
+        << "https://github.com/logos-co/logos-basecamp/releases/download/0.2.3/"
+           "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg" << true;
+
+    // A fork (or a typosquat org) is not us.
+    QTest::newRow("wrong org")
+        << "https://github.com/evil/logos-basecamp/releases/tag/0.2.3" << false;
+    QTest::newRow("wrong repo")
+        << "https://github.com/logos-co/logos-basecamp-evil/releases/tag/0.2.3" << false;
+
+    // Plain http is never acceptable — the payload is an executable.
+    QTest::newRow("http downgrade")
+        << "http://github.com/logos-co/logos-basecamp/releases/tag/0.2.3" << false;
+
+    QTest::newRow("host-prefix spoof")
+        << "https://github.com.evil.com/logos-co/logos-basecamp/releases/tag/0.2.3"
+        << false;
+    QTest::newRow("empty") << QString() << false;
+}
+
+void UpdateInfoTest::isTrustedReleaseUrl()
+{
+    QFETCH(QString, url);
+    QFETCH(bool, expected);
+    QCOMPARE(UpdateInfo::isTrustedReleaseUrl(url), expected);
+}
+
+void UpdateInfoTest::isAllowedDownloadHost_data()
+{
+    QTest::addColumn<QString>("host");
+    QTest::addColumn<bool>("expected");
+
+    // GitHub has moved release-asset hosting more than once, so the allowlist
+    // covers the family rather than the host of the day.
+    QTest::newRow("github.com")        << "github.com" << true;
+    QTest::newRow("release-assets")    << "release-assets.githubusercontent.com" << true;
+    QTest::newRow("objects")           << "objects.githubusercontent.com" << true;
+    QTest::newRow("s3")                << "github-production-release-asset-2e65be.s3.amazonaws.com"
+                                       << true;
+    QTest::newRow("uppercase host")    << "GitHub.com" << true;
+
+    QTest::newRow("evil.com")          << "evil.com" << false;
+    // Suffix-confusion: the allowlisted string appears, but not as the suffix.
+    QTest::newRow("suffix confusion")  << "githubusercontent.com.evil.com" << false;
+    QTest::newRow("notgithub.com")     << "notgithub.com" << false;
+    QTest::newRow("github.com.evil")   << "github.com.evil.com" << false;
+    QTest::newRow("bare s3")           << "s3.amazonaws.com" << false;
+    QTest::newRow("empty")             << QString() << false;
+}
+
+void UpdateInfoTest::isAllowedDownloadHost()
+{
+    QFETCH(QString, host);
+    QFETCH(bool, expected);
+    QCOMPARE(UpdateInfo::isAllowedDownloadHost(host), expected);
+}
+
+// ── presentation ────────────────────────────────────────────────────────────
+
+void UpdateInfoTest::formatBytes_data()
+{
+    QTest::addColumn<qint64>("bytes");
+    QTest::addColumn<QString>("expected");
+
+    // Decimal MB/GB (1000-based) — matches what GitHub and Finder report, so
+    // "271.1 MB" in our dialog matches the number the user sees on the site.
+    QTest::newRow("aarch64 AppImage") << Q_INT64_C(271104520) << "271.1 MB";
+    QTest::newRow("aarch64 dmg")      << Q_INT64_C(98701839)  << "98.7 MB";
+    QTest::newRow("x86_64 AppImage")  << Q_INT64_C(278084088) << "278.1 MB";
+    QTest::newRow("exactly 1 MB")     << Q_INT64_C(1000000)   << "1.0 MB";
+    QTest::newRow("1 GB")             << Q_INT64_C(1000000000) << "1.0 GB";
+    QTest::newRow("1 KB")             << Q_INT64_C(1000)      << "1 KB";
+    QTest::newRow("just under 1 KB")  << Q_INT64_C(999)       << "999 B";
+    QTest::newRow("zero")             << Q_INT64_C(0)         << "0 B";
+    // Negative is "unknown", not "-0 B" — Content-Length is optional.
+    QTest::newRow("negative")         << Q_INT64_C(-1)        << QString();
+}
+
+void UpdateInfoTest::formatBytes()
+{
+    QFETCH(qint64, bytes);
+    QFETCH(QString, expected);
+    QCOMPARE(UpdateInfo::formatBytes(bytes), expected);
+}
+
+void UpdateInfoTest::progressText_showsBothSizesAndPercent()
+{
+    const qint64 total    = 271104520;   // the real aarch64 AppImage
+    const qint64 received = 135552260;   // exactly half
+
+    const QString text = progressText(received, total);
+
+    QVERIFY2(text.contains(QStringLiteral("135.6 MB")),
+             qPrintable(QStringLiteral("received size missing from: ") + text));
+    QVERIFY2(text.contains(QStringLiteral("271.1 MB")),
+             qPrintable(QStringLiteral("total size missing from: ") + text));
+    QVERIFY2(text.contains(QStringLiteral("50%")),
+             qPrintable(QStringLiteral("percentage missing from: ") + text));
+
+    // Exact form, with the separator spelled by code point so this assertion
+    // does not depend on the source file's encoding surviving a round-trip.
+    const QString expected = QStringLiteral("135.6 MB / 271.1 MB ")
+                           + QChar(0x00B7) + QStringLiteral(" 50%");
+    QCOMPARE(text, expected);
+
+    // Integer truncation, not rounding: 99.9% must not read as 100%.
+    QVERIFY2(progressText(total - 1, total).contains(QStringLiteral("99%")),
+             "percentage truncates toward zero");
+    QCOMPARE(progressText(0, total),
+             QStringLiteral("0 B / 271.1 MB ") + QChar(0x00B7) + QStringLiteral(" 0%"));
+    QVERIFY2(progressText(total, total).contains(QStringLiteral("100%")),
+             "a completed download reads 100%");
+
+    // Clamped at 100%. A server is free to send more bytes than its own
+    // Content-Length advertised (or send none and let us fall back to the
+    // catalog's size, which can disagree); the progress line must not then
+    // read "113%". UpdateChecker also rejects a size mismatch outright, but
+    // the label is rendered live during the transfer, before that check runs.
+    QVERIFY2(progressText(total + 1, total).contains(QStringLiteral("100%")),
+             "overshooting the advertised total still reads 100%");
+    QVERIFY2(!progressText(total * 2, total).contains(QStringLiteral("200%")),
+             "a wildly oversized body must not render a >100% percentage");
+}
+
+void UpdateInfoTest::progressText_unknownTotalFallsBackToReceivedOnly()
+{
+    // No Content-Length (chunked response): show what we have rather than a
+    // bogus percentage or a divide-by-zero.
+    QCOMPARE(progressText(1500000, 0),  QStringLiteral("1.5 MB"));
+    QCOMPARE(progressText(1500000, -1), QStringLiteral("1.5 MB"));
+}
+
+void UpdateInfoTest::installHint_data()
+{
+    QTest::addColumn<QString>("os");
+    QTest::addColumn<bool>("expectHint");
+
+    QTest::newRow("macos")   << "macos"   << true;
+    QTest::newRow("linux")   << "linux"   << true;
+    QTest::newRow("windows") << "windows" << false;
+    QTest::newRow("empty")   << QString() << false;
+    // Case matters — hostOs() only ever emits the lowercase spellings.
+    QTest::newRow("macOS mixed case") << "macOS" << false;
+}
+
+void UpdateInfoTest::installHint()
+{
+    QFETCH(QString, os);
+    QFETCH(bool, expectHint);
+
+    const QString fileName = QString::fromLatin1(kAarch64Dmg);
+    const QString hint = UpdateInfo::installHint(os, fileName);
+
+    if (!expectHint) {
+        QVERIFY2(hint.isEmpty(),
+                 qPrintable(QStringLiteral("unsupported OS must yield no hint, got: ") + hint));
+        return;
+    }
+
+    QVERIFY2(!hint.isEmpty(), "supported OS must yield a hint");
+    QVERIFY2(hint.contains(fileName),
+             qPrintable(QStringLiteral("hint must name the downloaded file, got: ") + hint));
+    // Leading instruction is load-bearing: replacing a running .app is what
+    // produces the "application is damaged" reports.
+    QVERIFY2(hint.startsWith(QStringLiteral("Quit Basecamp")),
+             qPrintable(QStringLiteral("hint must lead with quitting the app, got: ") + hint));
+}
+
+// ── download decisions ──────────────────────────────────────────────────────
+//
+// These were inline in UpdateChecker.cpp's network callbacks, where they could
+// not be reached from a unit test: tests/CMakeLists.txt links no Qt6::Network,
+// so anything touching QNetworkReply fails to compile. Pulling the DECISION out
+// of the I/O leaves UpdateChecker a thin shell and makes the rules testable.
+
+void UpdateInfoTest::isAllowedDownloadUrl_requiresHttpsAndAllowedHost_data()
+{
+    QTest::addColumn<QString>("scheme");
+    QTest::addColumn<QString>("host");
+    QTest::addColumn<bool>("allowed");
+
+    // The real redirect chain: github.com 302s to a signed CDN URL.
+    QTest::newRow("github https")   << "https" << "github.com" << true;
+    QTest::newRow("release CDN")    << "https" << "release-assets.githubusercontent.com" << true;
+    QTest::newRow("objects CDN")    << "https" << "objects.githubusercontent.com" << true;
+    QTest::newRow("s3 release bucket")
+        << "https" << "github-production-release-asset-2e65be.s3.amazonaws.com" << true;
+    // Self-service bucket name — must NOT satisfy the gate.
+    QTest::newRow("s3 attacker bucket")
+        << "https" << "attacker.s3.amazonaws.com" << false;
+    QTest::newRow("scheme upcased") << "HTTPS" << "github.com" << true;
+
+    // Downgrade to plaintext on a hop that ends in an executable. Qt's
+    // NoLessSafeRedirectPolicy should already stop this; belt and braces.
+    QTest::newRow("http downgrade") << "http"  << "github.com" << false;
+    QTest::newRow("file scheme")    << "file"  << "github.com" << false;
+    // Suffix-confusion: a host that merely ENDS with our domain as a label.
+    QTest::newRow("suffix attack")  << "https" << "githubusercontent.com.evil.com" << false;
+    QTest::newRow("lookalike")      << "https" << "notgithub.com" << false;
+    QTest::newRow("unrelated")      << "https" << "evil.com" << false;
+}
+
+void UpdateInfoTest::isAllowedDownloadUrl_requiresHttpsAndAllowedHost()
+{
+    QFETCH(QString, scheme);
+    QFETCH(QString, host);
+    QFETCH(bool, allowed);
+    QCOMPARE(UpdateInfo::isAllowedDownloadUrl(scheme, host), allowed);
+}
+
+void UpdateInfoTest::isAcceptableHttpStatus_data()
+{
+    QTest::addColumn<int>("status");
+    QTest::addColumn<bool>("ok");
+
+    QTest::newRow("200 OK")        << 200 << true;
+    // 0 = attribute absent. The UI tests point the check at a file:// stub,
+    // which carries no HTTP status; rejecting 0 would break them.
+    QTest::newRow("non-HTTP (0)")  << 0   << true;
+    QTest::newRow("301")           << 301 << true;
+    QTest::newRow("302 to CDN")    << 302 << true;
+    QTest::newRow("307")           << 307 << true;
+
+    // The one that matters: without this check a 404 HTML body gets written to
+    // disk under a .dmg name and handed to the user as an installer.
+    QTest::newRow("404")           << 404 << false;
+    QTest::newRow("403 rate limit")<< 403 << false;
+    QTest::newRow("500")           << 500 << false;
+    QTest::newRow("418")           << 418 << false;
+}
+
+void UpdateInfoTest::isAcceptableHttpStatus()
+{
+    QFETCH(int, status);
+    QFETCH(bool, ok);
+    QCOMPARE(UpdateInfo::isAcceptableHttpStatus(status), ok);
+}
+
+void UpdateInfoTest::isDeclaredSizeMismatch_data()
+{
+    QTest::addColumn<int>("status");
+    QTest::addColumn<qint64>("declared");
+    QTest::addColumn<qint64>("expected");
+    QTest::addColumn<bool>("encoded");
+    QTest::addColumn<bool>("mismatch");
+
+    const qint64 dmg = Q_INT64_C(98701839);
+
+    QTest::newRow("exact match")   << 200 << dmg     << dmg << false << false;
+    QTest::newRow("swapped asset") << 200 << dmg + 1 << dmg << false << true;
+    QTest::newRow("truncated")     << 200 << Q_INT64_C(100) << dmg << false << true;
+
+    // A 3xx body is the redirect stub, not the asset — comparing it would
+    // abort every download that follows a CDN redirect.
+    QTest::newRow("redirect body") << 302 << Q_INT64_C(0) << dmg << false << false;
+    // A compressed body legitimately differs from the on-disk asset size.
+    QTest::newRow("gzipped")       << 200 << Q_INT64_C(5) << dmg << true  << false;
+    // Nothing to compare against — degrade to TLS-only trust, don't false-alarm.
+    QTest::newRow("no header")     << 200 << Q_INT64_C(-1) << dmg << false << false;
+    QTest::newRow("unknown asset") << 200 << dmg << Q_INT64_C(0) << false << false;
+}
+
+void UpdateInfoTest::isDeclaredSizeMismatch()
+{
+    QFETCH(int, status);
+    QFETCH(qint64, declared);
+    QFETCH(qint64, expected);
+    QFETCH(bool, encoded);
+    QFETCH(bool, mismatch);
+    QCOMPARE(UpdateInfo::isDeclaredSizeMismatch(status, declared, expected, encoded), mismatch);
+}
+
+void UpdateInfoTest::isCompleteDownload_data()
+{
+    QTest::addColumn<qint64>("written");
+    QTest::addColumn<qint64>("expected");
+    QTest::addColumn<bool>("complete");
+
+    const qint64 dmg = Q_INT64_C(98701839);
+
+    QTest::newRow("byte exact")      << dmg     << dmg << true;
+    QTest::newRow("one byte short")  << dmg - 1 << dmg << false;
+    QTest::newRow("overshoot")       << dmg + 1 << dmg << false;
+    QTest::newRow("empty file")      << Q_INT64_C(0) << dmg << false;
+    // Unknown published size: can't verify, so don't block the rename.
+    QTest::newRow("unknown size")    << dmg << Q_INT64_C(0)  << true;
+    QTest::newRow("negative size")   << dmg << Q_INT64_C(-1) << true;
+}
+
+void UpdateInfoTest::isCompleteDownload()
+{
+    QFETCH(qint64, written);
+    QFETCH(qint64, expected);
+    QFETCH(bool, complete);
+    QCOMPARE(UpdateInfo::isCompleteDownload(written, expected), complete);
+}
+
+void UpdateInfoTest::hasEnoughSpaceFor_data()
+{
+    QTest::addColumn<qint64>("assetSize");
+    QTest::addColumn<qint64>("available");
+    QTest::addColumn<bool>("enough");
+
+    const qint64 appImage = Q_INT64_C(271104520);          // the real aarch64 AppImage
+    const qint64 headroom = UpdateInfo::kDiskHeadroomBytes;
+
+    QTest::newRow("plenty free")   << appImage << appImage + headroom + 1 << true;
+    QTest::newRow("exactly enough")<< appImage << appImage + headroom     << true;
+    // Fits the file but not the headroom — refuse rather than fill the volume.
+    QTest::newRow("no headroom")   << appImage << appImage + headroom - 1 << false;
+    QTest::newRow("barely fits")   << appImage << appImage                << false;
+    QTest::newRow("nearly full")   << appImage << Q_INT64_C(1024)         << false;
+    // Unknown asset size — nothing to pre-check, let the write find out.
+    QTest::newRow("unknown size")  << Q_INT64_C(0) << Q_INT64_C(0)        << true;
+}
+
+void UpdateInfoTest::hasEnoughSpaceFor()
+{
+    QFETCH(qint64, assetSize);
+    QFETCH(qint64, available);
+    QFETCH(bool, enough);
+    QCOMPARE(UpdateInfo::hasEnoughSpaceFor(assetSize, available), enough);
+}
+
+void UpdateInfoTest::dedupedFileName_data()
+{
+    QTest::addColumn<QString>("input");
+    QTest::addColumn<int>("index");
+    QTest::addColumn<QString>("expected");
+
+    // The real asset name is dot-heavy (v0.2.3). completeBaseName/suffix split
+    // on the LAST dot, so the version must survive intact and only the true
+    // extension moves — this is the case a naive split('.') gets wrong.
+    QTest::newRow("real dmg")
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg" << 1
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64 (1).dmg";
+    QTest::newRow("real AppImage")
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage" << 2
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64 (2).AppImage";
+    QTest::newRow("no extension") << "LogosBasecamp" << 1 << "LogosBasecamp (1)";
+    QTest::newRow("index 50")     << "a.dmg" << 50 << "a (50).dmg";
+    // Degenerate input must not produce " (1)" with an empty stem.
+    QTest::newRow("empty")        << "" << 1 << "";
+}
+
+void UpdateInfoTest::dedupedFileName()
+{
+    QFETCH(QString, input);
+    QFETCH(int, index);
+    QFETCH(QString, expected);
+    QCOMPARE(UpdateInfo::dedupedFileName(input, index), expected);
+}
+
+// ── security regressions ────────────────────────────────────────────────────
+//
+// Both cases below were found by the /ship security review and are real: the
+// asset name and the asset URL both arrive from the network, and both were
+// reaching the filesystem / the socket with only partial validation.
+
+void UpdateInfoTest::isSafeAssetFileName_data()
+{
+    QTest::addColumn<QString>("name");
+    QTest::addColumn<bool>("safe");
+
+    QTest::newRow("real dmg")
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-aarch64.dmg" << true;
+    QTest::newRow("real AppImage")
+        << "LogosBasecamp-Desktop-v0.2.3-aa2377-x86_64.AppImage" << true;
+
+    // The exploit shape: satisfies selectAssetName's prefix AND suffix checks,
+    // and QDir::filePath is a plain join — so this escapes ~/Downloads, and on
+    // Linux the result would then be chmod +x'd.
+    QTest::newRow("traversal")
+        << "LogosBasecamp-Desktop-v9.9.9/../../../../tmp/pwn-aarch64.dmg" << false;
+    QTest::newRow("absolute path")
+        << "/etc/cron.d/pwn-aarch64.dmg" << false;
+    QTest::newRow("backslash")
+        << "LogosBasecamp-Desktop-v9.9.9\\..\\pwn-aarch64.dmg" << false;
+    QTest::newRow("bare dotdot")   << ".." << false;
+    QTest::newRow("dotfile")       << ".bashrc" << false;
+    // QFile::encodeName truncates at NUL, so the path QFile opens would differ
+    // from the one handed to setxattr.
+    QTest::newRow("embedded NUL")
+        << QString("LogosBasecamp-Desktop-v1") + QChar(QChar::Null) + QString("-aarch64.dmg")
+        << false;
+    QTest::newRow("newline")
+        << "LogosBasecamp-Desktop-v1\n-aarch64.dmg" << false;
+    QTest::newRow("empty")         << "" << false;
+    QTest::newRow("overlong")      << QString(300, QLatin1Char('a')) << false;
+}
+
+void UpdateInfoTest::isSafeAssetFileName()
+{
+    QFETCH(QString, name);
+    QFETCH(bool, safe);
+    QCOMPARE(UpdateInfo::isSafeAssetFileName(name), safe);
+}
+
+void UpdateInfoTest::selectAssetName_rejectsPathTraversalDespiteMatchingPrefixAndSuffix()
+{
+    // Pin the ACTUAL regression, not just the helper: a traversal name that
+    // passes both the prefix and suffix checks must still not be selected.
+    Asset evil;
+    evil.name  = QStringLiteral("LogosBasecamp-Desktop-v9.9.9/../../../../tmp/pwn-aarch64.dmg");
+    evil.url   = QStringLiteral("https://github.com/logos-co/logos-basecamp/releases/download/x/e");
+    evil.size  = 10;
+    evil.state = QStringLiteral("uploaded");
+
+    QVERIFY2(evil.name.startsWith(QStringLiteral("LogosBasecamp-Desktop-v")),
+             "fixture must satisfy the prefix check, or it proves nothing");
+    QVERIFY2(evil.name.endsWith(QStringLiteral("-aarch64.dmg")),
+             "fixture must satisfy the suffix check, or it proves nothing");
+
+    QCOMPARE(selectAssetName({evil}, QStringLiteral("macos"), QStringLiteral("arm64")),
+             QString());
+}
+
+void UpdateInfoTest::isAllowedDownloadHost_rejectsArbitraryS3Buckets()
+{
+    // S3 bucket names are self-service, so a bare "*.s3.amazonaws.com" would let
+    // anyone stand up a host that satisfies the only gate in front of a 271 MB
+    // executable. Only GitHub's release-asset bucket family is accepted.
+    QVERIFY(UpdateInfo::isAllowedDownloadHost(
+        QStringLiteral("github-production-release-asset-2e65be.s3.amazonaws.com")));
+    QVERIFY(!UpdateInfo::isAllowedDownloadHost(QStringLiteral("attacker.s3.amazonaws.com")));
+    QVERIFY(!UpdateInfo::isAllowedDownloadHost(QStringLiteral("s3.amazonaws.com")));
+}
+
+void UpdateInfoTest::shouldSkipCheck_data()
+{
+    QTest::addColumn<bool>("disabled");
+    QTest::addColumn<QString>("version");
+    QTest::addColumn<bool>("forced");
+    QTest::addColumn<bool>("portable");
+    QTest::addColumn<bool>("skip");
+
+    QTest::newRow("released portable build")  << false << "0.2.1" << false << true  << false;
+    // A dev nix build has no AppImage/DMG to replace.
+    QTest::newRow("released non-portable")    << false << "0.2.1" << false << false << true;
+    // The rule the UI tests depend on: forcing a version waives portable-build.
+    QTest::newRow("override waives portable") << false << "0.0.1" << true  << false << false;
+    // Master CI builds are stamped pre-release-<sha7>; nothing to compare.
+    QTest::newRow("dev version skips")        << false << "pre-release-aa23776" << false << true << true;
+    QTest::newRow("empty version skips")      << false << "" << false << true << true;
+    // Kill switch beats everything, including an explicit override.
+    QTest::newRow("kill switch wins")         << true  << "0.2.1" << true  << true  << true;
+}
+
+void UpdateInfoTest::shouldSkipCheck()
+{
+    QFETCH(bool, disabled);
+    QFETCH(QString, version);
+    QFETCH(bool, forced);
+    QFETCH(bool, portable);
+    QFETCH(bool, skip);
+    QCOMPARE(UpdateInfo::shouldSkipCheck(disabled, version, forced, portable), skip);
+}
+
+void UpdateInfoTest::downloadFraction_data()
+{
+    QTest::addColumn<qint64>("received");
+    QTest::addColumn<qint64>("total");
+    QTest::addColumn<qint64>("assetSize");
+    QTest::addColumn<qreal>("expected");
+
+    const qint64 t = Q_INT64_C(271104520);
+
+    QTest::newRow("half")            << t / 2 << t << t << 0.5;
+    QTest::newRow("start")           << Q_INT64_C(0) << t << t << 0.0;
+    QTest::newRow("complete")        << t << t << t << 1.0;
+    // Must agree with progressText's clamp: a bar past 1.0 next to a "100%"
+    // label is the disagreement a user actually sees.
+    QTest::newRow("overshoot clamps")<< t * 2 << t << t << 1.0;
+    // No Content-Length: fall back to the size the release API published.
+    QTest::newRow("falls back to asset size") << t / 2 << Q_INT64_C(-1) << t << 0.5;
+    // Nothing to divide by -> indeterminate, not a division by zero.
+    QTest::newRow("indeterminate")   << Q_INT64_C(10) << Q_INT64_C(0) << Q_INT64_C(0) << -1.0;
+}
+
+void UpdateInfoTest::downloadFraction()
+{
+    QFETCH(qint64, received);
+    QFETCH(qint64, total);
+    QFETCH(qint64, assetSize);
+    QFETCH(qreal, expected);
+    QCOMPARE(UpdateInfo::downloadFraction(received, total, assetSize), expected);
+}
+
+QTEST_GUILESS_MAIN(UpdateInfoTest)
+#include "update_info_test.moc"


### PR DESCRIPTION
## Summary

Basecamp had no way to tell you it was out of date. This adds a passive version check against the GitHub releases API and, when a newer stable release exists, an in-app notice plus an optional download of the matching platform artifact.

It implements tiers **(a) notice** and **(b) download-and-prompt** from #319. It does **not** self-install — no relaunch, no `execve`, no writing into the app bundle. That's tier (c), and it wants the DMG signing work in #27 first.

Basecamp's package manager already solves this for *modules* (`AppsModel::recomputeInstallStatus` → an "Update" `LogosBadge`). The host app was the one piece of the stack with zero staleness signal, which is how a user ended up on 0.2.1 with a stale bundled `delivery_module` and spent real time debugging what looked like a product bug.

**Structure** — `UpdateChecker` is a fourth child of `MainUIBackend`, deliberately outside the CoreModuleManager/UIPluginManager/PackageCoordinator triangle: it touches no `logos_core_*` C API and no `package_manager` IPC. The decision logic lives in a header-only `UpdateInfo.h` rather than in the I/O shell, because `tests/CMakeLists.txt` links no `Qt6::Network` and doesn't include `app/utils` — anything touching `QNetworkAccessManager` or `BuildInfo.h` is structurally untestable. Keeping the rules pure buys 158 unit cases over the parts that decide *what* to download.

Four commits, each independently buildable: backend, UI, tests, docs.

<details>
<summary><b>Three details that are load-bearing</b></summary>

1. **The eligibility gate uses `semver::valid()`, not `compare()`.** `compare()` sorts unparseable versions *below* every real one, so without the gate every dev build (stamped `pre-release-<sha7>`) would be told it was out of date. There's a test that pins exactly this.
2. **`QSysInfo::currentCpuArchitecture()` returns `arm64`; the release assets are named `-aarch64`.** That mismatch is the single most likely way this ships silently doing nothing on every Mac and every ARM Linux box.
3. **`/releases/latest` is ordered by creation date, not semver precedence.** A hotfix cut from an old branch can legitimately be "latest", so the comparison requires a strict `>` and never offers a downgrade.

</details>

## Linked issues

Closes #319

## Screenshots / recordings

All captured on macOS with `LOGOS_UPDATE_CURRENT_VERSION=0.2.1` to force a stale version against the live 0.2.3 release.

**Before** — `master` at 484da77. Dashboard goes straight from Version to Commits; no badge in the sidebar, no marker on Settings.

![Before](https://raw.githubusercontent.com/danisharora099/logos-basecamp/assets/pr-in-app-update/before-dashboard.png)

**After** — an Updates card between the build summary and Commits, an `UPDATE` badge under the sidebar version, and a marker on the Settings button so the badge is discoverable without opening anything.

![After](https://raw.githubusercontent.com/danisharora099/logos-basecamp/assets/pr-in-app-update/after-1-update-available.png)

<details>
<summary><b>Download states (click to expand)</b></summary>

**Downloading** — real transfer of the published 98.7 MB DMG, with cancel.

![Downloading](https://raw.githubusercontent.com/danisharora099/logos-basecamp/assets/pr-in-app-update/after-2-downloading.png)

**Done** — resolved path, platform-correct instructions, and Show in Finder. The instructions lead with "Quit Basecamp" because replacing a running `.app` is what produces "the application is damaged" reports.

![Done](https://raw.githubusercontent.com/danisharora099/logos-basecamp/assets/pr-in-app-update/after-3-done.png)

</details>

The section renders nothing at all on builds that report `Skipped` (dev / pre-release / non-nix), so this is invisible during normal local development.

## Test plan

- [x] `nix build .#app` succeeds
- [x] `nix build .#smoke-test -L` passes
- [x] `nix build .#integration-test -L` passes — 18/18, now including the two new update tests
- [ ] Doctests — not touched
- [x] Manual verification on:
  - [ ] Linux (AppImage) — **not verified, see below**
  - [x] Linux (Nix local build) — unit/qml/sandbox suites
  - [x] macOS
- [ ] N/A

Also run: `.#unit-tests` 10/10 (158 update cases), `.#shutdown-test` 3 passed / 0 failed, `.#qml-tests`, `.#sandbox-test`.

Verified by hand end to end: a real 98.7 MB download completing byte-exact against the published size, cancel mid-flight leaving no `.part`, the `com.apple.quarantine` xattr set with `spctl` reporting `accepted / source=Notarized Developer ID`, the already-downloaded short-circuit, the kill switch, and the dev-build skip.

**One gap I can't close from this machine:** the Linux AppImage. It can't be built from an aarch64-darwin host without a remote builder, and it's where the only real unknown lives — this is the first code in a shipped bundle that ever loads a Qt TLS backend. I verified the macOS half: `nix build .#bin-macos-app` carries all three Qt TLS plugins and `libqopensslbackend.dylib` resolves `libssl.3`/`libcrypto.3` via `@loader_path` into `Contents/Frameworks/`. Qt ignores `SSL_CERT_FILE` and scans its own hardcoded CA directory list, which covers mainstream distros, but someone with a Linux builder should confirm on a real AppImage. A TLS failure degrades to "couldn't check" — never to a false "up to date".

## Release notes

feat: notify when a newer Basecamp release is available, with optional in-app download

## Checklist

- [x] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [x] No unrelated changes bundled in
- [x] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed — README documents the notice and the opt-out
- [x] Uncommitted binaries, screenshots, or `.DS_Store` files removed — screenshots are hosted on a separate branch, nothing binary is in this diff

## Notes for reviewers

- **No VERSION bump or CHANGELOG entry, deliberately.** `flake.nix:58-66` documents that `VERSION` exists only on `release/**` branches and master builds fall back to `pre-release-<sha7>`; there's no `CHANGELOG.md`. Adding a VERSION file here would make every master build report itself as a release — which, given this feature, would turn the update checker **on** for master builds and tell every developer they're out of date.
- **This is the app's first outbound network request.** One unauthenticated `GET` to `api.github.com`, no identifiers beyond a `LogosBasecamp/<version>` user agent, and no `Authorization` header (Qt copies headers verbatim across redirects, so one would leak to the CDN). `LOGOS_DISABLE_UPDATE_CHECK=1` turns it off. It makes no request at all on dev builds.
- **The size check is a corruption detector, not an integrity control.** No `.sha256` is published, so TLS to an allowlisted host is the real guarantee. Both the initial asset URL and every redirect hop are host-allowlisted, and the asset filename is validated as a bare filename before it becomes a path. Publishing a signed digest from Jenkins is the natural follow-up — the `Verifying` stage is already reserved for it.
- **`nix/integration-test.nix` pins the check at a `file://` stub** rather than setting `LOGOS_DISABLE_UPDATE_CHECK`. That derivation is the only automated runner of `ui-tests.mjs`, and the tests self-skip on the kill switch — disabling would have meant CI printed a green skip forever. `smoke-test` and `shutdown-test` keep the kill switch, since they assert startup and teardown rather than update behaviour.
- **Known follow-ups, none blocking:** DRY up the repeated blocks in `DashboardView.qml`; namespace the five unprefixed `download*` properties on the facade (they read as package-download state, which `PackageCoordinator` also owns); split the NOTIFY so progress ticks don't re-evaluate four constant bindings; confirm the `com.apple.quarantine` flag word empirically; disk writes currently happen on the GUI thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
