### PR TITLE
feat(ci): change s3 storage from DO to Hetzner

### DIFF
--- a/ci/combined.Jenkinsfile
+++ b/ci/combined.Jenkinsfile
@@ -1,5 +1,5 @@
 #!/usr/bin/env groovy
-library 'status-jenkins-lib@v1.9.47'
+library 'status-jenkins-lib@v1.9.48'
 
 urls = [:]
 

--- a/ci/linux.Jenkinsfile
+++ b/ci/linux.Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.47'
+library 'status-jenkins-lib@v1.9.48'
 
 def isPRBuild = utils.isPRBuild()
 

--- a/ci/macos.Jenkinsfile
+++ b/ci/macos.Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-library 'status-jenkins-lib@v1.9.47'
+library 'status-jenkins-lib@v1.9.48'
 
 def isPRBuild = utils.isPRBuild()
 


### PR DESCRIPTION
Updated version of status-jenkins-lib which uses Hetzner object storage instead of Digital Ocean object storage. Part of the migration of CI infra to Hetzner.

Referenced issue:
* https://github.com/status-im/infra-ci/issues/282