### PR TITLE
fix(shell): stop reading the package_manager_ui widget after the host frees it

### DIFF
--- a/src/MainContainer.cpp
+++ b/src/MainContainer.cpp
@@ -25,6 +25,23 @@ constexpr int kAppsStackIndex     = 0;  // WorkspaceArea (QDockWidget-based)
 constexpr int kContentStackIndex  = 1;  // ContentViews.qml (App Manager + Settings)
 constexpr int kModulesStackIndex  = 2;  // package_manager_ui (sandboxed QQuickWidget)
 
+// The Package Manager page before package_manager_ui arrives -- and again after
+// it goes away. Built in two places, so it lives here: the stack must keep all
+// three pages at all times, because every section switch below indexes into it
+// by constant.
+QWidget* makePmuiPlaceholder(QWidget* parent)
+{
+    QWidget* ph = new QWidget(parent);
+    ph->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    QVBoxLayout* phLayout = new QVBoxLayout(ph);
+    phLayout->setAlignment(Qt::AlignCenter);
+    QLabel* loadingLabel = new QLabel(QStringLiteral("Loading Package Manager…"), ph);
+    loadingLabel->setAlignment(Qt::AlignCenter);
+    loadingLabel->setStyleSheet(QStringLiteral("color: #a0a0a0; font-size: 14px;"));
+    phLayout->addWidget(loadingLabel);
+    return ph;
+}
+
 // DEV_QML_PATH: when set, load QML view entry files from the filesystem source
 // tree instead of the embedded qrc resource
 QString devQmlRoot() {
@@ -219,19 +236,7 @@ void MainContainer::setupUi()
     // Index 2: placeholder for package_manager_ui — shows a centered
     // "Loading…" label until PMUI's QQuickWidget arrives via the
     // pluginWindowRequested intercept
-    QWidget* pmuiPlaceholder = new QWidget(m_contentStack);
-    pmuiPlaceholder->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
-    {
-        QVBoxLayout* phLayout = new QVBoxLayout(pmuiPlaceholder);
-        phLayout->setAlignment(Qt::AlignCenter);
-        QLabel* loadingLabel = new QLabel(QStringLiteral("Loading Package Manager…"),
-                                          pmuiPlaceholder);
-        loadingLabel->setAlignment(Qt::AlignCenter);
-        loadingLabel->setStyleSheet(QStringLiteral(
-            "color: #a0a0a0; font-size: 14px;"));
-        phLayout->addWidget(loadingLabel);
-    }
-    m_contentStack->addWidget(pmuiPlaceholder);
+    m_contentStack->addWidget(makePmuiPlaceholder(m_contentStack));
 
     // Content stack fills the content area — the version footer that
     // used to live in a QML bottom toolbar is now inside SidebarPanel.qml.
@@ -402,7 +407,19 @@ void MainContainer::onPluginWindowRequested(QWidget* widget, const QString& titl
 
 void MainContainer::onPluginWindowRemoveRequested(QWidget* widget)
 {
-    if (widget && widget == m_pmuiWidget) return;
+    if (widget && widget == m_pmuiWidget) {
+        // package_manager_ui is the Package Manager PAGE, not a dock, so it must
+        // not reach removePluginDock() -- but it cannot simply be left in the
+        // stack either: the host deleteLater()s it the moment this returns.
+        // Taking a page out without putting one back leaves a two-page stack
+        // that every `setCurrentIndex(kModulesStackIndex)` then indexes past the
+        // end of, and the section is dead for the rest of the session.
+        m_contentStack->removeWidget(widget);
+        m_contentStack->insertWidget(kModulesStackIndex,
+                                     makePmuiPlaceholder(m_contentStack));
+        m_pmuiWidget = nullptr;
+        return;
+    }
     if (m_workspaceArea && widget)
         m_workspaceArea->removePluginDock(widget);
 }

--- a/src/MainContainer.h
+++ b/src/MainContainer.h
@@ -4,6 +4,7 @@
 
 #include <QWidget>
 #include <QHBoxLayout>
+#include <QPointer>
 #include <QStackedWidget>
 
 class QQuickWidget;
@@ -64,7 +65,13 @@ private:
     // Workspace (QDockWidget-based, replaces the old QMdiArea workspace)
     WorkspaceArea* m_workspaceArea;
 
-    QWidget* m_pmuiWidget = nullptr;
+    // QPointer, not a raw pointer: this widget is owned by the HOST side, which
+    // deleteLater()s it on unload (UIPluginManager::unloadUiModuleImpl and
+    // ::teardownUiPluginWidget both do). As a raw pointer it was read at four
+    // sites after the widget had been freed, and `!m_pmuiWidget` stayed false
+    // forever, so the Package Manager section could never reload. Same guard the
+    // host applies to its own widget maps.
+    QPointer<QWidget> m_pmuiWidget;
     bool m_suppressNextNavToApps = false;
 
     // Content views (QML for Dashboard, Modules, PackageManager, Settings)


### PR DESCRIPTION
`src/MainContainer.h:67` held `QWidget* m_pmuiWidget` — a raw pointer to a widget the **host** owns and frees.

Both host teardown paths do the same thing: emit `pluginWindowRemoveRequested`, then `deleteLater()` the widget (`app/UIPluginManager.cpp:399`→`:407` and `:696`→`:698`). The shell's handler returned early for exactly that widget *without clearing the pointer*:

```cpp
void MainContainer::onPluginWindowRemoveRequested(QWidget* widget)
{
    if (widget && widget == m_pmuiWidget) return;   // <- freed a moment later
```

After an unload, `m_pmuiWidget` is read as a freed pointer at four sites (`:349`, `:377`, `:405`, `:412`), and `!m_pmuiWidget` never becomes true again — so `onSectionIndexChanged(2)` never re-issues `loadUiModule("package_manager_ui")`.

## `QPointer` alone is not the whole fix

The widget had *replaced* the placeholder at `kModulesStackIndex`, so freeing it also removes a page from a stack that every section switch indexes into by constant. `setCurrentIndex(kModulesStackIndex)` then addresses a two-page stack, and the Package Manager section is dead for the rest of the session.

So the removal path now puts the placeholder back. That also restores the exact startup state `onPluginWindowRequested` already knows how to consume — it looks up `widget(kModulesStackIndex)` and swaps it out — so a reload after an unload takes the identical path as the first load.

Placeholder construction moves into one `makePmuiPlaceholder()` helper used by both sites, so the startup page and the restored page cannot drift.

## Why it is reachable

`package_manager_ui` is listed by `UIPluginManager::uiModules()` (`app/UIPluginManager.cpp:154-188` — no exclusion, unlike `launcherApps()` at `:560`), and the Apps Inspector row wires `onAppUnloadRequested: name => backend.unloadUiModule(name)` (`src/Basecamp/Shell/ContentViews.qml:101`).

## Provenance

This is the same guard the host applies to its own widget maps — `m_uiModuleWidgets` / `m_qmlPluginWidgets` are `QMap<QString, QPointer<...>>` (`app/UIPluginManager.h:225-226`). The shell's own copy of the pointer had not been given it. The defect predates the shell split (it came in with `d7d2439`) but survives at the merged tip in a file the split rewrote.

## Verification and its limits

`nix build .#main-ui-plugin` green.

**There is no regression test, and I want to be explicit about that.** Nothing under `tests/` references `m_pmuiWidget`, and the reachable path needs a live shell plus a real `package_manager_ui` to exercise, which no current harness sets up. The fix is verified by compilation and by reading the ownership contract on both sides of the boundary — not by a test that fails before it and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)