### PR TITLE
fix(shared-runtime): empty the archives on every platform, and gate it

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -221,11 +221,18 @@ if(DEFINED LOGOS_CPP_SDK_ROOT)
             "logos-qt-host::logos_qt_host. LOGOS_QT_HOST_ROOT="
             "${LOGOS_QT_HOST_ROOT}")
     endif()
-    # Windows: the host is the image that WRITES the capability token, so if it
-    # keeps a static copy of TokenManager the plugin never sees the token no
-    # matter what the plugin links. Empty out the archives here too and let
-    # liblogos_core.dll be the one provider — cmake/LogosSharedFromDll.cmake.
-    # The link interface above is deliberately left intact.
+    # The host is the image that WRITES the capability token, so if it keeps a
+    # static copy of TokenManager the plugin never sees the token no matter what
+    # the plugin links. Empty out the archives and let liblogos_core be the one
+    # provider — cmake/LogosSharedFromDll.cmake. The link interface above is
+    # deliberately left intact.
+    #
+    # This runs on EVERY platform, not just Windows. Mach-O's two-level
+    # namespace gives no interposition either: the main_ui fold measured ONE
+    # reference to LogosAPI::forIdentity dragging logos_api.cpp.o into the exe
+    # and producing 31 refusals against a pre-fold baseline of 0. ELF does
+    # collapse duplicates, but we empty it there too so the invariant is one
+    # rule everywhere and nix/symbol-gate can assert it uniformly.
     #
     # Retargeted from logos-qt-sdk::logos_qt_sdk to logos-qt-host::logos_qt_host
     # by the B4 host split: the archive that carries LogosAPI/TokenManager moved

--- a/cmake/LogosSharedFromDll.cmake
+++ b/cmake/LogosSharedFromDll.cmake
@@ -1,25 +1,44 @@
-# Windows: take the shared C++ runtime from liblogos_core.dll, not from the
-# static archives.
+# Take the shared C++ runtime from liblogos_core, not from the static archives.
 #
-# LogosBasecamp.exe and main_ui.dll run in ONE process, and both link
-# liblogos_qt_sdk.a / liblogos_protocol.a. On ELF and Mach-O that is harmless:
-# liblogos_core exports the symbols and the loader interposes them, so there is
-# one LogosAPI, one TokenManager, one of everything. PE has no interposition, so
-# each image binds its own static copy and gets its own function-local statics.
-# The visible symptom was 29 "ModuleProxy: rejecting unauthorized call" lines and
-# no package_manager_ui in the sidebar: the host wrote the capability token into
-# its TokenManager and the plugin read a different, empty one.
+# LogosBasecamp and every plugin it loads in-process share ONE process, and all
+# of them link liblogos_qt_host.a / liblogos_protocol.a. Each image that links
+# an archive gets its own copy of the code in it, and therefore its own copy of
+# every function-local static inside it: TokenManager::instance, the per-identity
+# StoreRegistry, the host-services grant, the deferred event-subscription
+# registry. The host writes a capability token into its copy, another image reads
+# its own empty one, and every cross-module call is refused at runtime -- with no
+# build diagnostic anywhere.
 #
