### PR TITLE
docs: retire references to files, outputs and pins that no longer exist

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -337,9 +337,13 @@ target_link_libraries(LogosBasecamp PRIVATE
     ${LOGOS_VIEW_MODULE_RUNTIME_LIB}
     $<$<BOOL:${ENABLE_QML_INSPECTOR}>:qml-inspector>
     # logos_core is LAST, and that position is load-bearing on Windows: it is the
-    # IMPORT LIBRARY for liblogos_core.dll, the single provider of the shared C++
-    # runtime (LogosSharedFromDll.cmake empties the static archives defining those
-    # types). GNU ld takes only archive members satisfying references already
+    # IMPORT LIBRARY for liblogos_core.dll, which re-exports the shared C++
+    # runtime defined by liblogos_protocol.dll and liblogos_qt_host.dll. (This
+    # comment used to explain the ordering by LogosSharedFromDll.cmake emptying
+    # the static archives; that shim was deleted in #348 when the runtime became
+    # real shared libraries. The ordering rule below still holds -- only that
+    # justification is gone, so do not read its absence as licence to reorder.)
+    # GNU ld takes only archive members satisfying references already
     # undefined when it reaches them, so placing it ahead of
     # LOGOS_VIEW_MODULE_RUNTIME_LIB fails the mingw link with four undefined
     # references — LogosAPIClient::whenObjectAvailable / ::eventSubscriptionState

--- a/docs/project.md
+++ b/docs/project.md
@@ -18,30 +18,18 @@ logos-basecamp/
 │   ├── CMakeLists.txt                    # App build configuration
 │   ├── main.cpp                          # Entry point
 │   ├── window.h/cpp                      # Main window (QMainWindow)
-│   ├── interfaces/                       # Component interfaces (IComponent)
+│   ├── interfaces/                       # IShellHost/IShellObserver, IShellView, IComponent
 │   ├── utils/                            # Utility classes (paths, file helpers)
 │   ├── macos/                            # macOS-specific code (titlebar styling)
 │   ├── icons/                            # Application icons
 │   ├── MainUIBackend.h/cpp               # Core logic (module state, stats, navigation)
 │   ├── ShellHostAdapter.h/cpp            # IShellHost over MainUIBackend
-│   ├── LogosQmlBridge.h/cpp              # QML-to-C++ module call bridge
-│   ├── mdiview.h/cpp                     # MDI tab workspace
-│   ├── mdichild.h/cpp                    # Individual plugin tab window
-│   ├── qml/                              # QML UI files
-│   │   ├── panels/
-│   │   │   ├── SidebarPanel.qml          # Sidebar navigation
-│   │   │   └── UiModulesTab.qml          # Module management tab
-│   │   ├── views/
-│   │   │   ├── ContentViews.qml          # Content area stack layout
-│   │   │   ├── DashboardView.qml         # Dashboard screen
-│   │   │   ├── ModulesView.qml           # Modules management screen
-│   │   │   ├── CoreModulesView.qml       # Core modules list
-│   │   │   ├── PluginInterfaceView.qml   # Interface inspection (methods + events)
-│   │   │   └── SettingsView.qml          # Settings screen
-│   │   └── controls/                     # Reusable QML controls
-│   │       ├── SidebarIconButton.qml
-│   │       ├── SidebarAppDelegate.qml
-│   │       └── SidebarCircleButton.qml
+│   ├── CoreModuleManager.h/cpp           # Core-module lifecycle over the SDK facade
+│   ├── UIPluginManager.h/cpp             # UI-plugin load/unload, widget ownership
+│   ├── PluginLoader.h/cpp                # Per-plugin identities, ui-host spawning
+│   ├── PackageCoordinator.h/cpp          # Install/uninstall flows
+│   ├── AppsModel.h/cpp                   # App list model
+│   ├── ModuleInstanceModel.h/cpp         # Module list model
 │   └── restricted/                       # ui_qml sandbox (network + filesystem + native-plugin)
 │   │   ├── QmlSandbox.h/cpp               # applies the sandbox policy to a QML engine
 │   │   ├── DenyAllNetworkAccessManager.h/cpp
@@ -65,9 +53,13 @@ logos-basecamp/
 │   ├── smoke-test.nix                    # Smoke test derivation
 │   ├── integration-test.nix              # UI integration test harness
 │   ├── host-services-test.nix            # Host-services grant guard
-│   ├── appimage.nix                      # Linux AppImage packaging
-│   ├── macos-bundle.nix                  # macOS .app bundle
-│   └── macos-dmg.nix                     # macOS DMG packaging
+│   ├── symbol-gate.nix                   # One-runtime gate + its negative control
+│   ├── unit-tests.nix                    # C++ unit tests
+│   ├── qml-tests.nix                     # QML tests
+│   ├── sandbox-test.nix                  # ui_qml sandbox-escape regression test
+│   ├── shutdown-test.nix                 # Quit-gesture teardown tests
+│   ├── coverage.nix                      # gcovr report over app/ and src/
+│   └── build-info.nix                    # Version/build metadata
 ├── qt-ios/                               # iOS build configuration (experimental)
 │   ├── CMakeLists.txt
 │   ├── Main.qml
@@ -227,13 +219,13 @@ The shell's entire contract is `IShellHost`: a `QWidget*` out, eight named opera
 
 ### MainContainer
 
-**Files:** `app/MainContainer.h`, `app/MainContainer.cpp`
+**Files:** `src/MainContainer.h`, `src/MainContainer.cpp` — plugin side, Qt only
 
-**Purpose:** UI coordinator that creates the `MainUIBackend`, assembles the sidebar (QML `SidebarPanel`) and content area (stacked widget with MdiView + QML system views), and routes navigation signals between them.
+**Purpose:** UI coordinator that assembles the sidebar (QML `SidebarPanel`) and content area (stacked widget with `WorkspaceArea` + QML system views), and routes navigation between them. It does **not** create `MainUIBackend` any more — `Window` owns that and the shell borrows it through `IShellHost`, reaching it from QML as an opaque `QObject*` via `backendObject()`.
 
 ### LogosQmlBridge
 
-**Files:** `app/LogosQmlBridge.h`, `app/LogosQmlBridge.cpp`
+**Files:** none in this repo — `LogosQmlBridge` is an external header, included by `app/PluginLoader.cpp` from a flake input's include path (logos-view-module-runtime).
 
 **Purpose:** Bridge between QML-based UI Apps and Logos Modules. Injected into each QML UI App's context as `logos`, enabling UI Apps to call Logos Module methods via the Logos API.
 
@@ -245,17 +237,11 @@ The shell's entire contract is `IShellHost`: a `QWidget*` out, eight named opera
 
 The bridge validates that the `LogosAPI` is available and the target Logos Module is connected before dispatching. Results are serialized to JSON (objects, arrays, primitives) for consumption by QML.
 
-### MdiView
+### WorkspaceArea
 
-**Files:** `app/mdiview.h`, `app/mdiview.cpp`
+**Files:** `src/WorkspaceArea.h`, `src/WorkspaceArea.cpp` — plugin side, Qt only
 
-**Purpose:** Multi-document interface workspace. Manages a tab bar with one tab per loaded UI App. Handles tab creation, removal, switching, and custom styling with close buttons.
-
-### MdiChild
-
-**Files:** `app/mdichild.h`, `app/mdichild.cpp`
-
-**Purpose:** Individual tab in the MDI area. Wraps a UI App's widget and manages its lifecycle within the tabbed workspace.
+**Purpose:** Dock-based app workspace, one dock per loaded UI App: `addPluginDock` / `removePluginDock` / `activatePluginDock`. It replaced the earlier `MdiView` / `MdiChild` QMdiArea tab pair, which no longer exist.
 
 ### QML Sandbox
 
@@ -515,7 +501,6 @@ nix build '.#app'                  # Standard development build
 nix build '.#bin-bundle-dir'             # Self-contained portable build
 nix build '.#bin-appimage'         # Linux AppImage
 nix build '.#bin-macos-app'        # macOS .app bundle
-nix build '.#bin-macos-dmg'        # macOS DMG
 nix build '.#logos-qt-mcp'         # QML inspector for testing
 ```
 

--- a/doctests/basecamp-modules-bundle.test.yaml
+++ b/doctests/basecamp-modules-bundle.test.yaml
@@ -207,9 +207,9 @@ sections:
         text: |
           The UI plugins **Settings → Apps Inspector** will list are carried
           under `plugins/` — confirm the package manager UI shipped in the
-          bundle. Basecamp's *own* shell is deliberately NOT here: it is
-          carried as a `main_ui` plugin again — one that links Qt and nothing
-          else, so the assertion below is that `main_ui` is PRESENT.
+          bundle. Basecamp's own shell is carried there too, as a `main_ui`
+          plugin that links Qt and nothing else, so the assertion below is
+          that `main_ui` is PRESENT.
         run: "ls result-bundle/plugins"
         expect_contains:
           - "package_manager_ui"

--- a/flake.nix
+++ b/flake.nix
@@ -105,17 +105,17 @@
     # leaving them alone keeps this build byte-identical to liblogos's own
     # except for the loader rev itself.
     #
-    # Rev-pinned rather than tracking the branch: 06134bfc is the tip of
-    # feat/host-services-grant. Drop the rev once that merges, at which point
-    # liblogos's own lock can carry it and this input can go away.
+    # The rev pin is gone -- feat/host-services-grant merged and this input now
+    # follows master. It is still declared rather than removed because the
+    # `follows` below is load-bearing; once liblogos's own lock carries the same
+    # resolution, the input itself can go away.
     logos-module-loader-qt = {
       url = "github:logos-co/logos-module-loader-qt";
       inputs.logos-protocol.follows = "logos-protocol";
     };
-    # Rev-pinned: f2a15ef3 is the tip of fix/b4-align-protocol-with-qt-host —
-    # the liblogos aligned with the split host runtime and the per-client token
-    # store. liblogos_core.dll's export list (the other half of the Windows
-    # one-copy fix) lands there, not on master.
+    # Follows master. (This input used to be rev-pinned to a branch carrying the
+    # split host runtime and liblogos_core.dll's export list; that landed on
+    # master and the pin was retired, but the comment explaining it outlived it.)
     logos-liblogos = {
       url = "github:logos-co/logos-liblogos";
       inputs.default-module-loader.follows = "logos-module-loader-qt";
@@ -123,32 +123,24 @@
     logos-package-manager.url = "github:logos-co/logos-package-manager";
     logos-package-manager-module.url = "github:logos-co/logos-package-manager-module";
     logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module";
-    # Rev-pinned: 07dba1f is the tip of feat/universal-capability, built against
-    # the new module-builder. Master's capability_module targets the pre-split
-    # runtime and would load a second host copy into this process.
-    #
-    # This was walked back to 0cb33fb (the legacy hand-written Qt plugin) for one
-    # reason: 07dba1f is a UNIVERSAL module that asks the host for the
-    # `token_registry` / `token_delivery` services and fails CLOSED when they do
-    # not arrive, and the loader pinned here could not grant them. That is fixed
-    # above, at logos-module-loader-qt — so the pin returns to the rev the
-    # comment always described.
+    # Follows master. (This input carried a rev pin through the universal-module
+    # transition, walked between 07dba1f and 0cb33fb depending on whether the
+    # loader of the day could grant `token_registry` / `token_delivery` to a
+    # module that fails CLOSED without them. Both sides of that landed on master
+    # and the pin was retired; the history is kept here only because the
+    # fail-closed handshake is the thing to remember if this ever regresses.)
     logos-capability-module.url = "github:logos-co/logos-capability-module";
     logos-package.url = "github:logos-co/logos-package";
-    # Rev-pinned: c932e1c is the tip of feat/universal-view-plugin — the
-    # generated view plugin. This UI is loaded in-process by the app, so it must
-    # come from the same generation as the host runtime above.
-    # Rev-pinned: f135195 is the tip of feat/universal-view-plugin — the
-    # generated view plugin. This UI is loaded in-process by the app, so it must
-    # come from the same generation as the host runtime above.
-    #
-    # f135195 is that branch WITH master merged in. The previous value, c932e1c,
+    # Follows master. (Rev-pinned through the universal-view-plugin transition,
+    # and the pin had to be a merge of that branch with master: the branch alone
     # published packages for the four native systems only, so the cross build
     # failed with "logos-module-builder: dependency 'package_manager' publishes
-    # no packages for x86_64-windows". Master fixed that (#68, a pure lock bump)
-    # but does not carry the view plugin, so tracking master here would trade a
-    # build failure for a runtime mismatch that still looks green. The merge
-    # gives both.
+    # no packages for x86_64-windows", while master alone did not carry the view
+    # plugin and would have traded a build failure for a runtime mismatch that
+    # still looked green. Both landed and the pin was retired. The constraint
+    # that outlives it: this UI is loaded IN-PROCESS by the app, so it must come
+    # from the same generation as the host runtime above.)
+    #
     # `package_manager` and `package_downloader` are the SAME flakes as this
     # root's logos-package-manager-module / logos-package-downloader-module
     # inputs, at the same revs, with identical resolved subtrees -- they are
@@ -396,14 +388,11 @@
             }
           else null;
 
-          # Linux AppImage (only for Linux)
-          appImage = if pkgs.stdenv.isLinux then
-            import ./nix/appimage.nix {
-              inherit pkgs src;
-              app = appDistributed;
-              version = common.version;
-            }
-          else null;
+          # (There is no ./nix/appimage.nix binding here. The shipped AppImage is
+          # the `bin-appimage` output further down, built by nix-bundle-appimage.
+          # A dead `appImage = import ./nix/appimage.nix ...` binding survived
+          # here long after that file was removed, evaluating only because
+          # nothing ever forced it.)
 
           # Self-contained directory bundle: appDistributed modules expect host Qt
           # via @rpath; qtApp copies Qt frameworks into lib/ and rewrites the binary.
@@ -554,7 +543,9 @@
           # A second definition is a second TokenManager and every cross-module
           # call is refused at runtime with no build diagnostic.
           # Build: nix build .#symbol-gate  (CI: the "One-runtime symbol gate"
-          # step in test-linux and test-macos runs this and its negative control)
+          # step in test-linux, test-macos AND build-windows runs this and its
+          # negative control -- Windows being the one where a duplicate is fatal,
+          # since PE has no symbol interposition to collapse it)
           symbol-gate = import ./nix/symbol-gate.nix { inherit pkgs; appPkg = app; };
 
           # Negative control for the above. Plants a REAL duplicate runtime where

--- a/nix/coverage.nix
+++ b/nix/coverage.nix
@@ -12,7 +12,8 @@
 #
 # Scope caveat: gcovr only sees files that were compiled into the test
 # binaries. Sources no unit test links at all (PackageCoordinator,
-# UIPluginManager, PluginLoader, MainContainer, MainUIBackend) produce no
+# UIPluginManager, PluginLoader, MainUIBackend app-side; MainContainer and
+# MainShellView shell-side) produce no
 # .gcno and therefore do NOT appear in the report as 0% — the percentage here
 # is "coverage of the code under unit test", not of all of app/. Adding a
 # source to tests/CMakeLists.txt is what pulls it into the denominator.
@@ -76,11 +77,17 @@ pkgs.stdenv.mkDerivation {
     runHook preInstall
     mkdir -p $out
 
-    # --filter app/ keeps the report to production code (the tests' own
-    # translation units and CMake's *_autogen moc stubs are excluded).
+    # --filter keeps the report to production code (the tests' own translation
+    # units and CMake's *_autogen moc stubs are excluded). BOTH trees are
+    # listed: the shell split moved AppsFilterProxy, ModulesFilterProxy,
+    # InstallEnums, ShortcutBridge and WorkspaceArea into src/, and all five are
+    # still compiled into unit-test binaries via tests/CMakeLists.txt's srcdeps.
+    # With app/ alone their .gcno/.gcda were produced and then discarded, so
+    # four of the ten test binaries contributed nothing to the numbers.
     gcovr \
       --root "$PWD" \
       --filter 'app/' \
+      --filter 'src/' \
       --exclude '.*_autogen.*' \
       --gcov-executable "${gcovExecutable}" \
       --exclude-unreachable-branches \

--- a/tests/shutdown-tests.mjs
+++ b/tests/shutdown-tests.mjs
@@ -3,7 +3,9 @@
 // logos-basecamp shutdown tests
 //
 // Verifies every supported quit gesture actually terminates the process
-// cleanly (exit code 0, via the orderly teardown in app/main.cpp:224-254).
+// cleanly (exit code 0, via the orderly teardown in app/main.cpp -- the
+// block after app.exec() returns, ending in mainWindow.reset() then
+// core.reset(); it has moved twice, so it is named rather than line-numbered).
 //
 // Each test spawns a fresh app instance because triggering shutdown kills
 // the app — the shared-instance model in ui-tests.mjs doesn't fit.


### PR DESCRIPTION
A sweep of documentation and comments that the shell split and the pin retirement made false. No behaviour change **except one dead nix binding**, which is the only item here I would call more than cosmetic.

## The two that are not cosmetic

**`flake.nix` imported a file that does not exist.**

```nix
appImage = if pkgs.stdenv.isLinux then
  import ./nix/appimage.nix { ... }
```

`nix/appimage.nix` is not in the tree. The binding survives only because nix is lazy and nothing forces it — `bin-appimage` is built by `nix-bundle-appimage` instead. Anyone who referenced `appImage` would have hit a file-not-found at eval time. Deleted.

**`app/CMakeLists.txt`'s `logos_core`-last rule lost its justification.** The rule is load-bearing on the mingw link, and its comment explained it by "LogosSharedFromDll.cmake empties the static archives defining those types" — a file deleted in #348, and flatly contradicted by the comment 14 lines below it. The rule stands; only its stated reason was gone, which is exactly how the next person concludes it is vestigial, reorders the line, and gets four undefined references.

## Four stale `Rev-pinned:` blocks

`logos-module-loader-qt`, `logos-liblogos`, `logos-capability-module`, `logos-package-manager-ui`. **None of those inputs carries a `rev` or `ref` any more** — `3c21c1f` retired the pins and left every explanation behind. The `logos-package-manager-ui` one was a *duplicated pair* of near-identical paragraphs describing two different revs of the same dead pin.

Rewritten rather than deleted, because two of them carry constraints that outlive the pin and would be expensive to rediscover: `capability_module` fails **closed** without `token_registry`/`token_delivery`, and `package-manager-ui` is loaded **in-process** so it must match the host runtime's generation.

## `nix/coverage.nix` was reporting on half the codebase

`--filter 'app/'` alone. The split moved `AppsFilterProxy`, `ModulesFilterProxy`, `InstallEnums`, `ShortcutBridge` and `WorkspaceArea` into `src/`, and all five are still compiled into unit-test binaries through `srcdeps` — so their `.gcno`/`.gcda` were produced and then discarded. Four of the ten test binaries contributed nothing to the number published to the CI job summary, and `failUnderLine` could never regress on shell code. `failUnderLine` defaults to `0`, so widening the filter cannot break the build.

## `docs/project.md`

- The `app/` tree listed `LogosQmlBridge.h/cpp`, `mdiview.h/cpp`, `mdichild.h/cpp` and an `app/qml/` subtree of nine QML files. None exists — the QML lives at `src/Basecamp/`. Replaced with the sources actually there.
- The `nix/` listing named `appimage.nix`, `macos-bundle.nix`, `macos-dmg.nix` — none of which exists — and **omitted `symbol-gate.nix`**, which `:193` relies on as the thing enforcing the shell boundary.
- `MainContainer`'s section still said `app/`; `9b8cf6e` recorded `R100` into `src/`. The same commit fixed the tree block 172 lines earlier and left the prose section — so the file stated both locations, and the wrong one is where a reader looking for the class lands. It also said MainContainer creates `MainUIBackend`, which `Window` now owns.
- `LogosQmlBridge`'s section cited `app/` paths for an **external** header that arrives from a flake input's include path.
- `MdiView` / `MdiChild` sections describe classes that no longer exist; the role is `src/WorkspaceArea`.
- Advertised a `.#bin-macos-dmg` output that is defined nowhere (`README.md` already disagreed).

## Two more

- `tests/shutdown-tests.mjs` pointed at `app/main.cpp:224-254` as "the orderly teardown". Those lines are *startup* code. The reference was already wrong when written and has since moved twice, so it now names the block rather than line-numbering it.
- `doctests/basecamp-modules-bundle.test.yaml` read *"Basecamp's own shell is deliberately NOT here: it is carried as a `main_ui` plugin again"* — a fold-era clause left in front of its own replacement, negating the rest of the sentence and the assertion below it. Its twin in `basecamp-modules.test.yaml` was rewritten cleanly.

## Verification

`nix eval` green on both `aarch64-darwin` (`.#app`) and `x86_64-linux` (`.#bin-appimage`) — the relevant check, since deleting the `appImage` binding is the one real code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)