### PR TITLE
fix(ci): run the symbol gate — on Windows too, where it matters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,15 @@ jobs:
           attic-token-ci: ${{ secrets.ATTIC_TOKEN_CI }}
           attic-token-public: ${{ secrets.ATTIC_TOKEN_PUBLIC }}
 
+      # This is the platform the gate exists for. PE has no symbol
+      # interposition, so a duplicate runtime that Linux and macOS silently
+      # collapse to one is FATAL here -- and CI cross-builds this bundle and
+      # never runs it, so a build-time assertion is the only signal there is.
+      - name: One-runtime symbol gate
+        run: |
+          nix build .#packages.x86_64-windows.symbol-gate -L
+          nix build .#packages.x86_64-windows.symbol-gate-negative -L
+
       - name: Build the Windows bundle
         run: nix build .#packages.x86_64-windows.bin-bundle-dir -L
 
@@ -205,12 +214,9 @@ jobs:
       # An absence assertion that has never been seen to fail is indistinguish-
       # able from a broken one, so the two ship together or not at all.
       #
-      # Not yet run for x86_64-windows -- the platform where this matters most,
-      # since PE has no symbol interposition to collapse a duplicate. That
-      # attribute cannot be evaluated at all as pinned (see flake.nix, the
-      # `binBundleDir` note), which is a pre-existing blocker. The gate itself
-      # now understands the Windows layout, so wiring it is a one-line follow-up
-      # once the attribute evaluates.
+      # Also wired into build-windows, which is where it matters most: PE has
+      # no symbol interposition to collapse a duplicate, and CI cross-builds
+      # that bundle without ever running it.
       - name: One-runtime symbol gate
         run: |
           nix build .#symbol-gate -L
@@ -278,12 +284,9 @@ jobs:
       # An absence assertion that has never been seen to fail is indistinguish-
       # able from a broken one, so the two ship together or not at all.
       #
-      # Not yet run for x86_64-windows -- the platform where this matters most,
-      # since PE has no symbol interposition to collapse a duplicate. That
-      # attribute cannot be evaluated at all as pinned (see flake.nix, the
-      # `binBundleDir` note), which is a pre-existing blocker. The gate itself
-      # now understands the Windows layout, so wiring it is a one-line follow-up
-      # once the attribute evaluates.
+      # Also wired into build-windows, which is where it matters most: PE has
+      # no symbol interposition to collapse a duplicate, and CI cross-builds
+      # that bundle without ever running it.
       - name: One-runtime symbol gate
         run: |
           nix build .#symbol-gate -L

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,6 +192,30 @@ jobs:
       - name: Host-services grant guard
         run: nix build .#host-services-test -L
 
+      # The one control that mechanically enforces the one-runtime invariant:
+      # each of TokenManager / StoreRegistry / LogosAPI / LogosAPIClient is
+      # DEFINED by exactly one image among those sharing a process, and the
+      # main_ui plugin defines none of them. Until this step existed the gate
+      # was exposed in flake.nix `checks` and built by nothing -- no job
+      # enumerated it and no `nix flake check` runs in this repo -- so a PR that
+      # linked the logos runtime back into main_ui would merge green.
+      #
+      # The negative control is not optional. It plants a REAL duplicate definer
+      # where an in-process consumer goes and asserts the gate REJECTS that tree.
+      # An absence assertion that has never been seen to fail is indistinguish-
+      # able from a broken one, so the two ship together or not at all.
+      #
+      # Not yet run for x86_64-windows -- the platform where this matters most,
+      # since PE has no symbol interposition to collapse a duplicate. That
+      # attribute cannot be evaluated at all as pinned (see flake.nix, the
+      # `binBundleDir` note), which is a pre-existing blocker. The gate itself
+      # now understands the Windows layout, so wiring it is a one-line follow-up
+      # once the attribute evaluates.
+      - name: One-runtime symbol gate
+        run: |
+          nix build .#symbol-gate -L
+          nix build .#symbol-gate-negative -L
+
       # Report-only non-blocking for now
       - name: Coverage report
         continue-on-error: true
@@ -240,6 +264,30 @@ jobs:
       # real .app bundle (same pairing as integration-test-bundle above).
       - name: Host-services grant guard
         run: nix build .#host-services-test-bundle -L
