### PR TITLE
fix(symbol-gate): resolve makeBinaryWrapper stubs, which nm reads as real

### DIFF
--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -56,16 +56,25 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
   note() { printf '  %-56s %s\n' "$1" "$2"; }
   bad()  { FAIL=1; printf '  %-56s %s\n' "$1" "$2"; }
 
-  # A dev build installs bin/<name> as a shell wrapper that execs bin/.<name>
-  # (nix/app.nix's QT_PLUGIN_PATH wrapper). Measuring the wrapper reads ZERO
-  # symbols and makes every assertion below vacuously true.
+  # nix wraps binaries TWO ways and both defeat a naive measurement:
+  #   * a shell wrapper that execs bin/.<name>   (nix/app.nix's QT_PLUGIN_PATH
+  #     wrapper) -- nm reads ZERO symbols from it
+  #   * makeBinaryWrapper's COMPILED stub beside bin/.<name>-wrapped -- nm reads
+  #     ~10 symbols from it, so the "did nm read anything" guard below does NOT
+  #     catch this one. Measured in logos-logoscore-cli: bin/logoscore is such a
+  #     stub, and measuring it reports 0 runtime symbols for a binary that in
+  #     fact imports 12.
+  # So the rule is deterministic rather than heuristic: if a hidden sibling
+  # exists, it IS the image, and we never measure bin/<name>.
   resolve_image() {
     local f="$1" d b real
     d=$(dirname "$f"); b=$(basename "$f")
+    for cand in "$d/.$b-wrapped" "$d/.$b"; do
+      [ -e "$cand" ] && { printf '%s\n' "$cand"; return; }
+    done
     if head -c2 "$f" 2>/dev/null | grep -q '#!'; then
       real=$(sed -nE 's/^exec "\$BINDIR\/([^"]+)".*/\1/p' "$f" | tail -1)
       [ -n "$real" ] && [ -e "$d/$real" ] && { printf '%s\n' "$d/$real"; return; }
-      [ -e "$d/.$b" ] && { printf '%s\n' "$d/.$b"; return; }
     fi
     printf '%s\n' "$f"
   }


### PR DESCRIPTION
Stacked on #337, like #339.

## The hole

The resolver handled nix's **shell** wrapper (`bin/<name>` execs `bin/.<name>`) — that case is safe anyway, because `nm` reads zero symbols from a script and the validity guard catches it.

It did **not** handle `makeBinaryWrapper`, which leaves a *compiled* stub at `bin/<name>` and the real image at `bin/.<name>-wrapped`. That one is worse: the stub is a genuine Mach-O with ~10 symbols, so "did `nm` read anything" **passes**, and the gate reports 0 runtime symbols for an image it never looked at.

## Found by pointing it at a second repo

`logos-logoscore-cli`'s `bin/logoscore` is exactly such a stub:

| image | total symbols | defines runtime | imports runtime |
|---|---|---|---|
| `bin/logoscore` (stub) | 10 | 0 | **0** |
| `bin/.logoscore-wrapped` (real) | 3508 | 0 | **12** |

Measuring the stub gives a clean bill for a binary that in fact imports `TokenManager::instance`, `TokenManager::saveToken` and `LogosAPIClient::*` from `liblogos_core.dylib`.

## The fix

Deterministic, not heuristic: if a hidden sibling (`.<name>-wrapped` or `.<name>`) exists, it **is** the image, and `bin/<name>` is never measured.

A threshold on symbol *count* would have been the wrong fix — there's no number that separates a wrapper stub from a small real binary, and picking one puts the gate back in the business of guessing.

No change to the basecamp result: `bin/LogosBasecamp` is the shell-wrapper case and still resolves to `bin/.LogosBasecamp`.

```
nix build .#symbol-gate            PASS
nix build .#symbol-gate-negative   PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)