-# liblogos_core.dll now exports those symbols explicitly (see
-# logos-liblogos/src/CMakeLists.txt) and the consumers declare them
-# __declspec(dllimport) via LOGOS_SHARED_USE_DLL. That alone is NOT enough,
-# because ld picks archive members by object file for reasons that have nothing
-# to do with our symbols: measured here, main_ui's AppsModel.cpp.obj referenced
-# std::string's move constructor, ld satisfied it out of liblogos_qt_sdk.a's
-# logos_api.cpp.obj, and that one object dragged in LogosAPI, LogosAPIClient and
-# TokenManager behind it -- each then colliding with the DLL's export
-# ("multiple definition of `LogosAPI::LogosAPI'"). No export list can prevent
-# that; the archive simply must not be a candidate.
+# THIS IS NOT A WINDOWS-ONLY PROBLEM. An earlier version of this file asserted
+# "ELF and Mach-O already resolve to the one provider, and there is nothing to
+# fix" and returned early off Windows. That claim is false for Mach-O and was
+# falsified by measurement:
+#
+#   * PE   -- no interposition at all. A second archive is always a second
+#             singleton. Symptom measured here: 29 "ModuleProxy: rejecting
+#             unauthorized call" lines and no package_manager_ui in the sidebar.
+#   * Mach-O -- two-level namespace, so it behaves like PE, not like ELF. It
+#             appears to work only while the consumer image has NO definition of
+#             its own, so ld binds the undefined symbol to liblogos_core.dylib.
+#             The moment any reference drags an archive member in, that image
+#             gets its own copy silently. Measured when main_ui was folded into
+#             the executable: ONE reference to LogosAPI::forIdentity pulled
+#             logos_api.cpp.o and token_manager.cpp.o into the exe, which then
+#             defined nine runtime entry points liblogos_core.dylib did not
+#             export, and the app produced 31 refusals against a pre-fold
+#             baseline of 0.
+#   * ELF  -- flat namespace, first definition wins process-wide, so it really
+#             does collapse. We empty the archives here anyway, so the invariant
+#             is ONE rule on three platforms rather than three rules -- and so
+#             the symbol gate can assert the same thing everywhere.
+#
+# Declaring the symbols __declspec(dllimport) (LOGOS_SHARED_USE_DLL, Windows
+# only) is NOT sufficient on its own, because ld picks archive members by object
+# file for reasons that have nothing to do with our symbols: measured here,
+# main_ui's AppsModel.cpp.obj referenced std::string's move constructor, ld
+# satisfied it out of liblogos_qt_sdk.a's logos_api.cpp.obj, and that one object
+# dragged in LogosAPI, LogosAPIClient and TokenManager behind it. No export list
+# can prevent that; the archive simply must not be a candidate.
 #
 # So the archives are replaced by an EMPTY one. Everything else the imported
 # targets carry -- include directories, Qt/OpenSSL/Boost/nlohmann link
@@ -27,14 +46,12 @@
 # repointing IMPORTED_LOCATION rather than by dropping the
 # target_link_libraries() call and re-listing the usage requirements by hand.
 #
-# Off Windows this file is never included: ELF/Mach-O already resolve to the one
-# provider, and there is nothing to fix.
+# Once a consumer has no archive to fall back on, anything liblogos_core failed
+# to include becomes an UNDEFINED REFERENCE at link time. That is the intended
+# trade: a loud link error instead of a silent split-brain. The provider side
+# guarantees the coverage -- see logos-liblogos/src/CMakeLists.txt.
 
 function(logos_use_shared_runtime_from_dll)
-    if(NOT WIN32)
-        return()
-    endif()
-
     # One empty archive per build tree, shared by every target that needs it.
     set(_stub "${CMAKE_BINARY_DIR}/logos_shared_from_dll_stub.a")
     if(NOT EXISTS "${_stub}")
@@ -45,7 +62,7 @@ function(logos_use_shared_runtime_from_dll)
         if(NOT _ar_rc EQUAL 0 OR NOT EXISTS "${_stub}")
             message(FATAL_ERROR
                 "Could not create the empty archive that stands in for the "
-                "logos static libraries on Windows: ${_ar_err}")
+                "logos static libraries: ${_ar_err}")
         endif()
     endif()
 
@@ -55,9 +72,9 @@ function(logos_use_shared_runtime_from_dll)
                 "logos_use_shared_runtime_from_dll: ${_tgt} is not a target. It must be "
                 "an IMPORTED target whose archive can be replaced by the empty stand-in; "
                 "skipping it would leave a static copy of the shared runtime in this "
-                "image alongside liblogos_core.dll's exported one.")
+                "image alongside liblogos_core's exported one.")
         endif()
         set_target_properties(${_tgt} PROPERTIES IMPORTED_LOCATION "${_stub}")
-        message(STATUS "Windows: ${_tgt} provided by liblogos_core.dll, static archive suppressed")
+        message(STATUS "${_tgt} provided by liblogos_core, static archive suppressed")
     endforeach()
 endfunction()

--- a/flake.nix
+++ b/flake.nix
@@ -535,6 +535,23 @@
           # Smoke test (also exposed as a package so it can be built standalone)
           smoke-test = import ./nix/smoke-test.nix { inherit pkgs; appPkg = app; };
 