+
+      # The one control that mechanically enforces the one-runtime invariant:
+      # each of TokenManager / StoreRegistry / LogosAPI / LogosAPIClient is
+      # DEFINED by exactly one image among those sharing a process, and the
+      # main_ui plugin defines none of them. Until this step existed the gate
+      # was exposed in flake.nix `checks` and built by nothing -- no job
+      # enumerated it and no `nix flake check` runs in this repo -- so a PR that
+      # linked the logos runtime back into main_ui would merge green.
+      #
+      # The negative control is not optional. It plants a REAL duplicate definer
+      # where an in-process consumer goes and asserts the gate REJECTS that tree.
+      # An absence assertion that has never been seen to fail is indistinguish-
+      # able from a broken one, so the two ship together or not at all.
+      #
+      # Not yet run for x86_64-windows -- the platform where this matters most,
+      # since PE has no symbol interposition to collapse a duplicate. That
+      # attribute cannot be evaluated at all as pinned (see flake.nix, the
+      # `binBundleDir` note), which is a pre-existing blocker. The gate itself
+      # now understands the Windows layout, so wiring it is a one-line follow-up
+      # once the attribute evaluates.
+      - name: One-runtime symbol gate
+        run: |
+          nix build .#symbol-gate -L
+          nix build .#symbol-gate-negative -L
 
   release:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/')

--- a/flake.nix
+++ b/flake.nix
@@ -483,22 +483,23 @@
           #  * None of this has been RUN on Windows, by this change or by CI,
           #    which has never executed a Windows binary. Every claim above is
           #    build-time and tree-shape only.
-          #  * The two trees measured came from a harness that drops ONE entry
-          #    from installedDistributed -- packageManagerUIPlugin -- because
-          #    logos-package-manager-ui does not cross-compile at the rev this
-          #    flake pins: its generated logos_sdk.h includes
-          #    package_manager_api.h, which is not produced for the Windows
-          #    target. That is pre-existing and independent of this change; the
-          #    identical derivation fails when built straight from the pinned
-          #    rev with no basecamp involved. Everything above concerns Qt
-          #    staging and the DLL closure, which that one plugin does not
-          #    participate in -- but the numbers are from a bundle missing it.
-          #  * For the same reason `nix build .#packages.x86_64-windows.*`
-          #    cannot succeed on this branch as pinned. A second, unrelated
-          #    blocker sits in front of it at EVAL time: line ~119's
-          #    logos-package-downloader-module has no x86_64-windows target, so
-          #    the attribute cannot even be evaluated. Both blockers predate
-          #    this change and are identical with the bypass in place.
+          #  * The two trees measured came from a harness that dropped ONE
+          #    entry from installedDistributed -- packageManagerUIPlugin --
+          #    because logos-package-manager-ui did not cross-compile at the rev
+          #    this flake pinned then: its generated logos_sdk.h included
+          #    package_manager_api.h, which was not produced for the Windows
+          #    target. There was also a separate EVAL-time blocker, a
+          #    logos-package-downloader-module with no x86_64-windows target.
+          #
+          #    BOTH have since been fixed upstream. `.#packages.x86_64-windows.*`
+          #    now evaluates AND builds, and the resulting bundle DOES include
+          #    package_manager_ui -- so the numbers above describe a tree that
+          #    was missing a plugin which is no longer missing. Re-measure
+          #    before quoting them.
+          #
+          #    (The cross build needs an x86_64-linux builder: logos_build_info.h
+          #    is an x86_64-linux derivation, so it cannot run on an
+          #    aarch64-darwin host without one.)
           binBundleDir = withMainProgram (dirBundler appDistributed);
           binBundleDirInspector = withMainProgram (dirBundler appDistributedWithInspector);
         in

--- a/flake.nix
+++ b/flake.nix
@@ -537,10 +537,14 @@
 
           # One-runtime symbol gate. Asserts the logos C++ runtime (TokenManager,
           # StoreRegistry, LogosAPI, LogosAPIClient) is DEFINED exactly once across
