### PR TITLE
chore(deps): pick up ui-host's teardown grace period

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265575,11 +265575,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
         "type": "github"
       },
       "original": {
@@ -276477,11 +276477,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
         "type": "github"
       },
       "original": {
@@ -317194,11 +317194,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787172850,
-        "narHash": "sha256-p5MReDNu3sSosuGYzEeD+wVP4dYUL2KKHA6dtCBsTN8=",
+        "lastModified": 1787356738,
+        "narHash": "sha256-icN5SY1+l3xcup/9cvWnden6JW7n/mdDYm3bYHkcAO4=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "b9a6778fff2f5714ddb556647ab961f4689a9937",
+        "rev": "7cbc5a6ed3ba5ccffd584c25b966dbf67868d841",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
**Stacked on [#337](https://github.com/logos-co/logos-basecamp/pull/337), deliberately — not on master.** One `flake.lock` file, three revs.

[logos-view-module-runtime#26](https://github.com/logos-co/logos-view-module-runtime/pull/26) (`7cbc5a6`) gives a view its chance to finish between "stop" and teardown. Every `ui_qml` view is hosted by ui-host, and Basecamp structurally cannot do this itself — for `ui_qml` the plugin object is `QPluginLoader`-loaded inside the ui-host **child process**, so Basecamp holds a `QQuickWidget` and a `QProcess` wrapper with nothing to ask. This pin is how the feature reaches it.

## Why not master

Tried, and it fails to link:

```
liblogos_view_module_runtime.a(LogosQmlBridge.cpp.obj):
  undefined reference to `LogosAPI::forIdentity(QString const&, QObject*)'
```

Two things about that are worth stating, because the obvious reading of both is wrong.

**It is not two Qt hosts colliding — it is one host that is too old.** Resolving vmr `7cbc5a6`'s ten undefined `LogosAPI*` symbols against master's archives: **nine resolve, exactly one does not.**

**And master's `LogosAPI` does not arrive transitively.** It comes from basecamp's own root `logos-qt-sdk` pin, `c6be61d0`, which is **pre-split** and still ships the full runtime archive — 21 `LogosAPI` symbols, `forIdentity` not among them. "qt-sdk is headers-only after the split" is true of qt-sdk *master*, not of what basecamp pins.

So no bump of basecamp's existing inputs can fix it: `forIdentity` exists in logos-qt-sdk in exactly **one** commit, `1e2021f`, on an unmerged branch, and master deleted `logos_api.cpp` outright. What master needs is the qt-host migration — protocol ≥ #59 for `TokenManager::forIdentity`, a post-split qt-sdk so the duplicate `LogosAPI` definition goes, and liblogos #182 so `liblogos_core` stops defining `LogosAPI` too. **That migration is #337.** Redoing it off master would be re-implementing five merged PRs divergently.

## The change, on top of #337

| input | before | after |
|---|---|---|
| `logos-view-module-runtime` | `b9a6778f` | `7cbc5a6e` |
| `…/logos-plugin-qt` | `9b2c64e5` | `ef11c210` |
| `…/logos-protocol` | `f4407ff4` | `79894727` |

19832 nodes before and after, **0 added, 0 removed**, wiring identical, exactly 3 revs moved — all reachable only via `root → logos-view-module-runtime`.

## Verified on aarch64-darwin

- **`nix build .#bin-macos-app`** → `LogosBasecamp-macos-app-0.0.0-dev`. That is exactly what the `build-macos-app` job runs — **not** `unit-tests`, which do not link the UI plugin and stayed green right through the earlier breakage.
- **`symbol-gate` PASS** — one definer each (`qt_host` 26, `protocol` 35/49) — and `symbol-gate-negative` PASS, so the zero is a measurement rather than a broken script.
- The shipped `ui-host` contains `logos::runPluginAboutToUnload(QObject*, int)` — the feature is in the **artifact**, not just the lock.
- `smoke-test-bundle`, `unit-tests`, `qml-tests`, `sandbox-test` all green.

## Unproven: Windows

It cannot be cross-built on this machine, and **#337's green `build-windows` ran on `f272e7f` — the base *without* this bump** — so it does not cover this change. CI is the first real test of that leg. Flagging it rather than implying coverage I don't have.

## Residual, measured not guessed

A cross-process version skew remains: ui-host runs on protocol `79894727` / plugin-qt `ef11c21` while the app runs on `2e3344a` / `1aa3e31`. Bounded — the protocol delta is 3 commits (#66 plus two docs) whose only header change is comment-only, and the plugin-qt delta is `logos_plugin_unload.{h,cpp}` alone. Eliminating it means adding `logos-view-module-runtime.inputs.{logos-plugin-qt,logos-protocol}.follows`, which first requires moving basecamp's own `logos-plugin-qt` `1aa3e31 → ef11c21`, because vmr's `ui-host/main.cpp` includes `logos_plugin_unload.h` which `1aa3e31` lacks. That deserves its own PR and its own verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)