+          # One-runtime symbol gate. Asserts the logos C++ runtime (TokenManager,
+          # StoreRegistry, LogosAPI, LogosAPIClient) is DEFINED exactly once across
+          # the images that share one process — in liblogos_core, the single
+          # provider. A second definition is a second TokenManager and every
+          # cross-module call is refused at runtime with no build diagnostic.
+          # Build: nix build .#symbol-gate
+          symbol-gate = import ./nix/symbol-gate.nix { inherit pkgs; appPkg = app; };
+
+          # Negative control for the above. Plants a REAL duplicate runtime where
+          # an in-process consumer goes and asserts the gate REJECTS it. Ship both
+          # or neither: an absence assertion that has never been seen to fail is
+          # indistinguishable from a broken one.
+          # Build: nix build .#symbol-gate-negative
+          symbol-gate-negative = import ./nix/symbol-gate.nix {
+            inherit pkgs; appPkg = app; negativeControl = true;
+          };
+
           # ui_qml sandbox-escape regression test (F-008). Focused C++ unit test:
           # builds a real malicious QML plugin and asserts the production sandbox
           # refuses to load it. Build: nix build .#sandbox-test
@@ -631,6 +648,8 @@
         integration-test = self.packages.${system}.integration-test;
         shutdown-test = self.packages.${system}.shutdown-test;
         host-services-test = self.packages.${system}.host-services-test;