-          # the images that share one process — in liblogos_core, the single
-          # provider. A second definition is a second TokenManager and every
-          # cross-module call is refused at runtime with no build diagnostic.
-          # Build: nix build .#symbol-gate
+          # the images that share one process. The assertion is exactly-one and
+          # deliberately does NOT name an owner: liblogos_core stopped being the
+          # provider when the runtime became real shared libraries, and it is
+          # liblogos_protocol and liblogos_qt_host that define these types today.
+          # A second definition is a second TokenManager and every cross-module
+          # call is refused at runtime with no build diagnostic.
+          # Build: nix build .#symbol-gate  (CI: the "One-runtime symbol gate"
+          # step in test-linux and test-macos runs this and its negative control)
           symbol-gate = import ./nix/symbol-gate.nix { inherit pkgs; appPkg = app; };
 
           # Negative control for the above. Plants a REAL duplicate runtime where

--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -73,6 +73,7 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
     ++ [ pkgs.stdenv.cc.bintools ];
 } ''
   set -uo pipefail
+  export LC_ALL=C   # comm(1) below requires a byte-order sort
 
   # TIER 1 — the split-brain itself. No allowance, ever.
   TIER1_RE='^(TokenManager|StoreRegistry)::|^(vtable|typeinfo|typeinfo name|guard variable) for (TokenManager|StoreRegistry)\b'
@@ -109,7 +110,33 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
     fi
     printf '%s\n' "$f"
   }
+  ${if isWindows then ''
+  # PE reports an import THUNK as a defined text symbol. For every imported
+  # function GNU ld synthesizes a jump stub in .text AND an __imp_<mangled> slot
+  # in the import address table, and `nm --defined-only` shows the stub as `T`.
+  # Counting that alone reported liblogos_core.dll and LogosBasecamp.exe as
+  # DEFINERS of types they merely import -- measured on a real cross build: 3
+  # and 1 phantom TokenManager "definitions", against liblogos_protocol.dll's
+  # genuine 41.
+  #
+  # The paired __imp_ entry is the discriminator, and it is the RIGHT one: a
+  # genuine second copy statically linked into an image has no __imp_ slot, so
+  # it still counts as a definition. The PE export table would also hide the
+  # phantom -- liblogos_core.dll exports 0 TokenManager symbols and
+  # liblogos_protocol.dll exports 45 -- but it would hide a real private copy
+  # just as well, trading this false positive for a false NEGATIVE. That is the
+  # wrong direction for a gate whose whole job is catching a private copy.
+  names() {
+    local t; t=$(mktemp -d)
+    ${definedCmd} "$1" 2>/dev/null | awk '{print $3}' | grep -v '^$' | sort -u > "$t/all"
+    grep '^__imp_' "$t/all" | sed 's/^__imp_//' | sort -u > "$t/imp"
+    grep -v '^__imp_' "$t/all" | sort -u > "$t/def"
+    comm -23 "$t/def" "$t/imp" | ${tp}c++filt 2>/dev/null
+    rm -rf "$t"
+  }
+  '' else ''
   names() { ${definedCmd} "$1" 2>/dev/null | ${tp}c++filt 2>/dev/null | sed -E 's/^[0-9a-fA-F]+ [A-Za-z] //'; }
+  ''}
   valid() {
     local t; t=$(${totalCmd} "$1" 2>/dev/null | wc -l | tr -d ' ')
     [ "''${t:-0}" -gt 0 ] || { bad "$(basename "$1")" "ERROR: nm read 0 symbols — vacuous"; return 1; }

--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -41,6 +41,13 @@
 let
   isDarwin  = pkgs.stdenv.isDarwin;
   isWindows = pkgs.stdenv.hostPlatform.isWindows;
+  # "" natively, "x86_64-w64-mingw32-" for the Windows cross. The cross bintools
+  # installs ONLY the prefixed names, so a bare `nm` / `c++filt` is not on PATH
+  # in that derivation at all -- every measurement silently produced nothing and
+  # valid() below refused to assert over it. Fail-closed, but the gate could
+  # never run. (The HOST's own nm reads these PEs fine: 7350 symbols out of
+  # liblogos_core.dll. The tool was missing, not incapable.)
+  tp = pkgs.stdenv.cc.targetPrefix;
   # Mach-O: -gU is defined externals. ELF: -D --defined-only.
   #
   # PE gets NEITHER, because a PE has no ELF dynamic symbol table and `nm -D`
@@ -52,14 +59,14 @@ let
   # on the platform it matters most on. PE has no symbol interposition, so a
   # duplicate runtime that Linux and macOS quietly collapse to one is fatal
   # there and only there.
-  definedCmd = if isDarwin then "nm -gU"
-               else if isWindows then "nm --defined-only"
-               else "nm -D --defined-only";
+  definedCmd = if isDarwin then "${tp}nm -gU"
+               else if isWindows then "${tp}nm --defined-only"
+               else "${tp}nm -D --defined-only";
   # A count over a tool that read nothing is not evidence of absence. nix/app.nix
   # writes the same defence over its Qt DLL closure.
-  totalCmd   = if isDarwin then "nm -a"
-               else if isWindows then "nm"
-               else "nm -D";
+  totalCmd   = if isDarwin then "${tp}nm -a"
+               else if isWindows then "${tp}nm"
+               else "${tp}nm -D";
 in
 pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeControl "-negative"}" {
   nativeBuildInputs = [ pkgs.coreutils pkgs.findutils pkgs.gnugrep pkgs.gnused ]
