### PR TITLE
ci: take Nix and the Attic cache from setup-nix-cache-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,18 @@ on:
   pull_request:
     branches: [master]
 
-env:
-  ATTIC_CACHE: ${{ github.ref == 'refs/heads/master' && 'public' || 'ci' }}
-  # Empty on fork PRs (secrets not available) — Attic steps skip via the if below.
-  ATTIC_ENDPOINT: ${{ secrets.ATTIC_ENDPOINT }}
+# Nix and the Logos cache come from logos-co/setup-nix-cache-action, which owns
+# the installer, the substituters, the trusted keys, which cache is written
+# (public on master/main, ci elsewhere) and the push itself. This file used to
+# own all of that four times over.
+#
+# The ATTIC_CACHE / ATTIC_ENDPOINT env pair that lived here is gone: the first is
+# the shared action's decision, and the second existed only to feed `if:` guards
+# that skipped the push on fork PRs. The shared action needs no guard -- with no
+# token it configures the substituters anyway and skips the push, which is the
+# behaviour those guards were approximating. The repo's ATTIC_ENDPOINT secret is
+# consequently unused here; the action's default endpoint is the same host this
+# file already pointed at.
 
 jobs:
   build-appimage:
@@ -28,21 +36,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v27
+      - uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
-            fallback = true
-
-      - uses: ryanccn/attic-action@v0.4.1
-        if: ${{ env.ATTIC_ENDPOINT != '' }}
-        with:
-          endpoint: ${{ env.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          inputs-from: "."
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Build bin-appimage
         run: nix build .#bin-appimage
@@ -71,20 +68,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra-conf: |
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
-            fallback = true
-
-      - uses: ryanccn/attic-action@v0.4.1
-        if: ${{ env.ATTIC_ENDPOINT != '' }}
-        with:
-          endpoint: ${{ env.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          inputs-from: "."
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Build bin-macos-app
         run: nix build .#bin-macos-app
@@ -118,21 +105,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: cachix/install-nix-action@v27
+      - uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra_nix_config: |
-            experimental-features = nix-command flakes
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
-            fallback = true
-
-      - uses: ryanccn/attic-action@v0.4.1
-        if: ${{ env.ATTIC_ENDPOINT != '' }}
-        with:
-          endpoint: ${{ env.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          inputs-from: "."
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Unit tests
         run: nix build .#unit-tests -L
@@ -173,20 +149,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: logos-co/setup-nix-cache-action@v1
         with:
-          extra-conf: |
-            extra-substituters = https://cache.nix.logos.co/public
-            extra-trusted-public-keys = public:Z1wyVBEx8PHbXujYB52Mysv9Rd8rWIhyQ3bQyef9yy4=
-            fallback = true
-
-      - uses: ryanccn/attic-action@v0.4.1
-        if: ${{ env.ATTIC_ENDPOINT != '' }}
-        with:
-          endpoint: ${{ env.ATTIC_ENDPOINT }}
-          cache: ${{ env.ATTIC_CACHE }}
-          inputs-from: "."
-          token: ${{ github.ref == 'refs/heads/master' && secrets.ATTIC_TOKEN_PUBLIC || secrets.ATTIC_TOKEN_CI }}
+          attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
+          attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
       - name: Unit tests
         run: nix build .#unit-tests -L


### PR DESCRIPTION
`build.yml` owned its own Nix installer, substituter list, trusted keys, cache
selection and push — **four times over, in two different spellings**. All of it
now comes from `logos-co/setup-nix-cache-action@v1`. 237 → 203 lines; four
(installer + attic-action) pairs collapse to four one-step uses. Every job keeps
its build and test steps unchanged — only the preamble moved.

## What this fixes beyond the duplication

**The signing key.** This was the only repo in the fleet trusting
`public:Z1wyVBEx…`; the shared action configures `public:l4HrXgL4…` for the same
cache name. I could not determine from outside which is current — a narinfo's
`Sig:` names the key `public` but not its value, and two attempts to
discriminate by verifying a copy failed on incomplete closures rather than on
signatures. **Two answers to that question was the actual problem; there is now
one.**

**Nix version.** Two jobs ran `cachix/install-nix-action@v27` — Nix 2.22, below
the 2.26 floor where `--override-input` keeps the overridden input's own lock.
The other two ran `DeterminateSystems/nix-installer-action@main`, an **unpinned
ref on a release-producing workflow**. The shared action pins
`install-nix-action@v31` (`nix_version=2.35.1`).

**It now reads the `ci` cache.** Every block configured only
`cache.nix.logos.co/public` as a substituter while pushing to `ci` on branches —
so a branch build could not reuse what any earlier branch build had pushed. The
shared action configures both. That matters more than it used to: the mingw Qt
closure was primed into `ci` this week.

## One deliberate regression, stated rather than buried

The old steps passed `inputs-from: "."` to attic-action, which also pushes the
flake inputs' store paths. `setup-nix-cache-action` does not expose that input,
so slightly less is pushed per run. Reading the `ci` cache should more than
compensate on branches, but it is a real difference, and **the right fix is an
`inputs-from` passthrough in the shared action** rather than keeping a second
implementation here.

## Guards dropped with the env block they read

`if: env.ATTIC_ENDPOINT != ''` existed to skip the push on fork PRs where secrets
are absent. The shared action needs no guard: with no token it configures the
substituters and skips the push, which is what those guards approximated. This
repo's `ATTIC_ENDPOINT` secret is consequently unused here, and the action's
default endpoint is the same host this file already named.

## Not verified

**This has not run.** It touches the release path, which is exactly why it is a
PR rather than a direct push — let CI exercise all four jobs before merge.
`actionlint` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)