+        symbol-gate = self.packages.${system}.symbol-gate;
+        symbol-gate-negative = self.packages.${system}.symbol-gate-negative;
       });
 
       devShells = forAllSystems ({ pkgs, logosSdk, logosProtocolPkg, logosQtHost, logosModule, logosLiblogos, logosPackageManagerLibrary, logosPackageManagerModule, logosCapabilityModule, logosPackageLib, logosDesignSystem, logosCppSdkSrc, logosLiblogosSrc, logosPackageManagerModuleSrc, logosCapabilityModuleSrc, ... }: {

--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -1,0 +1,167 @@
+# The one-runtime symbol gate.
+#
+# INVARIANT: across the images that share ONE process, the logos C++ runtime is
+# DEFINED exactly once — in liblogos_core, the single provider. A second
+# definition is a second TokenManager: the host writes a capability token into
+# one store, another image reads an empty one, and every cross-module call is
+# refused at runtime with NO build diagnostic. See
+# logos-protocol/cpp/logos_shared_api.h and cmake/LogosSharedFromDll.cmake.
+#
+# This gate exists because nothing else in the tree measured it. The main_ui
+# fold shipped an executable that defined nine runtime entry points
+# liblogos_core.dylib did not export, and it was caught by hand, after the fact,
+# from 31 "ModuleProxy: rejecting unauthorized call" lines at runtime.
+#
+# THE IN-PROCESS IMAGE SET — this scoping IS the correctness of the gate:
+#   IN   bin/LogosBasecamp                the app
+#   IN   lib/liblogos_core.*              the single provider
+#   IN   plugins/*/*_replica_factory.*    QPluginLoader'd by LogosQmlBridge
+#   IN   plugins/main_ui/main_ui.*        QPluginLoader'd by Window, when split out
+#   OUT  bin/logos_host, bin/ui-host      SEPARATE PROCESSES; they correctly keep
+#                                         their own statics
+#   OUT  plugins/*/*_plugin.*             a ui_qml backend is loaded by ui-host,
+#                                         not by the app
+#   OUT  modules/**                       loaded by logos_host
+#
+# negativeControl = true builds the same script against a tree with a REAL
+# duplicate planted where a consumer goes, and asserts the gate REJECTS it.
+# Without that, an absence assertion is indistinguishable from a broken one.
+{ pkgs, appPkg, negativeControl ? false }:
+
+let
+  isDarwin = pkgs.stdenv.isDarwin;
+  # Mach-O: -gU is defined externals. ELF: -D --defined-only. mingw nm reads PE.
+  definedCmd = if isDarwin then "nm -gU" else "nm -D --defined-only";
+  # A count over a tool that read nothing is not evidence of absence. The same
+  # defence is written at nix/app.nix:382.
+  totalCmd   = if isDarwin then "nm -a" else "nm -D";
+in
+pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeControl "-negative"}" {
+  nativeBuildInputs = [ pkgs.coreutils pkgs.findutils pkgs.gnugrep pkgs.gnused ]
+    ++ [ pkgs.stdenv.cc.bintools ];
+} ''
+  set -uo pipefail
+
+  # TIER 1 — the split-brain itself. No allowance, ever.
+  TIER1_RE='^(TokenManager|StoreRegistry)::|^(vtable|typeinfo|typeinfo name|guard variable) for (TokenManager|StoreRegistry)\b'
+  # TIER 2 — LogosAPI/LogosAPIClient. Zero since the single-provider shim was
+  # extended to every platform; it was 26 on aarch64-darwin before that
+  # (LogosAPI duplicated in the exe while TokenManager was not — benign only
+  # because LogosAPI's ctor caches &TokenManager::instance(), which bound to the
+  # provider). Never raise this.
+  TIER2_RE='^(LogosAPI|LogosAPIClient)::|^(vtable|typeinfo|typeinfo name|guard variable) for (LogosAPI|LogosAPIClient)\b'
+  TIER2_ALLOW=0
+
+  FAIL=0
+  note() { printf '  %-56s %s\n' "$1" "$2"; }
+  bad()  { FAIL=1; printf '  %-56s %s\n' "$1" "$2"; }
+
+  # A dev build installs bin/<name> as a shell wrapper that execs bin/.<name>
+  # (nix/app.nix's QT_PLUGIN_PATH wrapper). Measuring the wrapper reads ZERO
+  # symbols and makes every assertion below vacuously true.
+  resolve_image() {
+    local f="$1" d b real
+    d=$(dirname "$f"); b=$(basename "$f")
+    if head -c2 "$f" 2>/dev/null | grep -q '#!'; then
+      real=$(sed -nE 's/^exec "\$BINDIR\/([^"]+)".*/\1/p' "$f" | tail -1)
+      [ -n "$real" ] && [ -e "$d/$real" ] && { printf '%s\n' "$d/$real"; return; }
+      [ -e "$d/.$b" ] && { printf '%s\n' "$d/.$b"; return; }
+    fi
+    printf '%s\n' "$f"
+  }
+  names() { ${definedCmd} "$1" 2>/dev/null | c++filt 2>/dev/null | sed -E 's/^[0-9a-fA-F]+ [A-Za-z] //'; }
+  valid() {
+    local t; t=$(${totalCmd} "$1" 2>/dev/null | wc -l | tr -d ' ')
+    [ "''${t:-0}" -gt 0 ] || { bad "$(basename "$1")" "ERROR: nm read 0 symbols — vacuous"; return 1; }
+  }
+
+  ROOT=$TMPDIR/bundle
+  mkdir -p "$ROOT"
+  cp -R ${appPkg}/. "$ROOT"/ 2>/dev/null || true
+  chmod -R u+w "$ROOT"
+
+  PROVIDER=""
+  for c in "$ROOT/lib/liblogos_core.dylib" "$ROOT/lib/liblogos_core.so" "$ROOT/bin/liblogos_core.dll"; do
+    [ -e "$c" ] && PROVIDER="$c" && break
+  done
+  [ -n "$PROVIDER" ] || { echo "FATAL: no liblogos_core under the bundle"; exit 1; }
+
+  ${pkgs.lib.optionalString negativeControl ''
+    # Plant a REAL second copy of the runtime where an in-process consumer goes.
+    mkdir -p "$ROOT/plugins/negative_control"
+    cp "$PROVIDER" "$ROOT/plugins/negative_control/main_ui''${PROVIDER##*liblogos_core}"
+    echo "NEGATIVE CONTROL: planted a duplicate runtime; the gate MUST reject this tree."
+  ''}
+
+  CONSUMERS=()
+  for e in "$ROOT/bin/LogosBasecamp" "$ROOT/bin/LogosBasecamp.exe"; do
+    [ -e "$e" ] && CONSUMERS+=("$(resolve_image "$e")")
+  done
+  while IFS= read -r p; do [ -n "$p" ] && CONSUMERS+=("$(resolve_image "$p")"); done < <(
+    find "$ROOT/plugins" -type f \( -name '*_replica_factory.*' -o -name 'main_ui.*' \) 2>/dev/null \
+      | grep -Ev '\.(txt|json)$' || true)
+
+  echo "provider  = ''${PROVIDER#$ROOT/}"
+  printf 'consumers = '; for c in "''${CONSUMERS[@]}"; do printf '%s ' "''${c#$ROOT/}"; done; echo
+
+  # Positive control AND demangler validity check in one: if c++filt were absent
+  # or broken this reports 0 and the gate fails, rather than passing vacuously.
+  echo
+  echo "== the provider DEFINES the runtime (expect >=1) =="
+  valid "$PROVIDER" || exit 1
+  n=$(names "$PROVIDER" | grep -Ec 'TokenManager::instance' || true)
+  if [ "$n" -ge 1 ]; then note "liblogos_core  TokenManager::instance" "$n  OK"
+  else bad "liblogos_core  TokenManager::instance" "$n  EXPECTED >=1 (or demangling is broken)"; fi
+
+  echo
+  echo "== TIER 1: no in-process consumer defines TokenManager/StoreRegistry (expect 0) =="
+  for img in "''${CONSUMERS[@]}"; do
+    valid "$img" || continue
+    n=$(names "$img" | grep -Ec "$TIER1_RE" || true)
+    if [ "$n" -eq 0 ]; then note "$(basename "$img")" "0  OK"
+    else bad "$(basename "$img")" "$n  SPLIT-BRAIN"; names "$img" | grep -E "$TIER1_RE" | sed 's/^/      /' | head -6; fi
+  done
+
+  echo
+  echo "== TIER 2: LogosAPI/LogosAPIClient duplication (expect <=$TIER2_ALLOW) =="
+  T2=0
+  for img in "''${CONSUMERS[@]}"; do
+    n=$(names "$img" | grep -Ec "$TIER2_RE" || true); T2=$((T2 + n)); note "$(basename "$img")" "$n"
+  done
+  if [ "$T2" -le "$TIER2_ALLOW" ]; then note "tier-2 total" "$T2  OK"
+  else bad "tier-2 total" "$T2  > $TIER2_ALLOW  REGRESSION"; fi
+
+  echo
+  echo "== non-weak statics defined in MORE THAN ONE in-process image (expect 0) =="
+  ${if isDarwin then ''
+    G=$TMPDIR/guards; rm -rf "$G"; mkdir -p "$G"
+    for img in "$PROVIDER" "''${CONSUMERS[@]}"; do
+      [ -e "$img" ] || continue
+      nm -m "$img" 2>/dev/null | c++filt 2>/dev/null | grep 'guard variable for' \
+        | grep -v 'weak external' | sed -E 's/.*guard variable for /guard variable for /' \
+        | sort -u > "$G/$(basename "$img").g" || true
+    done
+    DUPES=$(cat "$G"/*.g 2>/dev/null | sort | uniq -d || true)
+    if [ -z "$DUPES" ]; then note "cross-image non-weak guard vars" "0  OK"
+    else bad "cross-image non-weak guard vars" "$(printf '%s\n' "$DUPES" | wc -l | tr -d ' ')"; printf '%s\n' "$DUPES" | sed 's/^/      /' | head -8; fi
+  '' else ''
+    note "cross-image guard vars" "skipped (ELF interposes; nm -m is Mach-O only)"
+  ''}
+
+  echo
+  ${if negativeControl then ''
+    if [ "$FAIL" -ne 0 ]; then
+      echo "NEGATIVE CONTROL: PASS — the gate correctly rejected a planted duplicate."
+      mkdir -p $out; echo ok > $out/result; exit 0
+    else
+      echo "NEGATIVE CONTROL: FAIL — the gate ACCEPTED a planted duplicate. It is vacuous."
+      exit 1
+    fi
+  '' else ''
+    if [ "$FAIL" -eq 0 ]; then
+      echo "SYMBOL GATE: PASS"; mkdir -p $out; echo ok > $out/result; exit 0
+    else
+      echo "SYMBOL GATE: FAIL — see logos-protocol/cpp/logos_shared_api.h"; exit 1
+    fi
+  ''}
+''


### PR DESCRIPTION
Stacked on #337 — see *Why this base* below.

## What

`cmake/LogosSharedFromDll.cmake` early-returned `if(NOT WIN32)`, under a comment asserting *"ELF and Mach-O already resolve to the one provider, and there is nothing to fix."*

That claim is false for Mach-O, and **this repo's own history falsified it**: `9e2cc77` measured the `main_ui` fold putting nine runtime entry points into the executable and producing **31** `ModuleProxy: rejecting unauthorized call` lines, root-caused to Mach-O's two-level namespace giving no interposition.

The call site in `app/CMakeLists.txt` was **already unconditional** — it sits inside `if(DEFINED LOGOS_CPP_SDK_ROOT)`, not `if(WIN32)`. The early return inside the function was the only thing gating this to Windows, so removing it is the whole consumer-side fix.

## Measured (aarch64-darwin, `nix build .#app`)

| | before | after |
|---|---|---|
| images defining `TokenManager`/`StoreRegistry` | 0 | 0 |
| images defining `LogosAPI`/`LogosAPIClient` | **26** | **0** |
| cross-image non-weak guard variables | 0 | 0 |

The 26 were real: the executable carried its own copy of `logos_api.cpp.o`, including a **second `LogosAPI::staticMetaObject` in the same process**. Benign only because `LogosAPI`'s constructor caches `&TokenManager::instance()`, which was undefined in the exe and bound to the provider — i.e. one added reference to a protocol-only symbol away from the 31-refusal bug, with no build noise.

## New: `nix/symbol-gate.nix`

Nothing in this tree measured the invariant. The gate asserts that across the images sharing **one** process, the logos C++ runtime is DEFINED exactly once. Three things it does that a naive version gets wrong — each found by writing it:

- **`bin/LogosBasecamp` in a dev build is a shell wrapper** that execs `bin/.LogosBasecamp`. `nm` on the wrapper reads *zero* symbols, making every absence assertion vacuously true. The gate resolves it, and refuses to report a count when the tool read nothing.
- **The in-process image set** is exe + `liblogos_core` + `*_replica_factory` + `main_ui`. **Not** `bin/logos_host` or `bin/ui-host` (separate processes, correctly keeping their own statics), and **not** `plugins/*/*_plugin.*` (a `ui_qml` backend is loaded by `ui-host`). `package_manager_ui_plugin.dylib` genuinely defines 182 runtime symbols and is correctly exempt — scoping this wrong gives a permanently red gate on a non-problem.
- **Matching is anchored to the defining class.** Matching the demangled signature flags basecamp's own `MainContainer::MainContainer(LogosAPI*)` — a parameter type, not a definition.

The provider check doubles as a **demangler validity control**: if `c++filt` were absent or broken it reports 0 and the gate fails, rather than passing vacuously.

## New: `symbol-gate-negative`, shipped *with* the gate

It plants a real duplicate runtime where an in-process consumer goes and asserts the gate **rejects** it. An absence assertion that has never been seen to fail is indistinguishable from a broken one.

## Verified — all green on aarch64-darwin

`symbol-gate` · `symbol-gate-negative` · `unit-tests` · `smoke-test` · `sandbox-test` · `shutdown-test` · `qml-tests` · `integration-test` · `host-services-test`

**`integration-test` is the one `9e2cc77` shipped RED** (14 passed, 2 failed). It passes here.

## Why this base

Targets `fix/b4-windows-link-order` (#337) and stays there — #337 is the base for this whole
line of work and is not being merged to master yet. That is also the right home for the gate:
on master the `main_ui` plugin is still a second runtime-linking image, and #337's CI exercises
the gate on Windows and Linux, which a branch-based PR does not.

## Companion

logos-liblogos#180 makes `liblogos_core`'s coverage deterministic instead of incidental. **This PR does not depend on it**: against the pinned liblogos, `liblogos_core` already provides all 39 runtime symbols the executable needs (measured, 0 missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