@@ -102,7 +109,7 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
     fi
     printf '%s\n' "$f"
   }
-  names() { ${definedCmd} "$1" 2>/dev/null | c++filt 2>/dev/null | sed -E 's/^[0-9a-fA-F]+ [A-Za-z] //'; }
+  names() { ${definedCmd} "$1" 2>/dev/null | ${tp}c++filt 2>/dev/null | sed -E 's/^[0-9a-fA-F]+ [A-Za-z] //'; }
   valid() {
     local t; t=$(${totalCmd} "$1" 2>/dev/null | wc -l | tr -d ' ')
     [ "''${t:-0}" -gt 0 ] || { bad "$(basename "$1")" "ERROR: nm read 0 symbols — vacuous"; return 1; }
@@ -218,7 +225,7 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
     G=$TMPDIR/guards; rm -rf "$G"; mkdir -p "$G"
     for img in "$PROVIDER" "''${CONSUMERS[@]}"; do
       [ -e "$img" ] || continue
-      nm -m "$img" 2>/dev/null | c++filt 2>/dev/null | grep 'guard variable for' \
+      ${tp}nm -m "$img" 2>/dev/null | ${tp}c++filt 2>/dev/null | grep 'guard variable for' \
         | grep -v 'weak external' | sed -E 's/.*guard variable for /guard variable for /' \
         | sort -u > "$G/$(basename "$img").g" || true
     done

--- a/nix/symbol-gate.nix
+++ b/nix/symbol-gate.nix
@@ -12,8 +12,11 @@
 # liblogos_protocol owns TokenManager/LogosAPIClient and liblogos_qt_host owns
 # LogosAPI, and liblogos_core imports both like everyone else. Naming an owner
 # here would have to be edited every time ownership moves -- and the first time
-# it moved, this check failed while every real assertion still passed. See
-# logos-protocol/cpp/logos_shared_api.h and cmake/LogosSharedFromDll.cmake.
+# it moved, this check failed while every real assertion still passed. Ownership
+# is declared in logos-protocol/cpp/logos_shared_api.h. (Earlier revisions of
+# this comment also pointed at cmake/LogosSharedFromDll.cmake; that file was the
+# single-provider shim and was deleted in #348 once the runtime became real
+# shared libraries, so there is nothing to follow there any more.)
 #
 # Nothing else in the tree measures this, and it has no build diagnostic: it
 # surfaces at runtime as "ModuleProxy: rejecting unauthorized call" and
@@ -36,12 +39,27 @@
 { pkgs, appPkg, negativeControl ? false }:
 
 let
-  isDarwin = pkgs.stdenv.isDarwin;
-  # Mach-O: -gU is defined externals. ELF: -D --defined-only. mingw nm reads PE.
-  definedCmd = if isDarwin then "nm -gU" else "nm -D --defined-only";
-  # A count over a tool that read nothing is not evidence of absence. The same
-  # defence is written at nix/app.nix:382.
-  totalCmd   = if isDarwin then "nm -a" else "nm -D";
+  isDarwin  = pkgs.stdenv.isDarwin;
+  isWindows = pkgs.stdenv.hostPlatform.isWindows;
+  # Mach-O: -gU is defined externals. ELF: -D --defined-only.
+  #
+  # PE gets NEITHER, because a PE has no ELF dynamic symbol table and `nm -D`
+  # therefore reads nothing at all from a .dll. Measured against a real mingw
+  # PE (libffi-8.dll, binutils 2.46): `nm -D` -> 0 lines and an error on stderr,
+  # `nm` -> 687, `nm --defined-only` -> 686. Left as -D, valid() below would see
+  # zero symbols and abort the whole gate as vacuous before it asserted
+  # anything -- loud rather than silent, but the gate would never once have run
+  # on the platform it matters most on. PE has no symbol interposition, so a
+  # duplicate runtime that Linux and macOS quietly collapse to one is fatal
+  # there and only there.
+  definedCmd = if isDarwin then "nm -gU"
+               else if isWindows then "nm --defined-only"
+               else "nm -D --defined-only";
+  # A count over a tool that read nothing is not evidence of absence. nix/app.nix
+  # writes the same defence over its Qt DLL closure.
+  totalCmd   = if isDarwin then "nm -a"
+               else if isWindows then "nm"
+               else "nm -D";
 in
 pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeControl "-negative"}" {
   nativeBuildInputs = [ pkgs.coreutils pkgs.findutils pkgs.gnugrep pkgs.gnused ]
