### PR TITLE
fix(symbol-gate): find -L, or a symlinked plugin is silently not measured

### DIFF
--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -106,8 +106,13 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
   for e in "$ROOT/bin/LogosBasecamp" "$ROOT/bin/LogosBasecamp.exe"; do
     [ -e "$e" ] && CONSUMERS+=("$(resolve_image "$e")")
   done
+  # -L is load-bearing: a nix output can stage plugins as SYMLINKS into the
+  # store, and `find -type f` does NOT match a symlink -- it would return
+  # nothing and the gate would assert over an empty consumer set. Measured in
+  # logos-logoscore-cli, where `find` saw 0 of 2 real libraries. `[ -f ]`
+  # elsewhere is fine, because test(1) follows symlinks and find does not.
   while IFS= read -r p; do [ -n "$p" ] && CONSUMERS+=("$(resolve_image "$p")"); done < <(
-    find "$ROOT/plugins" -type f \( -name '*_replica_factory.*' -o -name 'main_ui.*' \) 2>/dev/null \
+    find -L "$ROOT/plugins" -type f \( -name '*_replica_factory.*' -o -name 'main_ui.*' \) 2>/dev/null \
       | grep -Ev '\.(txt|json)$' || true)
 
   echo "provider  = ''${PROVIDER#$ROOT/}"


### PR DESCRIPTION
Stacked on #337, following #339 and #340.

## The hole

A nix output can stage its libraries and plugins as **symlinks** into the store, and `find -type f` does not match a symlink. The consumer scan then comes back empty and the gate asserts over nothing — passing, with no image examined.

Found while porting the gate to `logos-logoscore-cli`, whose `lib/` holds two real libraries staged as symlinks:

```
find    "$ROOT/lib" -maxdepth 1 -type f   ->  0 entries
find -L "$ROOT/lib" -maxdepth 1 -type f   ->  2 entries
```

There, `libpackage_manager_lib.dylib` was silently dropped from the consumer set. With `-L` it is measured, and reports 0 as expected.

## Why basecamp's result does not change

`plugins/` here happens to hold real files today, so the consumer set is identical before and after:

```
consumers = bin/.LogosBasecamp plugins/package_manager_ui/package_manager_ui_replica_factory.dylib
```

The trap is one layout change away, and it would be invisible — the gate would go green having looked at nothing.

`[ -f ]` elsewhere in the script is fine: `test(1)` follows symlinks. `find` does not, and that asymmetry is the whole bug.

```
nix build .#symbol-gate            PASS
nix build .#symbol-gate-negative   PASS
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)