@@ -142,7 +160,16 @@ pkgs.runCommand "logos-basecamp-symbol-gate${pkgs.lib.optionalString negativeCon
   ALL=("$PROVIDER" "''${CONSUMERS[@]}")
   while IFS= read -r p; do
     [ -n "$p" ] && [ "$p" != "$PROVIDER" ] && ALL+=("$p")
-  done < <(find -L "$ROOT/lib" -maxdepth 1 -type f \( -name 'liblogos_*.dylib' -o -name 'liblogos_*.so' \) 2>/dev/null | grep -v 'liblogos_core' || true)
+  # bin/ is searched too, and .dll is matched: on Windows every liblogos_* shared
+  # image is staged into bin/, NOT lib/ (nix/app.nix flips _libdest for exactly
+  # that reason -- the PE loader searches the executable's directory). Globbing
+  # lib/*.{dylib,so} alone found ZERO definers on Windows, so the exactly-one
+  # assertion below reported "0 definers" for every family and could not pass on
+  # a correct tree. The three sibling probes above -- provider, negative control,
+  # consumer -- each learned this layout; this one had not.
+  done < <(find -L "$ROOT/lib" "$ROOT/bin" -maxdepth 1 -type f \
+    \( -name 'liblogos_*.dylib' -o -name 'liblogos_*.so' -o -name 'liblogos_*.dll' \) 2>/dev/null \
+    | grep -v 'liblogos_core' || true)
 
   # Exactly one definer per type. This doubles as the demangler validity
   # control: if c++filt were absent or broken every family would report ZERO


### PR DESCRIPTION
The one-runtime symbol gate was exposed in `flake.nix` `checks` and built by **nothing**. Both workflows enumerate individual `nix build .#<output>` steps by hand and no `nix flake check` runs in this repo:

```
$ git grep -E 'symbol-gate|flake check' origin/master -- .github/
$        # no output
```

So the control that mechanically enforces "each runtime type is defined exactly once, and `main_ui` defines none of them" was dead code. A PR relinking the logos runtime into `main_ui` would have merged green — and would have *run* green on Linux and macOS too, since both interpose a duplicate away at load time. It is fatal only on PE.

## The headline result

`main_ui.dll` defines **zero** logos runtime symbols on a real cross-built PE. That claim is what this branch's predecessor rests on, and until now nothing had measured it on the platform where getting it wrong actually breaks:

```
provider  = bin/liblogos_core.dll
consumers = bin/LogosBasecamp.exe
            plugins/package_manager_ui/package_manager_ui_replica_factory.dll
            plugins/main_ui/main_ui.dll

== each runtime type is defined by EXACTLY ONE image ==
  TokenManager      1 definer: liblogos_protocol.dll(41)   OK
  LogosAPI          1 definer: liblogos_qt_host.dll(32)    OK
  LogosAPIClient    1 definer: liblogos_protocol.dll(122)  OK

== TIER 1 (expect 0) ==
  LogosBasecamp.exe                          0  OK
  package_manager_ui_replica_factory.dll     0  OK
  main_ui.dll                                0  OK

== TIER 2 (expect <=0) ==   tier-2 total  0  OK

SYMBOL GATE: PASS
```

The negative control rejects a planted duplicate on PE as well, catching 41 `TokenManager` and 122 `LogosAPIClient` definitions — including the one that names the failure exactly:

```
main_ui.dll   41  SPLIT-BRAIN
    guard variable for TokenManager::instance()::instance
NEGATIVE CONTROL: PASS — the gate correctly rejected a planted duplicate.
```

That control is what makes the pass mean anything, and it independently proves the thunk filter below does not over-reach.

## What was wrong with the gate

Three bugs, all Windows-only. Only the first was findable by reading:

**1. The peer-image sweep globbed `$ROOT/lib` for `*.dylib`/`*.so`.** On Windows every `liblogos_*` shared image is staged into `bin/` as a `.dll` (`nix/app.nix` flips `_libdest`), so the sweep matched nothing, found no definer, and the exactly-one assertion reported `0 definers` for every family — **it could not pass on a correct tree**. Its three sibling probes had each been taught `bin/*.dll`; this one had not.

**2. `nm` and `c++filt` were not on PATH at all.** The cross bintools installs only `x86_64-w64-mingw32-`-prefixed names. Every measurement silently read nothing and `valid()` refused to assert over it:

```
liblogos_core.dll   ERROR: nm read 0 symbols — vacuous
```

Fail-closed, as designed — but the gate could never run. The tool was *missing, not incapable*: the host's own `nm` reads these PEs fine (7350 symbols out of `liblogos_core.dll`). Fixed with `stdenv.cc.targetPrefix`, which is empty natively and so a no-op on Linux and macOS.

**3. PE import thunks were counted as definitions.** With `nm` reachable, the gate reported a split-brain that is not there:

```
TokenManager  4 definers: liblogos_core.dll(3) LogosBasecamp.exe(1)
                          liblogos_protocol.dll(41) liblogos_qt_host.dll(5)
```

`liblogos_core.dll` defines zero runtime symbols by design and measures 0 on macOS. For every imported function ld synthesizes a `.text` stub **and** an `__imp_<mangled>` IAT slot, and `nm --defined-only` shows the stub as `T`:

```
I __imp__ZN12TokenManager8instanceEv
T TokenManager::instance()
```

So a symbol counts as defined only when the image has no `__imp_` slot for it.

**On why not the export table.** It also suppresses the phantom — `liblogos_core.dll` exports 0 `TokenManager` symbols, `liblogos_protocol.dll` exports 45 — and it was the first thing I reached for. It is the wrong tool: a genuine statically-linked private copy is absent from the export table too, so it trades a false positive for a false **negative**, in a gate whose entire job is catching a private copy. The `__imp_` pairing has no such hole, and the negative control above demonstrates it.

## What changed

- A `One-runtime symbol gate` step in `test-linux`, `test-macos` **and `build-windows`**, each building `.#symbol-gate` and `.#symbol-gate-negative`. The negative control is not optional: an absence assertion that has never been seen to fail is indistinguishable from a broken one.
- The three gate fixes above.
- Drops two stale comments — one pointing at `cmake/LogosSharedFromDll.cmake` (the single-provider shim, deleted in #348), one claiming `liblogos_core` is the provider. `liblogos_protocol` and `liblogos_qt_host` define these types now, which is exactly why the assertion is *exactly-one* rather than naming an owner.
- Corrects the `binBundleDir` note, stale in **both** claims: `logos-package-manager-ui` not cross-compiling, and a separate eval-time blocker in `logos-package-downloader-module`. Both were fixed upstream — the bundle the gate just ran against contains `package_manager_ui`, so the note's measurements describe a tree missing a plugin that is no longer missing.

## Verification

| platform | gate | negative control |
|---|---|---|
| aarch64-darwin | PASS | PASS (rejects at 49 symbols) |
| x86_64-windows | PASS | PASS (rejects at 41 + 122) |

The Windows cross build needs an **x86_64-linux builder** — `logos_build_info.h` is an `x86_64-linux` derivation, so it cannot run from an aarch64-darwin host. CI's `build-windows` runs on `ubuntu-latest`, so this is satisfied there; it is noted in the flake for anyone trying it from a Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)