### PR TITLE
fix(deps): one logos-package-downloader in the closure, not two

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -68,11 +68,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786467070,
-        "narHash": "sha256-bJLHdyQBld4AryXbSsKr+jcMf6os4xD+WL97ibdBn3A=",
+        "lastModified": 1787083717,
+        "narHash": "sha256-RUvjm4Imiri8cmSFm1wO4oBGaGiN18vitW+t7gleZWM=",
         "owner": "logos-co",
         "repo": "logos-container-subprocess",
-        "rev": "5c6aefcf4f185c94a92fa1345221c211fde8ef84",
+        "rev": "c6f7ec62792beda0480f8f4a095dbacadd06910a",
         "type": "github"
       },
       "original": {
@@ -84,9 +84,13 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
-        "logos-nix": "logos-nix_266",
+        "logos-nix": "logos-nix_231",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -112,9 +116,9 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
-        "logos-nix": "logos-nix_348",
+        "logos-nix": "logos-nix_351",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -140,10 +144,9 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -169,7 +172,7 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_33",
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_511",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -279,30 +282,12 @@
     "default-module-loader_3": {
       "inputs": {
         "logos-container": "logos-container_14",
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
+        "logos-cpp-sdk": "logos-cpp-sdk_18",
         "logos-module": "logos-module_38",
         "logos-module-loader": "logos-module-loader_6",
-        "logos-nix": "logos-nix_183",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "logos-qt-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk"
-        ],
+        "logos-nix": "logos-nix_184",
+        "logos-protocol": "logos-protocol_30",
+        "logos-qt-sdk": "logos-qt-sdk_13",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -314,11 +299,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787264581,
-        "narHash": "sha256-qqmat4okKyimPdas+X212Ehz+Vp2dT2ZeXBjbjYW/OQ=",
+        "lastModified": 1787668839,
+        "narHash": "sha256-l7Ij/BBc/3MvLRGRr4+D/mcJeRFija0NI4+XGIVLSrI=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "dece0c8aa3b5a29a3457196988d672eda58750d7",
+        "rev": "3e65e088df45bc2c68451933464bfbe3f63f88b1",
         "type": "github"
       },
       "original": {
@@ -331,31 +316,47 @@
       "inputs": {
         "logos-container": "logos-container_19",
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_54",
+        "logos-module": "logos-module_51",
         "logos-module-loader": "logos-module-loader_8",
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_235",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "logos-qt-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -382,31 +383,31 @@
       "inputs": {
         "logos-container": "logos-container_24",
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_70",
+        "logos-module": "logos-module_72",
         "logos-module-loader": "logos-module-loader_10",
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_355",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "logos-qt-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -434,18 +435,16 @@
         "logos-container": "logos-container_29",
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_86",
+        "logos-module": "logos-module_88",
         "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_430",
+        "logos-nix": "logos-nix_437",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -453,7 +452,6 @@
         ],
         "logos-qt-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -461,7 +459,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -495,9 +492,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_102",
+        "logos-module": "logos-module_104",
         "logos-module-loader": "logos-module-loader_14",
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_515",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -604,11 +601,11 @@
         "logos-module-builder": "logos-module-builder_6"
       },
       "locked": {
-        "lastModified": 1787279924,
-        "narHash": "sha256-niJhiT0YeCpI5MUjVp4UimVig6tcmLD1Zlj7dRBhybo=",
+        "lastModified": 1787828910,
+        "narHash": "sha256-HZlJybafxOR8hrVR6xK0HiZkWLKmHZ4byfmky8h/YsQ=",
         "owner": "logos-co",
         "repo": "logos-capability-module",
-        "rev": "973f71badd0c25bcf0c4b51c54f289862d304bab",
+        "rev": "98ff8414d48f702d6e4328bdc599ffeb83d02e06",
         "type": "github"
       },
       "original": {
@@ -919,7 +916,7 @@
     },
     "logos-container_16": {
       "inputs": {
-        "logos-nix": "logos-nix_211",
+        "logos-nix": "logos-nix_215",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -982,7 +979,11 @@
     "logos-container_18": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -990,7 +991,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1016,9 +1021,13 @@
     },
     "logos-container_19": {
       "inputs": {
-        "logos-nix": "logos-nix_267",
+        "logos-nix": "logos-nix_232",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1070,7 +1079,11 @@
     "logos-container_20": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1079,7 +1092,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1106,9 +1123,13 @@
     },
     "logos-container_21": {
       "inputs": {
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_263",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1134,7 +1155,11 @@
     "logos-container_22": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1142,7 +1167,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1169,7 +1198,7 @@
     "logos-container_23": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1177,7 +1206,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1203,9 +1232,9 @@
     },
     "logos-container_24": {
       "inputs": {
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_352",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1232,7 +1261,7 @@
     "logos-container_25": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1241,7 +1270,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1268,9 +1297,9 @@
     },
     "logos-container_26": {
       "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1296,7 +1325,7 @@
     "logos-container_27": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1304,7 +1333,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1332,7 +1361,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1341,7 +1369,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1367,10 +1394,9 @@
     },
     "logos-container_29": {
       "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_434",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1429,7 +1455,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1439,7 +1464,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1466,10 +1490,9 @@
     },
     "logos-container_31": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_465",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1496,7 +1519,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1505,7 +1527,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1568,7 +1589,7 @@
     },
     "logos-container_34": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_512",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1636,7 +1657,7 @@
     },
     "logos-container_36": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -2124,11 +2145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787433464,
-        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2152,11 +2173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2168,7 +2189,44 @@
     "logos-cpp-sdk_18": {
       "inputs": {
         "logos-lidl": "logos-lidl_51",
-        "logos-nix": "logos-nix_184",
+        "logos-nix": "logos-nix_181",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_19": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_53",
+        "logos-nix": "logos-nix_188",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2191,52 +2249,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_19": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_58",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_32",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2281,19 +2298,25 @@
     "logos-cpp-sdk_20": {
       "inputs": {
         "logos-lidl": "logos-lidl_60",
-        "logos-nix": "logos-nix_212",
-        "logos-protocol": [
+        "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-protocol"
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_34",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2315,29 +2338,31 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-lidl": "logos-lidl_66",
-        "logos-nix": [
+        "logos-lidl": "logos-lidl_62",
+        "logos-nix": "logos-nix_216",
+        "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
         ],
-        "logos-protocol": "logos-protocol_37",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2348,15 +2373,23 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-        "logos-lidl": "logos-lidl_68",
-        "logos-nix": "logos-nix_254",
+        "logos-lidl": "logos-lidl_63",
+        "logos-nix": "logos-nix_219",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2379,11 +2412,15 @@
     },
     "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-lidl": "logos-lidl_73",
-        "logos-nix": "logos-nix_265",
-        "logos-protocol": "logos-protocol_41",
+        "logos-lidl": "logos-lidl_68",
+        "logos-nix": "logos-nix_230",
+        "logos-protocol": "logos-protocol_38",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -2407,10 +2444,14 @@
     },
     "logos-cpp-sdk_24": {
       "inputs": {
-        "logos-lidl": "logos-lidl_74",
-        "logos-nix": "logos-nix_271",
+        "logos-lidl": "logos-lidl_69",
+        "logos-nix": "logos-nix_236",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2419,7 +2460,11 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2446,9 +2491,13 @@
     },
     "logos-cpp-sdk_25": {
       "inputs": {
-        "logos-lidl": "logos-lidl_81",
+        "logos-lidl": "logos-lidl_76",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2457,9 +2506,13 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_44",
+        "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2487,17 +2540,25 @@
     },
     "logos-cpp-sdk_26": {
       "inputs": {
-        "logos-lidl": "logos-lidl_83",
-        "logos-nix": "logos-nix_299",
+        "logos-lidl": "logos-lidl_78",
+        "logos-nix": "logos-nix_264",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2522,16 +2583,24 @@
     },
     "logos-cpp-sdk_27": {
       "inputs": {
-        "logos-lidl": "logos-lidl_89",
+        "logos-lidl": "logos-lidl_84",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_49",
+        "logos-protocol": "logos-protocol_46",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2555,27 +2624,47 @@
     },
     "logos-cpp-sdk_28": {
       "inputs": {
-        "logos-lidl": "logos-lidl_91",
-        "logos-nix": "logos-nix_336",
-        "logos-protocol": [
-          "logos-package-manager-ui",
+        "logos-lidl": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787433464,
-        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2586,24 +2675,29 @@
     },
     "logos-cpp-sdk_29": {
       "inputs": {
-        "logos-lidl": "logos-lidl_96",
-        "logos-nix": "logos-nix_347",
-        "logos-protocol": "logos-protocol_53",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+        "logos-lidl": "logos-lidl_91",
+        "logos-nix": [
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_54",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -2639,10 +2733,69 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_97",
-        "logos-nix": "logos-nix_353",
+        "logos-lidl": "logos-lidl_93",
+        "logos-nix": "logos-nix_339",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_31": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_98",
+        "logos-nix": "logos-nix_350",
+        "logos-protocol": "logos-protocol_58",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_32": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_99",
+        "logos-nix": "logos-nix_356",
+        "logos-protocol": [
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2651,7 +2804,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2676,94 +2829,26 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_31": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_104",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_56",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_32": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_106",
-        "logos-nix": "logos-nix_381",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-lidl": "logos-lidl_112",
+        "logos-lidl": "logos-lidl_106",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_61",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2787,29 +2872,31 @@
     },
     "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-lidl": "logos-lidl_114",
-        "logos-nix": "logos-nix_414",
+        "logos-lidl": "logos-lidl_108",
+        "logos-nix": "logos-nix_384",
         "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787270089,
-        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -2820,25 +2907,29 @@
     },
     "logos-cpp-sdk_35": {
       "inputs": {
-        "logos-lidl": "logos-lidl_119",
-        "logos-nix": "logos-nix_425",
-        "logos-protocol": "logos-protocol_64",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+        "logos-lidl": "logos-lidl_114",
+        "logos-nix": [
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_66",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -2849,11 +2940,69 @@
     },
     "logos-cpp-sdk_36": {
       "inputs": {
-        "logos-lidl": "logos-lidl_120",
-        "logos-nix": "logos-nix_431",
+        "logos-lidl": "logos-lidl_116",
+        "logos-nix": "logos-nix_421",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_37": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_121",
+        "logos-nix": "logos-nix_432",
+        "logos-protocol": "logos-protocol_70",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_38": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_122",
+        "logos-nix": "logos-nix_438",
+        "logos-protocol": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2863,7 +3012,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2888,100 +3036,26 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_37": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_127",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_67",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_38": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_129",
-        "logos-nix": "logos-nix_459",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_39": {
       "inputs": {
-        "logos-lidl": "logos-lidl_135",
+        "logos-lidl": "logos-lidl_129",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_72",
+        "logos-protocol": "logos-protocol_73",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3036,8 +3110,76 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
+        "logos-lidl": "logos-lidl_131",
+        "logos-nix": "logos-nix_466",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_41": {
+      "inputs": {
         "logos-lidl": "logos-lidl_137",
-        "logos-nix": "logos-nix_496",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_78",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_42": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_139",
+        "logos-nix": "logos-nix_499",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3067,111 +3209,27 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_41": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_142",
-        "logos-nix": "logos-nix_507",
-        "logos-protocol": "logos-protocol_75",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_42": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_143",
-        "logos-nix": "logos-nix_513",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_43": {
       "inputs": {
-        "logos-lidl": "logos-lidl_150",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_78",
+        "logos-lidl": "logos-lidl_144",
+        "logos-nix": "logos-nix_510",
+        "logos-protocol": "logos-protocol_81",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3182,14 +3240,16 @@
     },
     "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-lidl": "logos-lidl_152",
-        "logos-nix": "logos-nix_541",
+        "logos-lidl": "logos-lidl_145",
+        "logos-nix": "logos-nix_516",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3198,17 +3258,19 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3219,18 +3281,26 @@
     },
     "logos-cpp-sdk_45": {
       "inputs": {
-        "logos-lidl": "logos-lidl_158",
+        "logos-lidl": "logos-lidl_152",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_83",
+        "logos-protocol": "logos-protocol_84",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3253,6 +3323,78 @@
       }
     },
     "logos-cpp-sdk_46": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_154",
+        "logos-nix": "logos-nix_544",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_47": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_160",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_89",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_48": {
       "inputs": {
         "logos-lidl": [
           "logos-qt-sdk",
@@ -3287,14 +3429,14 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_47": {
+    "logos-cpp-sdk_49": {
       "inputs": {
-        "logos-lidl": "logos-lidl_162",
+        "logos-lidl": "logos-lidl_164",
         "logos-nix": [
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_88",
+        "logos-protocol": "logos-protocol_94",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3513,12 +3655,12 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
-        "nix-bundle-appimage": "nix-bundle-appimage_25",
-        "nix-bundle-dir": "nix-bundle-dir_56",
+        "logos-nix": "logos-nix_340",
+        "nix-bundle-appimage": "nix-bundle-appimage_24",
+        "nix-bundle-dir": "nix-bundle-dir_54",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3541,12 +3683,12 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_354",
-        "nix-bundle-appimage": "nix-bundle-appimage_26",
-        "nix-bundle-dir": "nix-bundle-dir_57",
+        "logos-nix": "logos-nix_357",
+        "nix-bundle-appimage": "nix-bundle-appimage_25",
+        "nix-bundle-dir": "nix-bundle-dir_55",
         "nix-bundle-macos-app": "nix-bundle-macos-app_11",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3573,13 +3715,12 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_422",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_68",
         "nix-bundle-macos-app": "nix-bundle-macos-app_12",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3602,13 +3743,12 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_439",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_69",
         "nix-bundle-macos-app": "nix-bundle-macos-app_13",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3635,9 +3775,9 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
-        "nix-bundle-appimage": "nix-bundle-appimage_36",
-        "nix-bundle-dir": "nix-bundle-dir_82",
+        "logos-nix": "logos-nix_500",
+        "nix-bundle-appimage": "nix-bundle-appimage_35",
+        "nix-bundle-dir": "nix-bundle-dir_80",
         "nix-bundle-macos-app": "nix-bundle-macos-app_14",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -3664,9 +3804,9 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
-        "nix-bundle-appimage": "nix-bundle-appimage_37",
-        "nix-bundle-dir": "nix-bundle-dir_83",
+        "logos-nix": "logos-nix_517",
+        "nix-bundle-appimage": "nix-bundle-appimage_36",
+        "nix-bundle-dir": "nix-bundle-dir_81",
         "nix-bundle-macos-app": "nix-bundle-macos-app_15",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -3840,7 +3980,7 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_189",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
         "nix-bundle-dir": "nix-bundle-dir_27",
         "nix-bundle-macos-app": "nix-bundle-macos-app_7",
@@ -3872,12 +4012,16 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_255",
-        "nix-bundle-appimage": "nix-bundle-appimage_19",
-        "nix-bundle-dir": "nix-bundle-dir_42",
+        "logos-nix": "logos-nix_220",
+        "nix-bundle-appimage": "nix-bundle-appimage_15",
+        "nix-bundle-dir": "nix-bundle-dir_32",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3900,12 +4044,16 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_272",
-        "nix-bundle-appimage": "nix-bundle-appimage_20",
-        "nix-bundle-dir": "nix-bundle-dir_43",
+        "logos-nix": "logos-nix_237",
+        "nix-bundle-appimage": "nix-bundle-appimage_16",
+        "nix-bundle-dir": "nix-bundle-dir_33",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4009,16 +4157,59 @@
         "default-module-loader": "default-module-loader_3",
         "logos-capability-module": "logos-capability-module_4",
         "logos-container": "logos-container_16",
-        "logos-cpp-sdk": "logos-cpp-sdk_20",
-        "logos-module": "logos-module_45",
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-module": "logos-module_46",
         "logos-module-loader": "logos-module-loader_7",
-        "logos-nix": "logos-nix_215",
-        "logos-package-manager": "logos-package-manager_8",
-        "logos-plugin-qt": "logos-plugin-qt_27",
-        "logos-protocol": "logos-protocol_34",
-        "logos-qt-sdk": "logos-qt-sdk_15",
+        "logos-modules-state-module": "logos-modules-state-module_2",
+        "logos-nix": "logos-nix_296",
+        "logos-package-manager": "logos-package-manager_11",
+        "logos-plugin-qt": "logos-plugin-qt_38",
+        "logos-protocol": "logos-protocol_49",
+        "logos-qt-sdk": "logos-qt-sdk_21",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_4"
+      },
+      "locked": {
+        "lastModified": 1787829932,
+        "narHash": "sha256-qLE8M1wXH7Ac6kHenPqpD/aKdEAnPQDJOAA0P9422cc=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "e477befff111142f34b4b45b7cbfe487123e72f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_4": {
+      "inputs": {
+        "default-container": "default-container_4",
+        "default-module-loader": "default-module-loader_4",
+        "logos-capability-module": "logos-capability-module_5",
+        "logos-container": "logos-container_21",
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
+        "logos-module": "logos-module_58",
+        "logos-module-loader": "logos-module-loader_9",
+        "logos-nix": "logos-nix_267",
+        "logos-package-manager": "logos-package-manager_9",
+        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-protocol": "logos-protocol_43",
+        "logos-qt-sdk": "logos-qt-sdk_19",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4041,60 +4232,22 @@
         "type": "github"
       }
     },
-    "logos-liblogos_4": {
-      "inputs": {
-        "default-container": "default-container_4",
-        "default-module-loader": "default-module-loader_4",
-        "logos-capability-module": "logos-capability-module_5",
-        "logos-container": "logos-container_21",
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
-        "logos-module": "logos-module_61",
-        "logos-module-loader": "logos-module-loader_9",
-        "logos-nix": "logos-nix_302",
-        "logos-package-manager": "logos-package-manager_12",
-        "logos-plugin-qt": "logos-plugin-qt_37",
-        "logos-protocol": "logos-protocol_46",
-        "logos-qt-sdk": "logos-qt-sdk_20",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix",
-          "nixpkgs"
-        ],
-        "process-stats": "process-stats_4"
-      },
-      "locked": {
-        "lastModified": 1787316686,
-        "narHash": "sha256-FRC6SYKwzoQLkSdiiiJ9Ov8Tn6k6hai33ey4PtjgdUY=",
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "rev": "b2a9a0ba9dca51dc0d96651989fab21cd249c5fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-liblogos",
-        "type": "github"
-      }
-    },
     "logos-liblogos_5": {
       "inputs": {
         "default-container": "default-container_5",
         "default-module-loader": "default-module-loader_5",
         "logos-capability-module": "logos-capability-module_6",
         "logos-container": "logos-container_26",
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
-        "logos-module": "logos-module_77",
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-module": "logos-module_79",
         "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_384",
-        "logos-package-manager": "logos-package-manager_16",
-        "logos-plugin-qt": "logos-plugin-qt_47",
-        "logos-protocol": "logos-protocol_58",
-        "logos-qt-sdk": "logos-qt-sdk_25",
+        "logos-nix": "logos-nix_387",
+        "logos-package-manager": "logos-package-manager_15",
+        "logos-plugin-qt": "logos-plugin-qt_49",
+        "logos-protocol": "logos-protocol_63",
+        "logos-qt-sdk": "logos-qt-sdk_26",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4123,17 +4276,16 @@
         "default-module-loader": "default-module-loader_6",
         "logos-capability-module": "logos-capability-module_7",
         "logos-container": "logos-container_31",
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
-        "logos-module": "logos-module_93",
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-module": "logos-module_95",
         "logos-module-loader": "logos-module-loader_13",
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_469",
         "logos-package-manager": "logos-package-manager_19",
-        "logos-plugin-qt": "logos-plugin-qt_57",
-        "logos-protocol": "logos-protocol_69",
-        "logos-qt-sdk": "logos-qt-sdk_30",
+        "logos-plugin-qt": "logos-plugin-qt_59",
+        "logos-protocol": "logos-protocol_75",
+        "logos-qt-sdk": "logos-qt-sdk_31",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4162,14 +4314,14 @@
         "default-module-loader": "default-module-loader_7",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_36",
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
-        "logos-module": "logos-module_109",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-module": "logos-module_111",
         "logos-module-loader": "logos-module-loader_15",
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_547",
         "logos-package-manager": "logos-package-manager_22",
-        "logos-plugin-qt": "logos-plugin-qt_67",
-        "logos-protocol": "logos-protocol_80",
-        "logos-qt-sdk": "logos-qt-sdk_35",
+        "logos-plugin-qt": "logos-plugin-qt_69",
+        "logos-protocol": "logos-protocol_86",
+        "logos-qt-sdk": "logos-qt-sdk_36",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -4256,7 +4408,85 @@
     "logos-lidl_100": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_101": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_102": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4266,7 +4496,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4292,10 +4522,10 @@
         "type": "github"
       }
     },
-    "logos-lidl_101": {
+    "logos-lidl_103": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4305,7 +4535,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4331,110 +4561,28 @@
         "type": "github"
       }
     },
-    "logos-lidl_102": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_103": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_104": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4457,25 +4605,25 @@
     "logos-lidl_105": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4498,18 +4646,24 @@
     "logos-lidl_106": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -4533,18 +4687,24 @@
     "logos-lidl_107": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -4568,19 +4728,19 @@
     "logos-lidl_108": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4603,16 +4763,18 @@
     "logos-lidl_109": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -4667,17 +4829,19 @@
     "logos-lidl_110": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4700,17 +4864,17 @@
     "logos-lidl_111": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4733,17 +4897,17 @@
     "logos-lidl_112": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4766,17 +4930,17 @@
     "logos-lidl_113": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4799,16 +4963,16 @@
     "logos-lidl_114": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -4816,11 +4980,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -4832,17 +4996,17 @@
     "logos-lidl_115": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4866,27 +5030,25 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -4899,16 +5061,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4932,16 +5092,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -4965,29 +5123,25 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -5031,35 +5185,25 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -5072,24 +5216,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5113,24 +5249,22 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5154,7 +5288,84 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_124": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_125": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5165,7 +5376,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5191,11 +5401,10 @@
         "type": "github"
       }
     },
-    "logos-lidl_124": {
+    "logos-lidl_126": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5206,7 +5415,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5232,116 +5440,28 @@
         "type": "github"
       }
     },
-    "logos-lidl_125": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_126": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_127": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5365,26 +5485,24 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5408,19 +5526,23 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -5470,19 +5592,23 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -5507,20 +5633,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5544,17 +5668,17 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -5579,18 +5703,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5614,18 +5738,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5649,18 +5771,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5684,18 +5804,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5719,15 +5837,15 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -5735,11 +5853,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -5752,16 +5870,16 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5787,25 +5905,25 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -5853,25 +5971,25 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -5886,14 +6004,47 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_142": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5913,74 +6064,31 @@
         "type": "github"
       }
     },
-    "logos-lidl_142": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_143": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -5996,10 +6104,7 @@
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6007,10 +6112,7 @@
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6040,6 +6142,88 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_146": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_147": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6071,7 +6255,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_146": {
+    "logos-lidl_148": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -6112,7 +6296,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_147": {
+    "logos-lidl_149": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -6145,92 +6329,6 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_148": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_149": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6284,8 +6382,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6296,8 +6394,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6327,6 +6425,92 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_152": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_153": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
@@ -6360,80 +6544,6 @@
         "type": "github"
       }
     },
-    "logos-lidl_152": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_153": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_154": {
       "inputs": {
         "logos-nix": [
@@ -6442,7 +6552,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6451,7 +6561,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6478,6 +6588,80 @@
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_156": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_157": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6506,92 +6690,22 @@
         "type": "github"
       }
     },
-    "logos-lidl_156": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_157": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_158": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6617,16 +6731,16 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6684,6 +6798,76 @@
     "logos-lidl_160": {
       "inputs": {
         "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_161": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_162": {
+      "inputs": {
+        "logos-nix": [
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6708,7 +6892,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_161": {
+    "logos-lidl_163": {
       "inputs": {
         "logos-nix": [
           "logos-qt-sdk",
@@ -6735,7 +6919,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_162": {
+    "logos-lidl_164": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -6764,7 +6948,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_163": {
+    "logos-lidl_165": {
       "inputs": {
         "logos-nix": [
           "logos-view-module-runtime",
@@ -8054,11 +8238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8074,8 +8258,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -8084,8 +8267,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8093,11 +8275,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8113,9 +8295,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8123,20 +8304,19 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8154,7 +8334,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8164,18 +8344,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8193,7 +8373,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8203,18 +8383,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8232,7 +8412,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8242,18 +8422,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8271,8 +8451,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8282,19 +8461,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8312,8 +8490,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8323,19 +8500,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8353,8 +8529,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8364,8 +8540,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8394,8 +8570,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8405,8 +8581,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8466,6 +8642,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -8474,6 +8653,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8501,6 +8683,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8509,6 +8694,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8516,11 +8704,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8536,7 +8724,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8544,18 +8732,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8570,25 +8758,31 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8602,26 +8796,32 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8635,26 +8835,32 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8668,26 +8874,32 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8701,15 +8913,62 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_68": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8729,60 +8988,45 @@
         "type": "github"
       }
     },
-    "logos-lidl_68": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_69": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8827,26 +9071,42 @@
     "logos-lidl_70": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8858,26 +9118,42 @@
     "logos-lidl_71": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8889,26 +9165,42 @@
     "logos-lidl_72": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8920,196 +9212,11 @@
     "logos-lidl_73": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_74": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_75": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_76": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_77": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_78": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9119,7 +9226,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9145,10 +9256,14 @@
         "type": "github"
       }
     },
-    "logos-lidl_79": {
+    "logos-lidl_74": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9159,13 +9274,250 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_75": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_76": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_77": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_78": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_79": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9222,24 +9574,26 @@
     "logos-lidl_80": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9263,25 +9617,25 @@
     "logos-lidl_81": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9304,24 +9658,24 @@
     "logos-lidl_82": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9345,19 +9699,25 @@
     "logos-lidl_83": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9380,19 +9740,25 @@
     "logos-lidl_84": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9415,19 +9781,25 @@
     "logos-lidl_85": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9450,16 +9822,18 @@
     "logos-lidl_86": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9467,11 +9841,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9483,28 +9857,30 @@
     "logos-lidl_87": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9516,28 +9892,28 @@
     "logos-lidl_88": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9549,17 +9925,17 @@
     "logos-lidl_89": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9615,17 +9991,17 @@
     "logos-lidl_90": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9648,14 +10024,16 @@
     "logos-lidl_91": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9663,11 +10041,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9679,15 +10057,17 @@
     "logos-lidl_92": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9710,15 +10090,15 @@
     "logos-lidl_93": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9741,15 +10121,15 @@
     "logos-lidl_94": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9772,15 +10152,15 @@
     "logos-lidl_95": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9803,28 +10183,26 @@
     "logos-lidl_96": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9836,34 +10214,26 @@
     "logos-lidl_97": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9875,23 +10245,17 @@
     "logos-lidl_98": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9914,23 +10278,23 @@
     "logos-lidl_99": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10018,17 +10382,17 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-design-system": "logos-design-system_11",
-        "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_356",
+        "logos-module": "logos-module_73",
+        "logos-nix": "logos-nix_359",
         "logos-plugin-core": "logos-plugin-core_9",
-        "logos-plugin-qt": "logos-plugin-qt_43",
-        "logos-protocol": "logos-protocol_54",
-        "logos-qt-sdk": "logos-qt-sdk_23",
+        "logos-plugin-qt": "logos-plugin-qt_45",
+        "logos-protocol": "logos-protocol_59",
+        "logos-qt-sdk": "logos-qt-sdk_24",
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10040,7 +10404,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_17",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_9",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10067,14 +10431,14 @@
     },
     "logos-module-builder_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-design-system": "logos-design-system_12",
-        "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_417",
+        "logos-module": "logos-module_84",
+        "logos-nix": "logos-nix_424",
         "logos-plugin-core": "logos-plugin-core_10",
-        "logos-plugin-qt": "logos-plugin-qt_51",
-        "logos-protocol": "logos-protocol_63",
-        "logos-qt-sdk": "logos-qt-sdk_27",
+        "logos-plugin-qt": "logos-plugin-qt_53",
+        "logos-protocol": "logos-protocol_68",
+        "logos-qt-sdk": "logos-qt-sdk_28",
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
         "logos-test-framework": "logos-test-framework_12",
@@ -10084,7 +10448,6 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_12",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -10092,11 +10455,11 @@
         "rust-overlay": "rust-overlay_12"
       },
       "locked": {
-        "lastModified": 1787365695,
-        "narHash": "sha256-f20KxGSgoll2cvtgxnASooKuZx87Ly9K7p5XtkN0V1Y=",
+        "lastModified": 1787447341,
+        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "352df67cd6cfa441397495876e21b0d5df93d9f6",
+        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
         "type": "github"
       },
       "original": {
@@ -10107,18 +10470,17 @@
     },
     "logos-module-builder_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-design-system": "logos-design-system_13",
-        "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_434",
+        "logos-module": "logos-module_89",
+        "logos-nix": "logos-nix_441",
         "logos-plugin-core": "logos-plugin-core_11",
-        "logos-plugin-qt": "logos-plugin-qt_53",
-        "logos-protocol": "logos-protocol_65",
-        "logos-qt-sdk": "logos-qt-sdk_28",
+        "logos-plugin-qt": "logos-plugin-qt_55",
+        "logos-protocol": "logos-protocol_71",
+        "logos-qt-sdk": "logos-qt-sdk_29",
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10131,7 +10493,6 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_11",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10158,14 +10519,14 @@
     },
     "logos-module-builder_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-design-system": "logos-design-system_14",
-        "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_499",
+        "logos-module": "logos-module_100",
+        "logos-nix": "logos-nix_502",
         "logos-plugin-core": "logos-plugin-core_12",
-        "logos-plugin-qt": "logos-plugin-qt_61",
-        "logos-protocol": "logos-protocol_74",
-        "logos-qt-sdk": "logos-qt-sdk_32",
+        "logos-plugin-qt": "logos-plugin-qt_63",
+        "logos-protocol": "logos-protocol_80",
+        "logos-qt-sdk": "logos-qt-sdk_33",
         "logos-rust-sdk": "logos-rust-sdk_13",
         "logos-standalone-app": "logos-standalone-app_6",
         "logos-test-framework": "logos-test-framework_14",
@@ -10198,14 +10559,14 @@
     },
     "logos-module-builder_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-design-system": "logos-design-system_15",
-        "logos-module": "logos-module_103",
-        "logos-nix": "logos-nix_516",
+        "logos-module": "logos-module_105",
+        "logos-nix": "logos-nix_519",
         "logos-plugin-core": "logos-plugin-core_13",
-        "logos-plugin-qt": "logos-plugin-qt_63",
-        "logos-protocol": "logos-protocol_76",
-        "logos-qt-sdk": "logos-qt-sdk_33",
+        "logos-plugin-qt": "logos-plugin-qt_65",
+        "logos-protocol": "logos-protocol_82",
+        "logos-qt-sdk": "logos-qt-sdk_34",
         "logos-rust-sdk": "logos-rust-sdk_14",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -10414,25 +10775,25 @@
         "logos-qt-sdk": "logos-qt-sdk_12",
         "logos-rust-sdk": "logos-rust-sdk_5",
         "logos-standalone-app": "logos-standalone-app_2",
-        "logos-test-framework": "logos-test-framework_6",
-        "logos-view-module": "logos-view-module_6",
-        "logos-view-module-runtime": "logos-view-module-runtime_6",
-        "nix-bundle-lgx": "nix-bundle-lgx_11",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_6",
+        "logos-test-framework": "logos-test-framework_8",
+        "logos-view-module": "logos-view-module_8",
+        "logos-view-module-runtime": "logos-view-module-runtime_8",
+        "nix-bundle-lgx": "nix-bundle-lgx_15",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_8",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_6"
+        "rust-overlay": "rust-overlay_8"
       },
       "locked": {
-        "lastModified": 1787447341,
-        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
+        "lastModified": 1787831749,
+        "narHash": "sha256-pNS997L9U9rX01/xKTBEHQUGN1vNtI6UXZ0f+XAAzBA=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
+        "rev": "2c51ff366f9118b21653d74f208bd000841d96e2",
         "type": "github"
       },
       "original": {
@@ -10443,14 +10804,14 @@
     },
     "logos-module-builder_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-design-system": "logos-design-system_7",
-        "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_187",
+        "logos-module": "logos-module_40",
+        "logos-nix": "logos-nix_191",
         "logos-plugin-core": "logos-plugin-core_5",
-        "logos-plugin-qt": "logos-plugin-qt_23",
-        "logos-protocol": "logos-protocol_30",
-        "logos-qt-sdk": "logos-qt-sdk_13",
+        "logos-plugin-qt": "logos-plugin-qt_24",
+        "logos-protocol": "logos-protocol_31",
+        "logos-qt-sdk": "logos-qt-sdk_14",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -10477,11 +10838,11 @@
         "rust-overlay": "rust-overlay_5"
       },
       "locked": {
-        "lastModified": 1787211948,
-        "narHash": "sha256-Ijr7Vz2ISDdOhJT80rL9eDNkBPbf9522IMk0LEb3n/w=",
+        "lastModified": 1787828214,
+        "narHash": "sha256-jrGy7Uf+ZR/k/AyCfybokj0Mvrixv6NMWootr9PJvhA=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "378bdba4ed633c79555b50aad22233c42f4f32e7",
+        "rev": "a0e9f3d8893ab7a61bd5ee5e941f3921ac1d2355",
         "type": "github"
       },
       "original": {
@@ -10494,33 +10855,37 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-design-system": "logos-design-system_8",
-        "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_257",
+        "logos-module": "logos-module_47",
+        "logos-nix": "logos-nix_222",
         "logos-plugin-core": "logos-plugin-core_6",
-        "logos-plugin-qt": "logos-plugin-qt_31",
-        "logos-protocol": "logos-protocol_39",
-        "logos-qt-sdk": "logos-qt-sdk_17",
+        "logos-plugin-qt": "logos-plugin-qt_28",
+        "logos-protocol": "logos-protocol_36",
+        "logos-qt-sdk": "logos-qt-sdk_16",
         "logos-rust-sdk": "logos-rust-sdk_7",
         "logos-standalone-app": "logos-standalone-app_3",
-        "logos-test-framework": "logos-test-framework_8",
-        "logos-view-module": "logos-view-module_8",
-        "logos-view-module-runtime": "logos-view-module-runtime_8",
-        "nix-bundle-lgx": "nix-bundle-lgx_15",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_8",
+        "logos-test-framework": "logos-test-framework_7",
+        "logos-view-module": "logos-view-module_7",
+        "logos-view-module-runtime": "logos-view-module-runtime_7",
+        "nix-bundle-lgx": "nix-bundle-lgx_13",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_8"
+        "rust-overlay": "rust-overlay_7"
       },
       "locked": {
-        "lastModified": 1787680752,
-        "narHash": "sha256-WAtpLO5o4XO9aiF1mjq6eq69selq7vm6qXel6BGk7iI=",
+        "lastModified": 1787752231,
+        "narHash": "sha256-JoiJB06qUeCP3xlDspf6ra2eL7clpbiGnAeyYpgvtmA=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "b06c287b20bb538a952e6f44efbf07d0ce973701",
+        "rev": "464a75d95f3d4e5d1121437480f608ec0a798499",
         "type": "github"
       },
       "original": {
@@ -10533,27 +10898,35 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_24",
         "logos-design-system": "logos-design-system_9",
-        "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_274",
+        "logos-module": "logos-module_52",
+        "logos-nix": "logos-nix_239",
         "logos-plugin-core": "logos-plugin-core_7",
-        "logos-plugin-qt": "logos-plugin-qt_33",
-        "logos-protocol": "logos-protocol_42",
-        "logos-qt-sdk": "logos-qt-sdk_18",
+        "logos-plugin-qt": "logos-plugin-qt_30",
+        "logos-protocol": "logos-protocol_39",
+        "logos-qt-sdk": "logos-qt-sdk_17",
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module"
         ],
-        "logos-test-framework": "logos-test-framework_7",
-        "logos-view-module": "logos-view-module_7",
-        "logos-view-module-runtime": "logos-view-module-runtime_7",
-        "nix-bundle-lgx": "nix-bundle-lgx_13",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
+        "logos-test-framework": "logos-test-framework_6",
+        "logos-view-module": "logos-view-module_6",
+        "logos-view-module-runtime": "logos-view-module-runtime_6",
+        "nix-bundle-lgx": "nix-bundle-lgx_11",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_6",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10562,7 +10935,7 @@
           "logos-nix",
           "nixpkgs"
         ],
-        "rust-overlay": "rust-overlay_7"
+        "rust-overlay": "rust-overlay_6"
       },
       "locked": {
         "lastModified": 1787211948,
@@ -10580,14 +10953,14 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-design-system": "logos-design-system_10",
-        "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_339",
+        "logos-module": "logos-module_68",
+        "logos-nix": "logos-nix_342",
         "logos-plugin-core": "logos-plugin-core_8",
-        "logos-plugin-qt": "logos-plugin-qt_41",
-        "logos-protocol": "logos-protocol_51",
-        "logos-qt-sdk": "logos-qt-sdk_22",
+        "logos-plugin-qt": "logos-plugin-qt_43",
+        "logos-protocol": "logos-protocol_56",
+        "logos-qt-sdk": "logos-qt-sdk_23",
         "logos-rust-sdk": "logos-rust-sdk_9",
         "logos-standalone-app": "logos-standalone-app_4",
         "logos-test-framework": "logos-test-framework_10",
@@ -10596,7 +10969,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_19",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_10",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -10604,11 +10977,11 @@
         "rust-overlay": "rust-overlay_10"
       },
       "locked": {
-        "lastModified": 1787447341,
-        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
+        "lastModified": 1787680752,
+        "narHash": "sha256-WAtpLO5o4XO9aiF1mjq6eq69selq7vm6qXel6BGk7iI=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
+        "rev": "b06c287b20bb538a952e6f44efbf07d0ce973701",
         "type": "github"
       },
       "original": {
@@ -10675,9 +11048,9 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_354",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10704,9 +11077,9 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10732,10 +11105,9 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10762,10 +11134,9 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10791,7 +11162,7 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -10821,7 +11192,7 @@
     "logos-module-loader_15": {
       "inputs": {
         "logos-container": "logos-container_37",
-        "logos-nix": "logos-nix_543",
+        "logos-nix": "logos-nix_546",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -10957,7 +11328,7 @@
     "logos-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_15",
-        "logos-nix": "logos-nix_182",
+        "logos-nix": "logos-nix_183",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -10986,7 +11357,7 @@
     "logos-module-loader_7": {
       "inputs": {
         "logos-container": "logos-container_17",
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_218",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -11014,9 +11385,13 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
-        "logos-nix": "logos-nix_269",
+        "logos-nix": "logos-nix_234",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11043,9 +11418,13 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
-        "logos-nix": "logos-nix_301",
+        "logos-nix": "logos-nix_266",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11098,7 +11477,60 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": "logos-nix_501",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_101": {
+      "inputs": {
+        "logos-nix": "logos-nix_503",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_102": {
+      "inputs": {
+        "logos-nix": "logos-nix_505",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11123,9 +11555,9 @@
         "type": "github"
       }
     },
-    "logos-module_101": {
+    "logos-module_103": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_509",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11151,9 +11583,9 @@
         "type": "github"
       }
     },
-    "logos-module_102": {
+    "logos-module_104": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_513",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11180,9 +11612,9 @@
         "type": "github"
       }
     },
-    "logos-module_103": {
+    "logos-module_105": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
+        "logos-nix": "logos-nix_518",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11210,9 +11642,9 @@
         "type": "github"
       }
     },
-    "logos-module_104": {
+    "logos-module_106": {
       "inputs": {
-        "logos-nix": "logos-nix_517",
+        "logos-nix": "logos-nix_520",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11241,9 +11673,9 @@
         "type": "github"
       }
     },
-    "logos-module_105": {
+    "logos-module_107": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11272,9 +11704,9 @@
         "type": "github"
       }
     },
-    "logos-module_106": {
+    "logos-module_108": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11304,9 +11736,9 @@
         "type": "github"
       }
     },
-    "logos-module_107": {
+    "logos-module_109": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_528",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11317,66 +11749,6 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_108": {
-      "inputs": {
-        "logos-nix": "logos-nix_527",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_109": {
-      "inputs": {
-        "logos-nix": "logos-nix_542",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -11424,7 +11796,67 @@
     },
     "logos-module_110": {
       "inputs": {
-        "logos-nix": "logos-nix_550",
+        "logos-nix": "logos-nix_530",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_111": {
+      "inputs": {
+        "logos-nix": "logos-nix_545",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_112": {
+      "inputs": {
+        "logos-nix": "logos-nix_553",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11451,9 +11883,9 @@
         "type": "github"
       }
     },
-    "logos-module_111": {
+    "logos-module_113": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11479,9 +11911,9 @@
         "type": "github"
       }
     },
-    "logos-module_112": {
+    "logos-module_114": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_561",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11507,9 +11939,9 @@
         "type": "github"
       }
     },
-    "logos-module_113": {
+    "logos-module_115": {
       "inputs": {
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -11535,9 +11967,9 @@
         "type": "github"
       }
     },
-    "logos-module_114": {
+    "logos-module_116": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_581",
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-module",
@@ -11559,9 +11991,9 @@
         "type": "github"
       }
     },
-    "logos-module_115": {
+    "logos-module_117": {
       "inputs": {
-        "logos-nix": "logos-nix_583",
+        "logos-nix": "logos-nix_586",
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -11584,9 +12016,9 @@
         "type": "github"
       }
     },
-    "logos-module_116": {
+    "logos-module_118": {
       "inputs": {
-        "logos-nix": "logos-nix_585",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -12365,7 +12797,7 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_182",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -12393,14 +12825,15 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_186",
+        "logos-nix": "logos-nix_187",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12449,7 +12882,7 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -12457,7 +12890,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12479,7 +12911,7 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_190",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -12487,7 +12919,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12517,7 +12949,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -12540,7 +12971,7 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -12548,7 +12979,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -12571,7 +13002,38 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_200",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_202",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -12600,42 +13062,14 @@
         "type": "github"
       }
     },
-    "logos-module_45": {
-      "inputs": {
-        "logos-nix": "logos-nix_213",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_217",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12657,12 +13091,14 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_221",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12684,12 +13120,15 @@
     },
     "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_229",
+        "logos-nix": "logos-nix_223",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12711,11 +13150,14 @@
     },
     "logos-module_49": {
       "inputs": {
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_225",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -12765,86 +13207,13 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_51": {
-      "inputs": {
-        "logos-nix": "logos-nix_258",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_260",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_53": {
-      "inputs": {
-        "logos-nix": "logos-nix_264",
-        "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -12867,11 +13236,15 @@
         "type": "github"
       }
     },
-    "logos-module_54": {
+    "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_268",
+        "logos-nix": "logos-nix_233",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12895,11 +13268,15 @@
         "type": "github"
       }
     },
-    "logos-module_55": {
+    "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_238",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12924,11 +13301,15 @@
         "type": "github"
       }
     },
-    "logos-module_56": {
+    "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_275",
+        "logos-nix": "logos-nix_240",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12954,11 +13335,15 @@
         "type": "github"
       }
     },
-    "logos-module_57": {
+    "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
+        "logos-nix": "logos-nix_242",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12984,11 +13369,15 @@
         "type": "github"
       }
     },
-    "logos-module_58": {
+    "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_246",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13015,17 +13404,119 @@
         "type": "github"
       }
     },
-    "logos-module_59": {
+    "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_248",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_250",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_265",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_273",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -13075,15 +13566,15 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -13106,91 +13597,13 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
+        "logos-nix": "logos-nix_281",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_308",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_63": {
-      "inputs": {
-        "logos-nix": "logos-nix_313",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_64": {
-      "inputs": {
-        "logos-nix": "logos-nix_316",
-        "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -13213,11 +13626,15 @@
         "type": "github"
       }
     },
-    "logos-module_65": {
+    "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -13240,12 +13657,98 @@
         "type": "github"
       }
     },
+    "logos-module_63": {
+      "inputs": {
+        "logos-nix": "logos-nix_302",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_64": {
+      "inputs": {
+        "logos-nix": "logos-nix_306",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_65": {
+      "inputs": {
+        "logos-nix": "logos-nix_309",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_314",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13267,11 +13770,12 @@
     },
     "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_316",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13293,11 +13797,10 @@
     },
     "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_341",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13319,12 +13822,11 @@
     },
     "logos-module_69": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_343",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13371,9 +13873,62 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_345",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_71": {
+      "inputs": {
+        "logos-nix": "logos-nix_349",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_72": {
+      "inputs": {
+        "logos-nix": "logos-nix_353",
+        "nixpkgs": [
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13397,11 +13952,11 @@
         "type": "github"
       }
     },
-    "logos-module_71": {
+    "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_358",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13426,11 +13981,11 @@
         "type": "github"
       }
     },
-    "logos-module_72": {
+    "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_360",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13456,11 +14011,11 @@
         "type": "github"
       }
     },
-    "logos-module_73": {
+    "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_362",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13486,11 +14041,11 @@
         "type": "github"
       }
     },
-    "logos-module_74": {
+    "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13517,11 +14072,11 @@
         "type": "github"
       }
     },
-    "logos-module_75": {
+    "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_368",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13548,11 +14103,11 @@
         "type": "github"
       }
     },
-    "logos-module_76": {
+    "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_370",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -13579,69 +14134,14 @@
         "type": "github"
       }
     },
-    "logos-module_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_382",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_78": {
-      "inputs": {
-        "logos-nix": "logos-nix_390",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_385",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13690,11 +14190,12 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_393",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -13717,11 +14218,11 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_398",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -13744,11 +14245,12 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_416",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13770,12 +14272,12 @@
     },
     "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_418",
+        "logos-nix": "logos-nix_403",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13797,12 +14299,10 @@
     },
     "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13824,13 +14324,11 @@
     },
     "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_424",
+        "logos-nix": "logos-nix_425",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13852,14 +14350,11 @@
     },
     "logos-module_86": {
       "inputs": {
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13881,15 +14376,12 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_431",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13914,13 +14406,10 @@
         "logos-nix": "logos-nix_435",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13942,16 +14431,14 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
+        "logos-nix": "logos-nix_440",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -13999,10 +14486,69 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_441",
+        "logos-nix": "logos-nix_442",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_444",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_92": {
+      "inputs": {
+        "logos-nix": "logos-nix_448",
+        "nixpkgs": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -14029,12 +14575,11 @@
         "type": "github"
       }
     },
-    "logos-module_91": {
+    "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_450",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -14061,75 +14606,17 @@
         "type": "github"
       }
     },
-    "logos-module_92": {
+    "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_452",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_93": {
-      "inputs": {
-        "logos-nix": "logos-nix_460",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_94": {
-      "inputs": {
-        "logos-nix": "logos-nix_468",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -14152,13 +14639,12 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_473",
+        "logos-nix": "logos-nix_467",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -14180,12 +14666,12 @@
     },
     "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_476",
+        "logos-nix": "logos-nix_475",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -14208,12 +14694,11 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_480",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -14236,11 +14721,12 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_483",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -14262,12 +14748,12 @@
     },
     "logos-module_99": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_485",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -14290,6 +14776,24 @@
     "logos-modules-state-module": {
       "inputs": {
         "logos-module-builder": "logos-module-builder_3"
+      },
+      "locked": {
+        "lastModified": 1787794574,
+        "narHash": "sha256-wDjH3pE/72LK5DeK7l8Kl4m16ngUqFRebhvGa55sY0U=",
+        "owner": "logos-co",
+        "repo": "logos-modules-state-module",
+        "rev": "2370bcb11a46f1c7929864cbb699ec9fb8ce79e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-modules-state-module",
+        "type": "github"
+      }
+    },
+    "logos-modules-state-module_2": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_7"
       },
       "locked": {
         "lastModified": 1787794574,
@@ -15805,11 +16309,11 @@
         "nixpkgs-windows": "nixpkgs-windows_157"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -16071,11 +16575,11 @@
         "nixpkgs-windows": "nixpkgs-windows_170"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16090,11 +16594,11 @@
         "nixpkgs-windows": "nixpkgs-windows_171"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -16242,11 +16746,11 @@
         "nixpkgs-windows": "nixpkgs-windows_178"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -16542,43 +17046,7 @@
     },
     "logos-nix_205": {
       "inputs": {
-        "nixpkgs": "nixpkgs_205"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_206": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_206"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_207": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_207",
+        "nixpkgs": "nixpkgs_205",
         "nixpkgs-windows": "nixpkgs-windows_192"
       },
       "locked": {
@@ -16595,10 +17063,48 @@
         "type": "github"
       }
     },
+    "logos-nix_206": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_206",
+        "nixpkgs-windows": "nixpkgs-windows_193"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_207": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_207",
+        "nixpkgs-windows": "nixpkgs-windows_194"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_208": {
       "inputs": {
         "nixpkgs": "nixpkgs_208",
-        "nixpkgs-windows": "nixpkgs-windows_193"
+        "nixpkgs-windows": "nixpkgs-windows_195"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16616,15 +17122,14 @@
     },
     "logos-nix_209": {
       "inputs": {
-        "nixpkgs": "nixpkgs_209",
-        "nixpkgs-windows": "nixpkgs-windows_194"
+        "nixpkgs": "nixpkgs_209"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -16654,15 +17159,14 @@
     },
     "logos-nix_210": {
       "inputs": {
-        "nixpkgs": "nixpkgs_210",
-        "nixpkgs-windows": "nixpkgs-windows_195"
+        "nixpkgs": "nixpkgs_210"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16806,14 +17310,15 @@
     },
     "logos-nix_218": {
       "inputs": {
-        "nixpkgs": "nixpkgs_218"
+        "nixpkgs": "nixpkgs_218",
+        "nixpkgs-windows": "nixpkgs-windows_203"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16824,14 +17329,15 @@
     },
     "logos-nix_219": {
       "inputs": {
-        "nixpkgs": "nixpkgs_219"
+        "nixpkgs": "nixpkgs_219",
+        "nixpkgs-windows": "nixpkgs-windows_204"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16861,7 +17367,7 @@
     "logos-nix_220": {
       "inputs": {
         "nixpkgs": "nixpkgs_220",
-        "nixpkgs-windows": "nixpkgs-windows_203"
+        "nixpkgs-windows": "nixpkgs-windows_205"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16880,7 +17386,7 @@
     "logos-nix_221": {
       "inputs": {
         "nixpkgs": "nixpkgs_221",
-        "nixpkgs-windows": "nixpkgs-windows_204"
+        "nixpkgs-windows": "nixpkgs-windows_206"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16899,7 +17405,7 @@
     "logos-nix_222": {
       "inputs": {
         "nixpkgs": "nixpkgs_222",
-        "nixpkgs-windows": "nixpkgs-windows_205"
+        "nixpkgs-windows": "nixpkgs-windows_207"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16918,7 +17424,7 @@
     "logos-nix_223": {
       "inputs": {
         "nixpkgs": "nixpkgs_223",
-        "nixpkgs-windows": "nixpkgs-windows_206"
+        "nixpkgs-windows": "nixpkgs-windows_208"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16937,7 +17443,7 @@
     "logos-nix_224": {
       "inputs": {
         "nixpkgs": "nixpkgs_224",
-        "nixpkgs-windows": "nixpkgs-windows_207"
+        "nixpkgs-windows": "nixpkgs-windows_209"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16956,14 +17462,14 @@
     "logos-nix_225": {
       "inputs": {
         "nixpkgs": "nixpkgs_225",
-        "nixpkgs-windows": "nixpkgs-windows_208"
+        "nixpkgs-windows": "nixpkgs-windows_210"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16975,7 +17481,7 @@
     "logos-nix_226": {
       "inputs": {
         "nixpkgs": "nixpkgs_226",
-        "nixpkgs-windows": "nixpkgs-windows_209"
+        "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16993,14 +17499,15 @@
     },
     "logos-nix_227": {
       "inputs": {
-        "nixpkgs": "nixpkgs_227"
+        "nixpkgs": "nixpkgs_227",
+        "nixpkgs-windows": "nixpkgs-windows_212"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17012,7 +17519,7 @@
     "logos-nix_228": {
       "inputs": {
         "nixpkgs": "nixpkgs_228",
-        "nixpkgs-windows": "nixpkgs-windows_210"
+        "nixpkgs-windows": "nixpkgs-windows_213"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17031,7 +17538,7 @@
     "logos-nix_229": {
       "inputs": {
         "nixpkgs": "nixpkgs_229",
-        "nixpkgs-windows": "nixpkgs-windows_211"
+        "nixpkgs-windows": "nixpkgs-windows_214"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17068,7 +17575,7 @@
     "logos-nix_230": {
       "inputs": {
         "nixpkgs": "nixpkgs_230",
-        "nixpkgs-windows": "nixpkgs-windows_212"
+        "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17087,7 +17594,7 @@
     "logos-nix_231": {
       "inputs": {
         "nixpkgs": "nixpkgs_231",
-        "nixpkgs-windows": "nixpkgs-windows_213"
+        "nixpkgs-windows": "nixpkgs-windows_216"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17106,7 +17613,7 @@
     "logos-nix_232": {
       "inputs": {
         "nixpkgs": "nixpkgs_232",
-        "nixpkgs-windows": "nixpkgs-windows_214"
+        "nixpkgs-windows": "nixpkgs-windows_217"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17125,7 +17632,7 @@
     "logos-nix_233": {
       "inputs": {
         "nixpkgs": "nixpkgs_233",
-        "nixpkgs-windows": "nixpkgs-windows_215"
+        "nixpkgs-windows": "nixpkgs-windows_218"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17144,7 +17651,7 @@
     "logos-nix_234": {
       "inputs": {
         "nixpkgs": "nixpkgs_234",
-        "nixpkgs-windows": "nixpkgs-windows_216"
+        "nixpkgs-windows": "nixpkgs-windows_219"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17163,14 +17670,14 @@
     "logos-nix_235": {
       "inputs": {
         "nixpkgs": "nixpkgs_235",
-        "nixpkgs-windows": "nixpkgs-windows_217"
+        "nixpkgs-windows": "nixpkgs-windows_220"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -17182,7 +17689,7 @@
     "logos-nix_236": {
       "inputs": {
         "nixpkgs": "nixpkgs_236",
-        "nixpkgs-windows": "nixpkgs-windows_218"
+        "nixpkgs-windows": "nixpkgs-windows_221"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17201,7 +17708,7 @@
     "logos-nix_237": {
       "inputs": {
         "nixpkgs": "nixpkgs_237",
-        "nixpkgs-windows": "nixpkgs-windows_219"
+        "nixpkgs-windows": "nixpkgs-windows_222"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17219,14 +17726,15 @@
     },
     "logos-nix_238": {
       "inputs": {
-        "nixpkgs": "nixpkgs_238"
+        "nixpkgs": "nixpkgs_238",
+        "nixpkgs-windows": "nixpkgs-windows_223"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17237,14 +17745,15 @@
     },
     "logos-nix_239": {
       "inputs": {
-        "nixpkgs": "nixpkgs_239"
+        "nixpkgs": "nixpkgs_239",
+        "nixpkgs-windows": "nixpkgs-windows_224"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17275,7 +17784,7 @@
     "logos-nix_240": {
       "inputs": {
         "nixpkgs": "nixpkgs_240",
-        "nixpkgs-windows": "nixpkgs-windows_220"
+        "nixpkgs-windows": "nixpkgs-windows_225"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17294,7 +17803,7 @@
     "logos-nix_241": {
       "inputs": {
         "nixpkgs": "nixpkgs_241",
-        "nixpkgs-windows": "nixpkgs-windows_221"
+        "nixpkgs-windows": "nixpkgs-windows_226"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17313,7 +17822,7 @@
     "logos-nix_242": {
       "inputs": {
         "nixpkgs": "nixpkgs_242",
-        "nixpkgs-windows": "nixpkgs-windows_222"
+        "nixpkgs-windows": "nixpkgs-windows_227"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17332,7 +17841,7 @@
     "logos-nix_243": {
       "inputs": {
         "nixpkgs": "nixpkgs_243",
-        "nixpkgs-windows": "nixpkgs-windows_223"
+        "nixpkgs-windows": "nixpkgs-windows_228"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17351,7 +17860,7 @@
     "logos-nix_244": {
       "inputs": {
         "nixpkgs": "nixpkgs_244",
-        "nixpkgs-windows": "nixpkgs-windows_224"
+        "nixpkgs-windows": "nixpkgs-windows_229"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17370,7 +17879,7 @@
     "logos-nix_245": {
       "inputs": {
         "nixpkgs": "nixpkgs_245",
-        "nixpkgs-windows": "nixpkgs-windows_225"
+        "nixpkgs-windows": "nixpkgs-windows_230"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17388,14 +17897,15 @@
     },
     "logos-nix_246": {
       "inputs": {
-        "nixpkgs": "nixpkgs_246"
+        "nixpkgs": "nixpkgs_246",
+        "nixpkgs-windows": "nixpkgs-windows_231"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17406,14 +17916,15 @@
     },
     "logos-nix_247": {
       "inputs": {
-        "nixpkgs": "nixpkgs_247"
+        "nixpkgs": "nixpkgs_247",
+        "nixpkgs-windows": "nixpkgs-windows_232"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17425,7 +17936,7 @@
     "logos-nix_248": {
       "inputs": {
         "nixpkgs": "nixpkgs_248",
-        "nixpkgs-windows": "nixpkgs-windows_226"
+        "nixpkgs-windows": "nixpkgs-windows_233"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17444,7 +17955,7 @@
     "logos-nix_249": {
       "inputs": {
         "nixpkgs": "nixpkgs_249",
-        "nixpkgs-windows": "nixpkgs-windows_227"
+        "nixpkgs-windows": "nixpkgs-windows_234"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17482,7 +17993,7 @@
     "logos-nix_250": {
       "inputs": {
         "nixpkgs": "nixpkgs_250",
-        "nixpkgs-windows": "nixpkgs-windows_228"
+        "nixpkgs-windows": "nixpkgs-windows_235"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17500,14 +18011,15 @@
     },
     "logos-nix_251": {
       "inputs": {
-        "nixpkgs": "nixpkgs_251"
+        "nixpkgs": "nixpkgs_251",
+        "nixpkgs-windows": "nixpkgs-windows_236"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17518,14 +18030,15 @@
     },
     "logos-nix_252": {
       "inputs": {
-        "nixpkgs": "nixpkgs_252"
+        "nixpkgs": "nixpkgs_252",
+        "nixpkgs-windows": "nixpkgs-windows_237"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17537,7 +18050,7 @@
     "logos-nix_253": {
       "inputs": {
         "nixpkgs": "nixpkgs_253",
-        "nixpkgs-windows": "nixpkgs-windows_229"
+        "nixpkgs-windows": "nixpkgs-windows_238"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17556,7 +18069,7 @@
     "logos-nix_254": {
       "inputs": {
         "nixpkgs": "nixpkgs_254",
-        "nixpkgs-windows": "nixpkgs-windows_230"
+        "nixpkgs-windows": "nixpkgs-windows_239"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17575,7 +18088,7 @@
     "logos-nix_255": {
       "inputs": {
         "nixpkgs": "nixpkgs_255",
-        "nixpkgs-windows": "nixpkgs-windows_231"
+        "nixpkgs-windows": "nixpkgs-windows_240"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17594,7 +18107,7 @@
     "logos-nix_256": {
       "inputs": {
         "nixpkgs": "nixpkgs_256",
-        "nixpkgs-windows": "nixpkgs-windows_232"
+        "nixpkgs-windows": "nixpkgs-windows_241"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17612,15 +18125,14 @@
     },
     "logos-nix_257": {
       "inputs": {
-        "nixpkgs": "nixpkgs_257",
-        "nixpkgs-windows": "nixpkgs-windows_233"
+        "nixpkgs": "nixpkgs_257"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17631,15 +18143,14 @@
     },
     "logos-nix_258": {
       "inputs": {
-        "nixpkgs": "nixpkgs_258",
-        "nixpkgs-windows": "nixpkgs-windows_234"
+        "nixpkgs": "nixpkgs_258"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17651,7 +18162,7 @@
     "logos-nix_259": {
       "inputs": {
         "nixpkgs": "nixpkgs_259",
-        "nixpkgs-windows": "nixpkgs-windows_235"
+        "nixpkgs-windows": "nixpkgs-windows_242"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17689,7 +18200,7 @@
     "logos-nix_260": {
       "inputs": {
         "nixpkgs": "nixpkgs_260",
-        "nixpkgs-windows": "nixpkgs-windows_236"
+        "nixpkgs-windows": "nixpkgs-windows_243"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17708,7 +18219,7 @@
     "logos-nix_261": {
       "inputs": {
         "nixpkgs": "nixpkgs_261",
-        "nixpkgs-windows": "nixpkgs-windows_237"
+        "nixpkgs-windows": "nixpkgs-windows_244"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17727,7 +18238,7 @@
     "logos-nix_262": {
       "inputs": {
         "nixpkgs": "nixpkgs_262",
-        "nixpkgs-windows": "nixpkgs-windows_238"
+        "nixpkgs-windows": "nixpkgs-windows_245"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17746,7 +18257,7 @@
     "logos-nix_263": {
       "inputs": {
         "nixpkgs": "nixpkgs_263",
-        "nixpkgs-windows": "nixpkgs-windows_239"
+        "nixpkgs-windows": "nixpkgs-windows_246"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17765,7 +18276,7 @@
     "logos-nix_264": {
       "inputs": {
         "nixpkgs": "nixpkgs_264",
-        "nixpkgs-windows": "nixpkgs-windows_240"
+        "nixpkgs-windows": "nixpkgs-windows_247"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17784,7 +18295,7 @@
     "logos-nix_265": {
       "inputs": {
         "nixpkgs": "nixpkgs_265",
-        "nixpkgs-windows": "nixpkgs-windows_241"
+        "nixpkgs-windows": "nixpkgs-windows_248"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17803,7 +18314,7 @@
     "logos-nix_266": {
       "inputs": {
         "nixpkgs": "nixpkgs_266",
-        "nixpkgs-windows": "nixpkgs-windows_242"
+        "nixpkgs-windows": "nixpkgs-windows_249"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17822,7 +18333,7 @@
     "logos-nix_267": {
       "inputs": {
         "nixpkgs": "nixpkgs_267",
-        "nixpkgs-windows": "nixpkgs-windows_243"
+        "nixpkgs-windows": "nixpkgs-windows_250"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17841,7 +18352,7 @@
     "logos-nix_268": {
       "inputs": {
         "nixpkgs": "nixpkgs_268",
-        "nixpkgs-windows": "nixpkgs-windows_244"
+        "nixpkgs-windows": "nixpkgs-windows_251"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17860,7 +18371,7 @@
     "logos-nix_269": {
       "inputs": {
         "nixpkgs": "nixpkgs_269",
-        "nixpkgs-windows": "nixpkgs-windows_245"
+        "nixpkgs-windows": "nixpkgs-windows_252"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17897,15 +18408,14 @@
     },
     "logos-nix_270": {
       "inputs": {
-        "nixpkgs": "nixpkgs_270",
-        "nixpkgs-windows": "nixpkgs-windows_246"
+        "nixpkgs": "nixpkgs_270"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17916,15 +18426,14 @@
     },
     "logos-nix_271": {
       "inputs": {
-        "nixpkgs": "nixpkgs_271",
-        "nixpkgs-windows": "nixpkgs-windows_247"
+        "nixpkgs": "nixpkgs_271"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17936,7 +18445,7 @@
     "logos-nix_272": {
       "inputs": {
         "nixpkgs": "nixpkgs_272",
-        "nixpkgs-windows": "nixpkgs-windows_248"
+        "nixpkgs-windows": "nixpkgs-windows_253"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17955,7 +18464,7 @@
     "logos-nix_273": {
       "inputs": {
         "nixpkgs": "nixpkgs_273",
-        "nixpkgs-windows": "nixpkgs-windows_249"
+        "nixpkgs-windows": "nixpkgs-windows_254"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17974,7 +18483,7 @@
     "logos-nix_274": {
       "inputs": {
         "nixpkgs": "nixpkgs_274",
-        "nixpkgs-windows": "nixpkgs-windows_250"
+        "nixpkgs-windows": "nixpkgs-windows_255"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17993,7 +18502,7 @@
     "logos-nix_275": {
       "inputs": {
         "nixpkgs": "nixpkgs_275",
-        "nixpkgs-windows": "nixpkgs-windows_251"
+        "nixpkgs-windows": "nixpkgs-windows_256"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18012,7 +18521,7 @@
     "logos-nix_276": {
       "inputs": {
         "nixpkgs": "nixpkgs_276",
-        "nixpkgs-windows": "nixpkgs-windows_252"
+        "nixpkgs-windows": "nixpkgs-windows_257"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18031,14 +18540,14 @@
     "logos-nix_277": {
       "inputs": {
         "nixpkgs": "nixpkgs_277",
-        "nixpkgs-windows": "nixpkgs-windows_253"
+        "nixpkgs-windows": "nixpkgs-windows_258"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18050,7 +18559,7 @@
     "logos-nix_278": {
       "inputs": {
         "nixpkgs": "nixpkgs_278",
-        "nixpkgs-windows": "nixpkgs-windows_254"
+        "nixpkgs-windows": "nixpkgs-windows_259"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18068,15 +18577,14 @@
     },
     "logos-nix_279": {
       "inputs": {
-        "nixpkgs": "nixpkgs_279",
-        "nixpkgs-windows": "nixpkgs-windows_255"
+        "nixpkgs": "nixpkgs_279"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18107,7 +18615,7 @@
     "logos-nix_280": {
       "inputs": {
         "nixpkgs": "nixpkgs_280",
-        "nixpkgs-windows": "nixpkgs-windows_256"
+        "nixpkgs-windows": "nixpkgs-windows_260"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18126,7 +18634,7 @@
     "logos-nix_281": {
       "inputs": {
         "nixpkgs": "nixpkgs_281",
-        "nixpkgs-windows": "nixpkgs-windows_257"
+        "nixpkgs-windows": "nixpkgs-windows_261"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18145,7 +18653,7 @@
     "logos-nix_282": {
       "inputs": {
         "nixpkgs": "nixpkgs_282",
-        "nixpkgs-windows": "nixpkgs-windows_258"
+        "nixpkgs-windows": "nixpkgs-windows_262"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18164,7 +18672,7 @@
     "logos-nix_283": {
       "inputs": {
         "nixpkgs": "nixpkgs_283",
-        "nixpkgs-windows": "nixpkgs-windows_259"
+        "nixpkgs-windows": "nixpkgs-windows_263"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18183,7 +18691,7 @@
     "logos-nix_284": {
       "inputs": {
         "nixpkgs": "nixpkgs_284",
-        "nixpkgs-windows": "nixpkgs-windows_260"
+        "nixpkgs-windows": "nixpkgs-windows_264"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18202,7 +18710,7 @@
     "logos-nix_285": {
       "inputs": {
         "nixpkgs": "nixpkgs_285",
-        "nixpkgs-windows": "nixpkgs-windows_261"
+        "nixpkgs-windows": "nixpkgs-windows_265"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18221,7 +18729,7 @@
     "logos-nix_286": {
       "inputs": {
         "nixpkgs": "nixpkgs_286",
-        "nixpkgs-windows": "nixpkgs-windows_262"
+        "nixpkgs-windows": "nixpkgs-windows_266"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18240,7 +18748,7 @@
     "logos-nix_287": {
       "inputs": {
         "nixpkgs": "nixpkgs_287",
-        "nixpkgs-windows": "nixpkgs-windows_263"
+        "nixpkgs-windows": "nixpkgs-windows_267"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18259,7 +18767,7 @@
     "logos-nix_288": {
       "inputs": {
         "nixpkgs": "nixpkgs_288",
-        "nixpkgs-windows": "nixpkgs-windows_264"
+        "nixpkgs-windows": "nixpkgs-windows_268"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18278,7 +18786,7 @@
     "logos-nix_289": {
       "inputs": {
         "nixpkgs": "nixpkgs_289",
-        "nixpkgs-windows": "nixpkgs-windows_265"
+        "nixpkgs-windows": "nixpkgs-windows_269"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18315,15 +18823,14 @@
     },
     "logos-nix_290": {
       "inputs": {
-        "nixpkgs": "nixpkgs_290",
-        "nixpkgs-windows": "nixpkgs-windows_266"
+        "nixpkgs": "nixpkgs_290"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18334,8 +18841,26 @@
     },
     "logos-nix_291": {
       "inputs": {
-        "nixpkgs": "nixpkgs_291",
-        "nixpkgs-windows": "nixpkgs-windows_267"
+        "nixpkgs": "nixpkgs_291"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_292": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_292",
+        "nixpkgs-windows": "nixpkgs-windows_270"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18351,34 +18876,17 @@
         "type": "github"
       }
     },
-    "logos-nix_292": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_292"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_293": {
       "inputs": {
-        "nixpkgs": "nixpkgs_293"
+        "nixpkgs": "nixpkgs_293",
+        "nixpkgs-windows": "nixpkgs-windows_271"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18390,7 +18898,7 @@
     "logos-nix_294": {
       "inputs": {
         "nixpkgs": "nixpkgs_294",
-        "nixpkgs-windows": "nixpkgs-windows_268"
+        "nixpkgs-windows": "nixpkgs-windows_272"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18409,7 +18917,7 @@
     "logos-nix_295": {
       "inputs": {
         "nixpkgs": "nixpkgs_295",
-        "nixpkgs-windows": "nixpkgs-windows_269"
+        "nixpkgs-windows": "nixpkgs-windows_273"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18428,14 +18936,14 @@
     "logos-nix_296": {
       "inputs": {
         "nixpkgs": "nixpkgs_296",
-        "nixpkgs-windows": "nixpkgs-windows_270"
+        "nixpkgs-windows": "nixpkgs-windows_274"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18447,14 +18955,14 @@
     "logos-nix_297": {
       "inputs": {
         "nixpkgs": "nixpkgs_297",
-        "nixpkgs-windows": "nixpkgs-windows_271"
+        "nixpkgs-windows": "nixpkgs-windows_275"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18466,7 +18974,7 @@
     "logos-nix_298": {
       "inputs": {
         "nixpkgs": "nixpkgs_298",
-        "nixpkgs-windows": "nixpkgs-windows_272"
+        "nixpkgs-windows": "nixpkgs-windows_276"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18484,15 +18992,14 @@
     },
     "logos-nix_299": {
       "inputs": {
-        "nixpkgs": "nixpkgs_299",
-        "nixpkgs-windows": "nixpkgs-windows_273"
+        "nixpkgs": "nixpkgs_299"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -18541,15 +19048,14 @@
     },
     "logos-nix_300": {
       "inputs": {
-        "nixpkgs": "nixpkgs_300",
-        "nixpkgs-windows": "nixpkgs-windows_274"
+        "nixpkgs": "nixpkgs_300"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18561,7 +19067,7 @@
     "logos-nix_301": {
       "inputs": {
         "nixpkgs": "nixpkgs_301",
-        "nixpkgs-windows": "nixpkgs-windows_275"
+        "nixpkgs-windows": "nixpkgs-windows_277"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18580,7 +19086,7 @@
     "logos-nix_302": {
       "inputs": {
         "nixpkgs": "nixpkgs_302",
-        "nixpkgs-windows": "nixpkgs-windows_276"
+        "nixpkgs-windows": "nixpkgs-windows_278"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18599,7 +19105,7 @@
     "logos-nix_303": {
       "inputs": {
         "nixpkgs": "nixpkgs_303",
-        "nixpkgs-windows": "nixpkgs-windows_277"
+        "nixpkgs-windows": "nixpkgs-windows_279"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18618,7 +19124,7 @@
     "logos-nix_304": {
       "inputs": {
         "nixpkgs": "nixpkgs_304",
-        "nixpkgs-windows": "nixpkgs-windows_278"
+        "nixpkgs-windows": "nixpkgs-windows_280"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18636,14 +19142,15 @@
     },
     "logos-nix_305": {
       "inputs": {
-        "nixpkgs": "nixpkgs_305"
+        "nixpkgs": "nixpkgs_305",
+        "nixpkgs-windows": "nixpkgs-windows_281"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18654,14 +19161,15 @@
     },
     "logos-nix_306": {
       "inputs": {
-        "nixpkgs": "nixpkgs_306"
+        "nixpkgs": "nixpkgs_306",
+        "nixpkgs-windows": "nixpkgs-windows_282"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18673,7 +19181,7 @@
     "logos-nix_307": {
       "inputs": {
         "nixpkgs": "nixpkgs_307",
-        "nixpkgs-windows": "nixpkgs-windows_279"
+        "nixpkgs-windows": "nixpkgs-windows_283"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18692,14 +19200,14 @@
     "logos-nix_308": {
       "inputs": {
         "nixpkgs": "nixpkgs_308",
-        "nixpkgs-windows": "nixpkgs-windows_280"
+        "nixpkgs-windows": "nixpkgs-windows_284"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18711,7 +19219,7 @@
     "logos-nix_309": {
       "inputs": {
         "nixpkgs": "nixpkgs_309",
-        "nixpkgs-windows": "nixpkgs-windows_281"
+        "nixpkgs-windows": "nixpkgs-windows_285"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18749,7 +19257,7 @@
     "logos-nix_310": {
       "inputs": {
         "nixpkgs": "nixpkgs_310",
-        "nixpkgs-windows": "nixpkgs-windows_282"
+        "nixpkgs-windows": "nixpkgs-windows_286"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18768,7 +19276,7 @@
     "logos-nix_311": {
       "inputs": {
         "nixpkgs": "nixpkgs_311",
-        "nixpkgs-windows": "nixpkgs-windows_283"
+        "nixpkgs-windows": "nixpkgs-windows_287"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18786,15 +19294,14 @@
     },
     "logos-nix_312": {
       "inputs": {
-        "nixpkgs": "nixpkgs_312",
-        "nixpkgs-windows": "nixpkgs-windows_284"
+        "nixpkgs": "nixpkgs_312"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18806,7 +19313,7 @@
     "logos-nix_313": {
       "inputs": {
         "nixpkgs": "nixpkgs_313",
-        "nixpkgs-windows": "nixpkgs-windows_285"
+        "nixpkgs-windows": "nixpkgs-windows_288"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18824,14 +19331,15 @@
     },
     "logos-nix_314": {
       "inputs": {
-        "nixpkgs": "nixpkgs_314"
+        "nixpkgs": "nixpkgs_314",
+        "nixpkgs-windows": "nixpkgs-windows_289"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18843,7 +19351,7 @@
     "logos-nix_315": {
       "inputs": {
         "nixpkgs": "nixpkgs_315",
-        "nixpkgs-windows": "nixpkgs-windows_286"
+        "nixpkgs-windows": "nixpkgs-windows_290"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18862,7 +19370,7 @@
     "logos-nix_316": {
       "inputs": {
         "nixpkgs": "nixpkgs_316",
-        "nixpkgs-windows": "nixpkgs-windows_287"
+        "nixpkgs-windows": "nixpkgs-windows_291"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18881,7 +19389,7 @@
     "logos-nix_317": {
       "inputs": {
         "nixpkgs": "nixpkgs_317",
-        "nixpkgs-windows": "nixpkgs-windows_288"
+        "nixpkgs-windows": "nixpkgs-windows_292"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18900,7 +19408,7 @@
     "logos-nix_318": {
       "inputs": {
         "nixpkgs": "nixpkgs_318",
-        "nixpkgs-windows": "nixpkgs-windows_289"
+        "nixpkgs-windows": "nixpkgs-windows_293"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18919,7 +19427,7 @@
     "logos-nix_319": {
       "inputs": {
         "nixpkgs": "nixpkgs_319",
-        "nixpkgs-windows": "nixpkgs-windows_290"
+        "nixpkgs-windows": "nixpkgs-windows_294"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -18957,14 +19465,14 @@
     "logos-nix_320": {
       "inputs": {
         "nixpkgs": "nixpkgs_320",
-        "nixpkgs-windows": "nixpkgs-windows_291"
+        "nixpkgs-windows": "nixpkgs-windows_295"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18976,14 +19484,14 @@
     "logos-nix_321": {
       "inputs": {
         "nixpkgs": "nixpkgs_321",
-        "nixpkgs-windows": "nixpkgs-windows_292"
+        "nixpkgs-windows": "nixpkgs-windows_296"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18995,7 +19503,7 @@
     "logos-nix_322": {
       "inputs": {
         "nixpkgs": "nixpkgs_322",
-        "nixpkgs-windows": "nixpkgs-windows_293"
+        "nixpkgs-windows": "nixpkgs-windows_297"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19013,15 +19521,14 @@
     },
     "logos-nix_323": {
       "inputs": {
-        "nixpkgs": "nixpkgs_323",
-        "nixpkgs-windows": "nixpkgs-windows_294"
+        "nixpkgs": "nixpkgs_323"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19032,8 +19539,26 @@
     },
     "logos-nix_324": {
       "inputs": {
-        "nixpkgs": "nixpkgs_324",
-        "nixpkgs-windows": "nixpkgs-windows_295"
+        "nixpkgs": "nixpkgs_324"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_325": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_325",
+        "nixpkgs-windows": "nixpkgs-windows_298"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19049,34 +19574,17 @@
         "type": "github"
       }
     },
-    "logos-nix_325": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_325"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_326": {
       "inputs": {
-        "nixpkgs": "nixpkgs_326"
+        "nixpkgs": "nixpkgs_326",
+        "nixpkgs-windows": "nixpkgs-windows_299"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19088,7 +19596,7 @@
     "logos-nix_327": {
       "inputs": {
         "nixpkgs": "nixpkgs_327",
-        "nixpkgs-windows": "nixpkgs-windows_296"
+        "nixpkgs-windows": "nixpkgs-windows_300"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19107,7 +19615,7 @@
     "logos-nix_328": {
       "inputs": {
         "nixpkgs": "nixpkgs_328",
-        "nixpkgs-windows": "nixpkgs-windows_297"
+        "nixpkgs-windows": "nixpkgs-windows_301"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19126,14 +19634,14 @@
     "logos-nix_329": {
       "inputs": {
         "nixpkgs": "nixpkgs_329",
-        "nixpkgs-windows": "nixpkgs-windows_298"
+        "nixpkgs-windows": "nixpkgs-windows_302"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -19164,7 +19672,7 @@
     "logos-nix_330": {
       "inputs": {
         "nixpkgs": "nixpkgs_330",
-        "nixpkgs-windows": "nixpkgs-windows_299"
+        "nixpkgs-windows": "nixpkgs-windows_303"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19182,15 +19690,14 @@
     },
     "logos-nix_331": {
       "inputs": {
-        "nixpkgs": "nixpkgs_331",
-        "nixpkgs-windows": "nixpkgs-windows_300"
+        "nixpkgs": "nixpkgs_331"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -19201,8 +19708,26 @@
     },
     "logos-nix_332": {
       "inputs": {
-        "nixpkgs": "nixpkgs_332",
-        "nixpkgs-windows": "nixpkgs-windows_301"
+        "nixpkgs": "nixpkgs_332"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_333": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_333",
+        "nixpkgs-windows": "nixpkgs-windows_304"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19218,34 +19743,17 @@
         "type": "github"
       }
     },
-    "logos-nix_333": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_333"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_334": {
       "inputs": {
-        "nixpkgs": "nixpkgs_334"
+        "nixpkgs": "nixpkgs_334",
+        "nixpkgs-windows": "nixpkgs-windows_305"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19257,7 +19765,7 @@
     "logos-nix_335": {
       "inputs": {
         "nixpkgs": "nixpkgs_335",
-        "nixpkgs-windows": "nixpkgs-windows_302"
+        "nixpkgs-windows": "nixpkgs-windows_306"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19275,15 +19783,14 @@
     },
     "logos-nix_336": {
       "inputs": {
-        "nixpkgs": "nixpkgs_336",
-        "nixpkgs-windows": "nixpkgs-windows_303"
+        "nixpkgs": "nixpkgs_336"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19294,15 +19801,14 @@
     },
     "logos-nix_337": {
       "inputs": {
-        "nixpkgs": "nixpkgs_337",
-        "nixpkgs-windows": "nixpkgs-windows_304"
+        "nixpkgs": "nixpkgs_337"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19314,7 +19820,7 @@
     "logos-nix_338": {
       "inputs": {
         "nixpkgs": "nixpkgs_338",
-        "nixpkgs-windows": "nixpkgs-windows_305"
+        "nixpkgs-windows": "nixpkgs-windows_307"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19333,7 +19839,7 @@
     "logos-nix_339": {
       "inputs": {
         "nixpkgs": "nixpkgs_339",
-        "nixpkgs-windows": "nixpkgs-windows_306"
+        "nixpkgs-windows": "nixpkgs-windows_308"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19371,7 +19877,7 @@
     "logos-nix_340": {
       "inputs": {
         "nixpkgs": "nixpkgs_340",
-        "nixpkgs-windows": "nixpkgs-windows_307"
+        "nixpkgs-windows": "nixpkgs-windows_309"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19390,7 +19896,7 @@
     "logos-nix_341": {
       "inputs": {
         "nixpkgs": "nixpkgs_341",
-        "nixpkgs-windows": "nixpkgs-windows_308"
+        "nixpkgs-windows": "nixpkgs-windows_310"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19409,7 +19915,7 @@
     "logos-nix_342": {
       "inputs": {
         "nixpkgs": "nixpkgs_342",
-        "nixpkgs-windows": "nixpkgs-windows_309"
+        "nixpkgs-windows": "nixpkgs-windows_311"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19428,7 +19934,7 @@
     "logos-nix_343": {
       "inputs": {
         "nixpkgs": "nixpkgs_343",
-        "nixpkgs-windows": "nixpkgs-windows_310"
+        "nixpkgs-windows": "nixpkgs-windows_312"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19447,7 +19953,7 @@
     "logos-nix_344": {
       "inputs": {
         "nixpkgs": "nixpkgs_344",
-        "nixpkgs-windows": "nixpkgs-windows_311"
+        "nixpkgs-windows": "nixpkgs-windows_313"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19466,7 +19972,7 @@
     "logos-nix_345": {
       "inputs": {
         "nixpkgs": "nixpkgs_345",
-        "nixpkgs-windows": "nixpkgs-windows_312"
+        "nixpkgs-windows": "nixpkgs-windows_314"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19485,7 +19991,7 @@
     "logos-nix_346": {
       "inputs": {
         "nixpkgs": "nixpkgs_346",
-        "nixpkgs-windows": "nixpkgs-windows_313"
+        "nixpkgs-windows": "nixpkgs-windows_315"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19504,7 +20010,7 @@
     "logos-nix_347": {
       "inputs": {
         "nixpkgs": "nixpkgs_347",
-        "nixpkgs-windows": "nixpkgs-windows_314"
+        "nixpkgs-windows": "nixpkgs-windows_316"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19523,7 +20029,7 @@
     "logos-nix_348": {
       "inputs": {
         "nixpkgs": "nixpkgs_348",
-        "nixpkgs-windows": "nixpkgs-windows_315"
+        "nixpkgs-windows": "nixpkgs-windows_317"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19542,7 +20048,7 @@
     "logos-nix_349": {
       "inputs": {
         "nixpkgs": "nixpkgs_349",
-        "nixpkgs-windows": "nixpkgs-windows_316"
+        "nixpkgs-windows": "nixpkgs-windows_318"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19580,7 +20086,7 @@
     "logos-nix_350": {
       "inputs": {
         "nixpkgs": "nixpkgs_350",
-        "nixpkgs-windows": "nixpkgs-windows_317"
+        "nixpkgs-windows": "nixpkgs-windows_319"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19599,7 +20105,7 @@
     "logos-nix_351": {
       "inputs": {
         "nixpkgs": "nixpkgs_351",
-        "nixpkgs-windows": "nixpkgs-windows_318"
+        "nixpkgs-windows": "nixpkgs-windows_320"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19618,14 +20124,14 @@
     "logos-nix_352": {
       "inputs": {
         "nixpkgs": "nixpkgs_352",
-        "nixpkgs-windows": "nixpkgs-windows_319"
+        "nixpkgs-windows": "nixpkgs-windows_321"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19637,7 +20143,7 @@
     "logos-nix_353": {
       "inputs": {
         "nixpkgs": "nixpkgs_353",
-        "nixpkgs-windows": "nixpkgs-windows_320"
+        "nixpkgs-windows": "nixpkgs-windows_322"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19656,7 +20162,7 @@
     "logos-nix_354": {
       "inputs": {
         "nixpkgs": "nixpkgs_354",
-        "nixpkgs-windows": "nixpkgs-windows_321"
+        "nixpkgs-windows": "nixpkgs-windows_323"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19675,14 +20181,14 @@
     "logos-nix_355": {
       "inputs": {
         "nixpkgs": "nixpkgs_355",
-        "nixpkgs-windows": "nixpkgs-windows_322"
+        "nixpkgs-windows": "nixpkgs-windows_324"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -19694,7 +20200,7 @@
     "logos-nix_356": {
       "inputs": {
         "nixpkgs": "nixpkgs_356",
-        "nixpkgs-windows": "nixpkgs-windows_323"
+        "nixpkgs-windows": "nixpkgs-windows_325"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19713,7 +20219,7 @@
     "logos-nix_357": {
       "inputs": {
         "nixpkgs": "nixpkgs_357",
-        "nixpkgs-windows": "nixpkgs-windows_324"
+        "nixpkgs-windows": "nixpkgs-windows_326"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19732,7 +20238,7 @@
     "logos-nix_358": {
       "inputs": {
         "nixpkgs": "nixpkgs_358",
-        "nixpkgs-windows": "nixpkgs-windows_325"
+        "nixpkgs-windows": "nixpkgs-windows_327"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19751,7 +20257,7 @@
     "logos-nix_359": {
       "inputs": {
         "nixpkgs": "nixpkgs_359",
-        "nixpkgs-windows": "nixpkgs-windows_326"
+        "nixpkgs-windows": "nixpkgs-windows_328"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19789,7 +20295,7 @@
     "logos-nix_360": {
       "inputs": {
         "nixpkgs": "nixpkgs_360",
-        "nixpkgs-windows": "nixpkgs-windows_327"
+        "nixpkgs-windows": "nixpkgs-windows_329"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19808,7 +20314,7 @@
     "logos-nix_361": {
       "inputs": {
         "nixpkgs": "nixpkgs_361",
-        "nixpkgs-windows": "nixpkgs-windows_328"
+        "nixpkgs-windows": "nixpkgs-windows_330"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19827,7 +20333,7 @@
     "logos-nix_362": {
       "inputs": {
         "nixpkgs": "nixpkgs_362",
-        "nixpkgs-windows": "nixpkgs-windows_329"
+        "nixpkgs-windows": "nixpkgs-windows_331"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19846,7 +20352,7 @@
     "logos-nix_363": {
       "inputs": {
         "nixpkgs": "nixpkgs_363",
-        "nixpkgs-windows": "nixpkgs-windows_330"
+        "nixpkgs-windows": "nixpkgs-windows_332"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19865,7 +20371,7 @@
     "logos-nix_364": {
       "inputs": {
         "nixpkgs": "nixpkgs_364",
-        "nixpkgs-windows": "nixpkgs-windows_331"
+        "nixpkgs-windows": "nixpkgs-windows_333"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19884,7 +20390,7 @@
     "logos-nix_365": {
       "inputs": {
         "nixpkgs": "nixpkgs_365",
-        "nixpkgs-windows": "nixpkgs-windows_332"
+        "nixpkgs-windows": "nixpkgs-windows_334"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19903,7 +20409,7 @@
     "logos-nix_366": {
       "inputs": {
         "nixpkgs": "nixpkgs_366",
-        "nixpkgs-windows": "nixpkgs-windows_333"
+        "nixpkgs-windows": "nixpkgs-windows_335"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19922,7 +20428,7 @@
     "logos-nix_367": {
       "inputs": {
         "nixpkgs": "nixpkgs_367",
-        "nixpkgs-windows": "nixpkgs-windows_334"
+        "nixpkgs-windows": "nixpkgs-windows_336"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19941,7 +20447,7 @@
     "logos-nix_368": {
       "inputs": {
         "nixpkgs": "nixpkgs_368",
-        "nixpkgs-windows": "nixpkgs-windows_335"
+        "nixpkgs-windows": "nixpkgs-windows_337"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19960,7 +20466,7 @@
     "logos-nix_369": {
       "inputs": {
         "nixpkgs": "nixpkgs_369",
-        "nixpkgs-windows": "nixpkgs-windows_336"
+        "nixpkgs-windows": "nixpkgs-windows_338"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19998,7 +20504,7 @@
     "logos-nix_370": {
       "inputs": {
         "nixpkgs": "nixpkgs_370",
-        "nixpkgs-windows": "nixpkgs-windows_337"
+        "nixpkgs-windows": "nixpkgs-windows_339"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20017,7 +20523,7 @@
     "logos-nix_371": {
       "inputs": {
         "nixpkgs": "nixpkgs_371",
-        "nixpkgs-windows": "nixpkgs-windows_338"
+        "nixpkgs-windows": "nixpkgs-windows_340"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20036,7 +20542,7 @@
     "logos-nix_372": {
       "inputs": {
         "nixpkgs": "nixpkgs_372",
-        "nixpkgs-windows": "nixpkgs-windows_339"
+        "nixpkgs-windows": "nixpkgs-windows_341"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20055,7 +20561,7 @@
     "logos-nix_373": {
       "inputs": {
         "nixpkgs": "nixpkgs_373",
-        "nixpkgs-windows": "nixpkgs-windows_340"
+        "nixpkgs-windows": "nixpkgs-windows_342"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20073,14 +20579,15 @@
     },
     "logos-nix_374": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374"
+        "nixpkgs": "nixpkgs_374",
+        "nixpkgs-windows": "nixpkgs-windows_343"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20091,14 +20598,15 @@
     },
     "logos-nix_375": {
       "inputs": {
-        "nixpkgs": "nixpkgs_375"
+        "nixpkgs": "nixpkgs_375",
+        "nixpkgs-windows": "nixpkgs-windows_344"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20110,7 +20618,7 @@
     "logos-nix_376": {
       "inputs": {
         "nixpkgs": "nixpkgs_376",
-        "nixpkgs-windows": "nixpkgs-windows_341"
+        "nixpkgs-windows": "nixpkgs-windows_345"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20128,15 +20636,14 @@
     },
     "logos-nix_377": {
       "inputs": {
-        "nixpkgs": "nixpkgs_377",
-        "nixpkgs-windows": "nixpkgs-windows_342"
+        "nixpkgs": "nixpkgs_377"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20147,15 +20654,14 @@
     },
     "logos-nix_378": {
       "inputs": {
-        "nixpkgs": "nixpkgs_378",
-        "nixpkgs-windows": "nixpkgs-windows_343"
+        "nixpkgs": "nixpkgs_378"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20167,7 +20673,7 @@
     "logos-nix_379": {
       "inputs": {
         "nixpkgs": "nixpkgs_379",
-        "nixpkgs-windows": "nixpkgs-windows_344"
+        "nixpkgs-windows": "nixpkgs-windows_346"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20205,7 +20711,7 @@
     "logos-nix_380": {
       "inputs": {
         "nixpkgs": "nixpkgs_380",
-        "nixpkgs-windows": "nixpkgs-windows_345"
+        "nixpkgs-windows": "nixpkgs-windows_347"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20224,7 +20730,7 @@
     "logos-nix_381": {
       "inputs": {
         "nixpkgs": "nixpkgs_381",
-        "nixpkgs-windows": "nixpkgs-windows_346"
+        "nixpkgs-windows": "nixpkgs-windows_348"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20243,7 +20749,7 @@
     "logos-nix_382": {
       "inputs": {
         "nixpkgs": "nixpkgs_382",
-        "nixpkgs-windows": "nixpkgs-windows_347"
+        "nixpkgs-windows": "nixpkgs-windows_349"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20262,7 +20768,7 @@
     "logos-nix_383": {
       "inputs": {
         "nixpkgs": "nixpkgs_383",
-        "nixpkgs-windows": "nixpkgs-windows_348"
+        "nixpkgs-windows": "nixpkgs-windows_350"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20281,7 +20787,7 @@
     "logos-nix_384": {
       "inputs": {
         "nixpkgs": "nixpkgs_384",
-        "nixpkgs-windows": "nixpkgs-windows_349"
+        "nixpkgs-windows": "nixpkgs-windows_351"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20300,7 +20806,7 @@
     "logos-nix_385": {
       "inputs": {
         "nixpkgs": "nixpkgs_385",
-        "nixpkgs-windows": "nixpkgs-windows_350"
+        "nixpkgs-windows": "nixpkgs-windows_352"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20319,7 +20825,7 @@
     "logos-nix_386": {
       "inputs": {
         "nixpkgs": "nixpkgs_386",
-        "nixpkgs-windows": "nixpkgs-windows_351"
+        "nixpkgs-windows": "nixpkgs-windows_353"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20337,14 +20843,15 @@
     },
     "logos-nix_387": {
       "inputs": {
-        "nixpkgs": "nixpkgs_387"
+        "nixpkgs": "nixpkgs_387",
+        "nixpkgs-windows": "nixpkgs-windows_354"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20355,14 +20862,15 @@
     },
     "logos-nix_388": {
       "inputs": {
-        "nixpkgs": "nixpkgs_388"
+        "nixpkgs": "nixpkgs_388",
+        "nixpkgs-windows": "nixpkgs-windows_355"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20374,7 +20882,7 @@
     "logos-nix_389": {
       "inputs": {
         "nixpkgs": "nixpkgs_389",
-        "nixpkgs-windows": "nixpkgs-windows_352"
+        "nixpkgs-windows": "nixpkgs-windows_356"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20411,15 +20919,14 @@
     },
     "logos-nix_390": {
       "inputs": {
-        "nixpkgs": "nixpkgs_390",
-        "nixpkgs-windows": "nixpkgs-windows_353"
+        "nixpkgs": "nixpkgs_390"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20430,15 +20937,14 @@
     },
     "logos-nix_391": {
       "inputs": {
-        "nixpkgs": "nixpkgs_391",
-        "nixpkgs-windows": "nixpkgs-windows_354"
+        "nixpkgs": "nixpkgs_391"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20450,7 +20956,7 @@
     "logos-nix_392": {
       "inputs": {
         "nixpkgs": "nixpkgs_392",
-        "nixpkgs-windows": "nixpkgs-windows_355"
+        "nixpkgs-windows": "nixpkgs-windows_357"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20469,7 +20975,7 @@
     "logos-nix_393": {
       "inputs": {
         "nixpkgs": "nixpkgs_393",
-        "nixpkgs-windows": "nixpkgs-windows_356"
+        "nixpkgs-windows": "nixpkgs-windows_358"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20488,14 +20994,14 @@
     "logos-nix_394": {
       "inputs": {
         "nixpkgs": "nixpkgs_394",
-        "nixpkgs-windows": "nixpkgs-windows_357"
+        "nixpkgs-windows": "nixpkgs-windows_359"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20507,7 +21013,7 @@
     "logos-nix_395": {
       "inputs": {
         "nixpkgs": "nixpkgs_395",
-        "nixpkgs-windows": "nixpkgs-windows_358"
+        "nixpkgs-windows": "nixpkgs-windows_360"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20525,26 +21031,8 @@
     },
     "logos-nix_396": {
       "inputs": {
-        "nixpkgs": "nixpkgs_396"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_397": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_397",
-        "nixpkgs-windows": "nixpkgs-windows_359"
+        "nixpkgs": "nixpkgs_396",
+        "nixpkgs-windows": "nixpkgs-windows_361"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20560,10 +21048,29 @@
         "type": "github"
       }
     },
+    "logos-nix_397": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_397",
+        "nixpkgs-windows": "nixpkgs-windows_362"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_398": {
       "inputs": {
         "nixpkgs": "nixpkgs_398",
-        "nixpkgs-windows": "nixpkgs-windows_360"
+        "nixpkgs-windows": "nixpkgs-windows_363"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20581,15 +21088,14 @@
     },
     "logos-nix_399": {
       "inputs": {
-        "nixpkgs": "nixpkgs_399",
-        "nixpkgs-windows": "nixpkgs-windows_361"
+        "nixpkgs": "nixpkgs_399"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20639,7 +21145,7 @@
     "logos-nix_400": {
       "inputs": {
         "nixpkgs": "nixpkgs_400",
-        "nixpkgs-windows": "nixpkgs-windows_362"
+        "nixpkgs-windows": "nixpkgs-windows_364"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20658,7 +21164,7 @@
     "logos-nix_401": {
       "inputs": {
         "nixpkgs": "nixpkgs_401",
-        "nixpkgs-windows": "nixpkgs-windows_363"
+        "nixpkgs-windows": "nixpkgs-windows_365"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20677,7 +21183,7 @@
     "logos-nix_402": {
       "inputs": {
         "nixpkgs": "nixpkgs_402",
-        "nixpkgs-windows": "nixpkgs-windows_364"
+        "nixpkgs-windows": "nixpkgs-windows_366"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20696,7 +21202,7 @@
     "logos-nix_403": {
       "inputs": {
         "nixpkgs": "nixpkgs_403",
-        "nixpkgs-windows": "nixpkgs-windows_365"
+        "nixpkgs-windows": "nixpkgs-windows_367"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20715,7 +21221,7 @@
     "logos-nix_404": {
       "inputs": {
         "nixpkgs": "nixpkgs_404",
-        "nixpkgs-windows": "nixpkgs-windows_366"
+        "nixpkgs-windows": "nixpkgs-windows_368"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20734,7 +21240,7 @@
     "logos-nix_405": {
       "inputs": {
         "nixpkgs": "nixpkgs_405",
-        "nixpkgs-windows": "nixpkgs-windows_367"
+        "nixpkgs-windows": "nixpkgs-windows_369"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20753,7 +21259,7 @@
     "logos-nix_406": {
       "inputs": {
         "nixpkgs": "nixpkgs_406",
-        "nixpkgs-windows": "nixpkgs-windows_368"
+        "nixpkgs-windows": "nixpkgs-windows_370"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20771,14 +21277,15 @@
     },
     "logos-nix_407": {
       "inputs": {
-        "nixpkgs": "nixpkgs_407"
+        "nixpkgs": "nixpkgs_407",
+        "nixpkgs-windows": "nixpkgs-windows_371"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20789,14 +21296,15 @@
     },
     "logos-nix_408": {
       "inputs": {
-        "nixpkgs": "nixpkgs_408"
+        "nixpkgs": "nixpkgs_408",
+        "nixpkgs-windows": "nixpkgs-windows_372"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20808,7 +21316,7 @@
     "logos-nix_409": {
       "inputs": {
         "nixpkgs": "nixpkgs_409",
-        "nixpkgs-windows": "nixpkgs-windows_369"
+        "nixpkgs-windows": "nixpkgs-windows_373"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20845,15 +21353,14 @@
     },
     "logos-nix_410": {
       "inputs": {
-        "nixpkgs": "nixpkgs_410",
-        "nixpkgs-windows": "nixpkgs-windows_370"
+        "nixpkgs": "nixpkgs_410"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20864,15 +21371,14 @@
     },
     "logos-nix_411": {
       "inputs": {
-        "nixpkgs": "nixpkgs_411",
-        "nixpkgs-windows": "nixpkgs-windows_371"
+        "nixpkgs": "nixpkgs_411"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20884,7 +21390,7 @@
     "logos-nix_412": {
       "inputs": {
         "nixpkgs": "nixpkgs_412",
-        "nixpkgs-windows": "nixpkgs-windows_372"
+        "nixpkgs-windows": "nixpkgs-windows_374"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20903,7 +21409,7 @@
     "logos-nix_413": {
       "inputs": {
         "nixpkgs": "nixpkgs_413",
-        "nixpkgs-windows": "nixpkgs-windows_373"
+        "nixpkgs-windows": "nixpkgs-windows_375"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20922,7 +21428,7 @@
     "logos-nix_414": {
       "inputs": {
         "nixpkgs": "nixpkgs_414",
-        "nixpkgs-windows": "nixpkgs-windows_374"
+        "nixpkgs-windows": "nixpkgs-windows_376"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20941,7 +21447,7 @@
     "logos-nix_415": {
       "inputs": {
         "nixpkgs": "nixpkgs_415",
-        "nixpkgs-windows": "nixpkgs-windows_375"
+        "nixpkgs-windows": "nixpkgs-windows_377"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20960,7 +21466,7 @@
     "logos-nix_416": {
       "inputs": {
         "nixpkgs": "nixpkgs_416",
-        "nixpkgs-windows": "nixpkgs-windows_376"
+        "nixpkgs-windows": "nixpkgs-windows_378"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20979,7 +21485,7 @@
     "logos-nix_417": {
       "inputs": {
         "nixpkgs": "nixpkgs_417",
-        "nixpkgs-windows": "nixpkgs-windows_377"
+        "nixpkgs-windows": "nixpkgs-windows_379"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20997,15 +21503,14 @@
     },
     "logos-nix_418": {
       "inputs": {
-        "nixpkgs": "nixpkgs_418",
-        "nixpkgs-windows": "nixpkgs-windows_378"
+        "nixpkgs": "nixpkgs_418"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21016,15 +21521,14 @@
     },
     "logos-nix_419": {
       "inputs": {
-        "nixpkgs": "nixpkgs_419",
-        "nixpkgs-windows": "nixpkgs-windows_379"
+        "nixpkgs": "nixpkgs_419"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21267,11 +21771,11 @@
         "nixpkgs-windows": "nixpkgs-windows_390"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21400,11 +21904,11 @@
         "nixpkgs-windows": "nixpkgs-windows_397"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21719,14 +22223,15 @@
     },
     "logos-nix_452": {
       "inputs": {
-        "nixpkgs": "nixpkgs_452"
+        "nixpkgs": "nixpkgs_452",
+        "nixpkgs-windows": "nixpkgs-windows_412"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21737,14 +22242,15 @@
     },
     "logos-nix_453": {
       "inputs": {
-        "nixpkgs": "nixpkgs_453"
+        "nixpkgs": "nixpkgs_453",
+        "nixpkgs-windows": "nixpkgs-windows_413"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21756,7 +22262,7 @@
     "logos-nix_454": {
       "inputs": {
         "nixpkgs": "nixpkgs_454",
-        "nixpkgs-windows": "nixpkgs-windows_412"
+        "nixpkgs-windows": "nixpkgs-windows_414"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21775,7 +22281,7 @@
     "logos-nix_455": {
       "inputs": {
         "nixpkgs": "nixpkgs_455",
-        "nixpkgs-windows": "nixpkgs-windows_413"
+        "nixpkgs-windows": "nixpkgs-windows_415"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21794,7 +22300,7 @@
     "logos-nix_456": {
       "inputs": {
         "nixpkgs": "nixpkgs_456",
-        "nixpkgs-windows": "nixpkgs-windows_414"
+        "nixpkgs-windows": "nixpkgs-windows_416"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21813,7 +22319,7 @@
     "logos-nix_457": {
       "inputs": {
         "nixpkgs": "nixpkgs_457",
-        "nixpkgs-windows": "nixpkgs-windows_415"
+        "nixpkgs-windows": "nixpkgs-windows_417"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21832,7 +22338,7 @@
     "logos-nix_458": {
       "inputs": {
         "nixpkgs": "nixpkgs_458",
-        "nixpkgs-windows": "nixpkgs-windows_416"
+        "nixpkgs-windows": "nixpkgs-windows_418"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21850,15 +22356,14 @@
     },
     "logos-nix_459": {
       "inputs": {
-        "nixpkgs": "nixpkgs_459",
-        "nixpkgs-windows": "nixpkgs-windows_417"
+        "nixpkgs": "nixpkgs_459"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21888,15 +22393,14 @@
     },
     "logos-nix_460": {
       "inputs": {
-        "nixpkgs": "nixpkgs_460",
-        "nixpkgs-windows": "nixpkgs-windows_418"
+        "nixpkgs": "nixpkgs_460"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21983,14 +22487,15 @@
     },
     "logos-nix_465": {
       "inputs": {
-        "nixpkgs": "nixpkgs_465"
+        "nixpkgs": "nixpkgs_465",
+        "nixpkgs-windows": "nixpkgs-windows_423"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22001,14 +22506,15 @@
     },
     "logos-nix_466": {
       "inputs": {
-        "nixpkgs": "nixpkgs_466"
+        "nixpkgs": "nixpkgs_466",
+        "nixpkgs-windows": "nixpkgs-windows_424"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22020,7 +22526,7 @@
     "logos-nix_467": {
       "inputs": {
         "nixpkgs": "nixpkgs_467",
-        "nixpkgs-windows": "nixpkgs-windows_423"
+        "nixpkgs-windows": "nixpkgs-windows_425"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22039,7 +22545,7 @@
     "logos-nix_468": {
       "inputs": {
         "nixpkgs": "nixpkgs_468",
-        "nixpkgs-windows": "nixpkgs-windows_424"
+        "nixpkgs-windows": "nixpkgs-windows_426"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22058,7 +22564,7 @@
     "logos-nix_469": {
       "inputs": {
         "nixpkgs": "nixpkgs_469",
-        "nixpkgs-windows": "nixpkgs-windows_425"
+        "nixpkgs-windows": "nixpkgs-windows_427"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22096,7 +22602,7 @@
     "logos-nix_470": {
       "inputs": {
         "nixpkgs": "nixpkgs_470",
-        "nixpkgs-windows": "nixpkgs-windows_426"
+        "nixpkgs-windows": "nixpkgs-windows_428"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22115,7 +22621,7 @@
     "logos-nix_471": {
       "inputs": {
         "nixpkgs": "nixpkgs_471",
-        "nixpkgs-windows": "nixpkgs-windows_427"
+        "nixpkgs-windows": "nixpkgs-windows_429"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22133,45 +22639,7 @@
     },
     "logos-nix_472": {
       "inputs": {
-        "nixpkgs": "nixpkgs_472",
-        "nixpkgs-windows": "nixpkgs-windows_428"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_473": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_473",
-        "nixpkgs-windows": "nixpkgs-windows_429"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_474": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_474"
+        "nixpkgs": "nixpkgs_472"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -22187,10 +22655,47 @@
         "type": "github"
       }
     },
+    "logos-nix_473": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_473"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_474": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_474",
+        "nixpkgs-windows": "nixpkgs-windows_430"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_475": {
       "inputs": {
         "nixpkgs": "nixpkgs_475",
-        "nixpkgs-windows": "nixpkgs-windows_430"
+        "nixpkgs-windows": "nixpkgs-windows_431"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22209,7 +22714,7 @@
     "logos-nix_476": {
       "inputs": {
         "nixpkgs": "nixpkgs_476",
-        "nixpkgs-windows": "nixpkgs-windows_431"
+        "nixpkgs-windows": "nixpkgs-windows_432"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22228,7 +22733,7 @@
     "logos-nix_477": {
       "inputs": {
         "nixpkgs": "nixpkgs_477",
-        "nixpkgs-windows": "nixpkgs-windows_432"
+        "nixpkgs-windows": "nixpkgs-windows_433"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22247,7 +22752,7 @@
     "logos-nix_478": {
       "inputs": {
         "nixpkgs": "nixpkgs_478",
-        "nixpkgs-windows": "nixpkgs-windows_433"
+        "nixpkgs-windows": "nixpkgs-windows_434"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22266,14 +22771,14 @@
     "logos-nix_479": {
       "inputs": {
         "nixpkgs": "nixpkgs_479",
-        "nixpkgs-windows": "nixpkgs-windows_434"
+        "nixpkgs-windows": "nixpkgs-windows_435"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -22304,7 +22809,7 @@
     "logos-nix_480": {
       "inputs": {
         "nixpkgs": "nixpkgs_480",
-        "nixpkgs-windows": "nixpkgs-windows_435"
+        "nixpkgs-windows": "nixpkgs-windows_436"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22322,15 +22827,14 @@
     },
     "logos-nix_481": {
       "inputs": {
-        "nixpkgs": "nixpkgs_481",
-        "nixpkgs-windows": "nixpkgs-windows_436"
+        "nixpkgs": "nixpkgs_481"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22398,14 +22902,15 @@
     },
     "logos-nix_485": {
       "inputs": {
-        "nixpkgs": "nixpkgs_485"
+        "nixpkgs": "nixpkgs_485",
+        "nixpkgs-windows": "nixpkgs-windows_440"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22416,14 +22921,15 @@
     },
     "logos-nix_486": {
       "inputs": {
-        "nixpkgs": "nixpkgs_486"
+        "nixpkgs": "nixpkgs_486",
+        "nixpkgs-windows": "nixpkgs-windows_441"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22435,7 +22941,7 @@
     "logos-nix_487": {
       "inputs": {
         "nixpkgs": "nixpkgs_487",
-        "nixpkgs-windows": "nixpkgs-windows_440"
+        "nixpkgs-windows": "nixpkgs-windows_442"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22454,7 +22960,7 @@
     "logos-nix_488": {
       "inputs": {
         "nixpkgs": "nixpkgs_488",
-        "nixpkgs-windows": "nixpkgs-windows_441"
+        "nixpkgs-windows": "nixpkgs-windows_443"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22473,7 +22979,7 @@
     "logos-nix_489": {
       "inputs": {
         "nixpkgs": "nixpkgs_489",
-        "nixpkgs-windows": "nixpkgs-windows_442"
+        "nixpkgs-windows": "nixpkgs-windows_444"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22511,7 +23017,7 @@
     "logos-nix_490": {
       "inputs": {
         "nixpkgs": "nixpkgs_490",
-        "nixpkgs-windows": "nixpkgs-windows_443"
+        "nixpkgs-windows": "nixpkgs-windows_445"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22530,7 +23036,7 @@
     "logos-nix_491": {
       "inputs": {
         "nixpkgs": "nixpkgs_491",
-        "nixpkgs-windows": "nixpkgs-windows_444"
+        "nixpkgs-windows": "nixpkgs-windows_446"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22548,44 +23054,7 @@
     },
     "logos-nix_492": {
       "inputs": {
-        "nixpkgs": "nixpkgs_492",
-        "nixpkgs-windows": "nixpkgs-windows_445"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_493": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_493"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_494": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_494"
+        "nixpkgs": "nixpkgs_492"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -22601,10 +23070,47 @@
         "type": "github"
       }
     },
+    "logos-nix_493": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_493"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_494": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_494",
+        "nixpkgs-windows": "nixpkgs-windows_447"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_495": {
       "inputs": {
         "nixpkgs": "nixpkgs_495",
-        "nixpkgs-windows": "nixpkgs-windows_446"
+        "nixpkgs-windows": "nixpkgs-windows_448"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22623,7 +23129,7 @@
     "logos-nix_496": {
       "inputs": {
         "nixpkgs": "nixpkgs_496",
-        "nixpkgs-windows": "nixpkgs-windows_447"
+        "nixpkgs-windows": "nixpkgs-windows_449"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22642,7 +23148,7 @@
     "logos-nix_497": {
       "inputs": {
         "nixpkgs": "nixpkgs_497",
-        "nixpkgs-windows": "nixpkgs-windows_448"
+        "nixpkgs-windows": "nixpkgs-windows_450"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22661,7 +23167,7 @@
     "logos-nix_498": {
       "inputs": {
         "nixpkgs": "nixpkgs_498",
-        "nixpkgs-windows": "nixpkgs-windows_449"
+        "nixpkgs-windows": "nixpkgs-windows_451"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22680,7 +23186,7 @@
     "logos-nix_499": {
       "inputs": {
         "nixpkgs": "nixpkgs_499",
-        "nixpkgs-windows": "nixpkgs-windows_450"
+        "nixpkgs-windows": "nixpkgs-windows_452"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22737,7 +23243,7 @@
     "logos-nix_500": {
       "inputs": {
         "nixpkgs": "nixpkgs_500",
-        "nixpkgs-windows": "nixpkgs-windows_451"
+        "nixpkgs-windows": "nixpkgs-windows_453"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22756,7 +23262,7 @@
     "logos-nix_501": {
       "inputs": {
         "nixpkgs": "nixpkgs_501",
-        "nixpkgs-windows": "nixpkgs-windows_452"
+        "nixpkgs-windows": "nixpkgs-windows_454"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22775,7 +23281,7 @@
     "logos-nix_502": {
       "inputs": {
         "nixpkgs": "nixpkgs_502",
-        "nixpkgs-windows": "nixpkgs-windows_453"
+        "nixpkgs-windows": "nixpkgs-windows_455"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22794,7 +23300,7 @@
     "logos-nix_503": {
       "inputs": {
         "nixpkgs": "nixpkgs_503",
-        "nixpkgs-windows": "nixpkgs-windows_454"
+        "nixpkgs-windows": "nixpkgs-windows_456"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22813,7 +23319,7 @@
     "logos-nix_504": {
       "inputs": {
         "nixpkgs": "nixpkgs_504",
-        "nixpkgs-windows": "nixpkgs-windows_455"
+        "nixpkgs-windows": "nixpkgs-windows_457"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22832,7 +23338,7 @@
     "logos-nix_505": {
       "inputs": {
         "nixpkgs": "nixpkgs_505",
-        "nixpkgs-windows": "nixpkgs-windows_456"
+        "nixpkgs-windows": "nixpkgs-windows_458"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22851,7 +23357,7 @@
     "logos-nix_506": {
       "inputs": {
         "nixpkgs": "nixpkgs_506",
-        "nixpkgs-windows": "nixpkgs-windows_457"
+        "nixpkgs-windows": "nixpkgs-windows_459"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22870,7 +23376,7 @@
     "logos-nix_507": {
       "inputs": {
         "nixpkgs": "nixpkgs_507",
-        "nixpkgs-windows": "nixpkgs-windows_458"
+        "nixpkgs-windows": "nixpkgs-windows_460"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22889,7 +23395,7 @@
     "logos-nix_508": {
       "inputs": {
         "nixpkgs": "nixpkgs_508",
-        "nixpkgs-windows": "nixpkgs-windows_459"
+        "nixpkgs-windows": "nixpkgs-windows_461"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22908,7 +23414,7 @@
     "logos-nix_509": {
       "inputs": {
         "nixpkgs": "nixpkgs_509",
-        "nixpkgs-windows": "nixpkgs-windows_460"
+        "nixpkgs-windows": "nixpkgs-windows_462"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22946,7 +23452,7 @@
     "logos-nix_510": {
       "inputs": {
         "nixpkgs": "nixpkgs_510",
-        "nixpkgs-windows": "nixpkgs-windows_461"
+        "nixpkgs-windows": "nixpkgs-windows_463"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22965,7 +23471,7 @@
     "logos-nix_511": {
       "inputs": {
         "nixpkgs": "nixpkgs_511",
-        "nixpkgs-windows": "nixpkgs-windows_462"
+        "nixpkgs-windows": "nixpkgs-windows_464"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22984,14 +23490,14 @@
     "logos-nix_512": {
       "inputs": {
         "nixpkgs": "nixpkgs_512",
-        "nixpkgs-windows": "nixpkgs-windows_463"
+        "nixpkgs-windows": "nixpkgs-windows_465"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23003,7 +23509,7 @@
     "logos-nix_513": {
       "inputs": {
         "nixpkgs": "nixpkgs_513",
-        "nixpkgs-windows": "nixpkgs-windows_464"
+        "nixpkgs-windows": "nixpkgs-windows_466"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23022,7 +23528,7 @@
     "logos-nix_514": {
       "inputs": {
         "nixpkgs": "nixpkgs_514",
-        "nixpkgs-windows": "nixpkgs-windows_465"
+        "nixpkgs-windows": "nixpkgs-windows_467"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23041,14 +23547,14 @@
     "logos-nix_515": {
       "inputs": {
         "nixpkgs": "nixpkgs_515",
-        "nixpkgs-windows": "nixpkgs-windows_466"
+        "nixpkgs-windows": "nixpkgs-windows_468"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23060,7 +23566,7 @@
     "logos-nix_516": {
       "inputs": {
         "nixpkgs": "nixpkgs_516",
-        "nixpkgs-windows": "nixpkgs-windows_467"
+        "nixpkgs-windows": "nixpkgs-windows_469"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23079,7 +23585,7 @@
     "logos-nix_517": {
       "inputs": {
         "nixpkgs": "nixpkgs_517",
-        "nixpkgs-windows": "nixpkgs-windows_468"
+        "nixpkgs-windows": "nixpkgs-windows_470"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23098,7 +23604,7 @@
     "logos-nix_518": {
       "inputs": {
         "nixpkgs": "nixpkgs_518",
-        "nixpkgs-windows": "nixpkgs-windows_469"
+        "nixpkgs-windows": "nixpkgs-windows_471"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23117,7 +23623,7 @@
     "logos-nix_519": {
       "inputs": {
         "nixpkgs": "nixpkgs_519",
-        "nixpkgs-windows": "nixpkgs-windows_470"
+        "nixpkgs-windows": "nixpkgs-windows_472"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23154,7 +23660,7 @@
     "logos-nix_520": {
       "inputs": {
         "nixpkgs": "nixpkgs_520",
-        "nixpkgs-windows": "nixpkgs-windows_471"
+        "nixpkgs-windows": "nixpkgs-windows_473"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23173,7 +23679,7 @@
     "logos-nix_521": {
       "inputs": {
         "nixpkgs": "nixpkgs_521",
-        "nixpkgs-windows": "nixpkgs-windows_472"
+        "nixpkgs-windows": "nixpkgs-windows_474"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23192,7 +23698,7 @@
     "logos-nix_522": {
       "inputs": {
         "nixpkgs": "nixpkgs_522",
-        "nixpkgs-windows": "nixpkgs-windows_473"
+        "nixpkgs-windows": "nixpkgs-windows_475"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23211,7 +23717,7 @@
     "logos-nix_523": {
       "inputs": {
         "nixpkgs": "nixpkgs_523",
-        "nixpkgs-windows": "nixpkgs-windows_474"
+        "nixpkgs-windows": "nixpkgs-windows_476"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23230,7 +23736,7 @@
     "logos-nix_524": {
       "inputs": {
         "nixpkgs": "nixpkgs_524",
-        "nixpkgs-windows": "nixpkgs-windows_475"
+        "nixpkgs-windows": "nixpkgs-windows_477"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23249,7 +23755,7 @@
     "logos-nix_525": {
       "inputs": {
         "nixpkgs": "nixpkgs_525",
-        "nixpkgs-windows": "nixpkgs-windows_476"
+        "nixpkgs-windows": "nixpkgs-windows_478"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23268,7 +23774,7 @@
     "logos-nix_526": {
       "inputs": {
         "nixpkgs": "nixpkgs_526",
-        "nixpkgs-windows": "nixpkgs-windows_477"
+        "nixpkgs-windows": "nixpkgs-windows_479"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23287,7 +23793,7 @@
     "logos-nix_527": {
       "inputs": {
         "nixpkgs": "nixpkgs_527",
-        "nixpkgs-windows": "nixpkgs-windows_478"
+        "nixpkgs-windows": "nixpkgs-windows_480"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23306,7 +23812,7 @@
     "logos-nix_528": {
       "inputs": {
         "nixpkgs": "nixpkgs_528",
-        "nixpkgs-windows": "nixpkgs-windows_479"
+        "nixpkgs-windows": "nixpkgs-windows_481"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23325,7 +23831,7 @@
     "logos-nix_529": {
       "inputs": {
         "nixpkgs": "nixpkgs_529",
-        "nixpkgs-windows": "nixpkgs-windows_480"
+        "nixpkgs-windows": "nixpkgs-windows_482"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23362,7 +23868,7 @@
     "logos-nix_530": {
       "inputs": {
         "nixpkgs": "nixpkgs_530",
-        "nixpkgs-windows": "nixpkgs-windows_481"
+        "nixpkgs-windows": "nixpkgs-windows_483"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23381,7 +23887,7 @@
     "logos-nix_531": {
       "inputs": {
         "nixpkgs": "nixpkgs_531",
-        "nixpkgs-windows": "nixpkgs-windows_482"
+        "nixpkgs-windows": "nixpkgs-windows_484"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23400,7 +23906,7 @@
     "logos-nix_532": {
       "inputs": {
         "nixpkgs": "nixpkgs_532",
-        "nixpkgs-windows": "nixpkgs-windows_483"
+        "nixpkgs-windows": "nixpkgs-windows_485"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23419,7 +23925,7 @@
     "logos-nix_533": {
       "inputs": {
         "nixpkgs": "nixpkgs_533",
-        "nixpkgs-windows": "nixpkgs-windows_484"
+        "nixpkgs-windows": "nixpkgs-windows_486"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23437,14 +23943,15 @@
     },
     "logos-nix_534": {
       "inputs": {
-        "nixpkgs": "nixpkgs_534"
+        "nixpkgs": "nixpkgs_534",
+        "nixpkgs-windows": "nixpkgs-windows_487"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23455,14 +23962,15 @@
     },
     "logos-nix_535": {
       "inputs": {
-        "nixpkgs": "nixpkgs_535"
+        "nixpkgs": "nixpkgs_535",
+        "nixpkgs-windows": "nixpkgs-windows_488"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23474,7 +23982,7 @@
     "logos-nix_536": {
       "inputs": {
         "nixpkgs": "nixpkgs_536",
-        "nixpkgs-windows": "nixpkgs-windows_485"
+        "nixpkgs-windows": "nixpkgs-windows_489"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23492,15 +24000,14 @@
     },
     "logos-nix_537": {
       "inputs": {
-        "nixpkgs": "nixpkgs_537",
-        "nixpkgs-windows": "nixpkgs-windows_486"
+        "nixpkgs": "nixpkgs_537"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23511,15 +24018,14 @@
     },
     "logos-nix_538": {
       "inputs": {
-        "nixpkgs": "nixpkgs_538",
-        "nixpkgs-windows": "nixpkgs-windows_487"
+        "nixpkgs": "nixpkgs_538"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23531,7 +24037,7 @@
     "logos-nix_539": {
       "inputs": {
         "nixpkgs": "nixpkgs_539",
-        "nixpkgs-windows": "nixpkgs-windows_488"
+        "nixpkgs-windows": "nixpkgs-windows_490"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23569,7 +24075,7 @@
     "logos-nix_540": {
       "inputs": {
         "nixpkgs": "nixpkgs_540",
-        "nixpkgs-windows": "nixpkgs-windows_489"
+        "nixpkgs-windows": "nixpkgs-windows_491"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23588,7 +24094,7 @@
     "logos-nix_541": {
       "inputs": {
         "nixpkgs": "nixpkgs_541",
-        "nixpkgs-windows": "nixpkgs-windows_490"
+        "nixpkgs-windows": "nixpkgs-windows_492"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23607,7 +24113,7 @@
     "logos-nix_542": {
       "inputs": {
         "nixpkgs": "nixpkgs_542",
-        "nixpkgs-windows": "nixpkgs-windows_491"
+        "nixpkgs-windows": "nixpkgs-windows_493"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23626,7 +24132,7 @@
     "logos-nix_543": {
       "inputs": {
         "nixpkgs": "nixpkgs_543",
-        "nixpkgs-windows": "nixpkgs-windows_492"
+        "nixpkgs-windows": "nixpkgs-windows_494"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23645,7 +24151,7 @@
     "logos-nix_544": {
       "inputs": {
         "nixpkgs": "nixpkgs_544",
-        "nixpkgs-windows": "nixpkgs-windows_493"
+        "nixpkgs-windows": "nixpkgs-windows_495"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23664,7 +24170,7 @@
     "logos-nix_545": {
       "inputs": {
         "nixpkgs": "nixpkgs_545",
-        "nixpkgs-windows": "nixpkgs-windows_494"
+        "nixpkgs-windows": "nixpkgs-windows_496"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23683,7 +24189,7 @@
     "logos-nix_546": {
       "inputs": {
         "nixpkgs": "nixpkgs_546",
-        "nixpkgs-windows": "nixpkgs-windows_495"
+        "nixpkgs-windows": "nixpkgs-windows_497"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23701,14 +24207,15 @@
     },
     "logos-nix_547": {
       "inputs": {
-        "nixpkgs": "nixpkgs_547"
+        "nixpkgs": "nixpkgs_547",
+        "nixpkgs-windows": "nixpkgs-windows_498"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23719,14 +24226,15 @@
     },
     "logos-nix_548": {
       "inputs": {
-        "nixpkgs": "nixpkgs_548"
+        "nixpkgs": "nixpkgs_548",
+        "nixpkgs-windows": "nixpkgs-windows_499"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23738,7 +24246,7 @@
     "logos-nix_549": {
       "inputs": {
         "nixpkgs": "nixpkgs_549",
-        "nixpkgs-windows": "nixpkgs-windows_496"
+        "nixpkgs-windows": "nixpkgs-windows_500"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23775,15 +24283,14 @@
     },
     "logos-nix_550": {
       "inputs": {
-        "nixpkgs": "nixpkgs_550",
-        "nixpkgs-windows": "nixpkgs-windows_497"
+        "nixpkgs": "nixpkgs_550"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23794,15 +24301,14 @@
     },
     "logos-nix_551": {
       "inputs": {
-        "nixpkgs": "nixpkgs_551",
-        "nixpkgs-windows": "nixpkgs-windows_498"
+        "nixpkgs": "nixpkgs_551"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23814,7 +24320,7 @@
     "logos-nix_552": {
       "inputs": {
         "nixpkgs": "nixpkgs_552",
-        "nixpkgs-windows": "nixpkgs-windows_499"
+        "nixpkgs-windows": "nixpkgs-windows_501"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23833,7 +24339,7 @@
     "logos-nix_553": {
       "inputs": {
         "nixpkgs": "nixpkgs_553",
-        "nixpkgs-windows": "nixpkgs-windows_500"
+        "nixpkgs-windows": "nixpkgs-windows_502"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23852,14 +24358,14 @@
     "logos-nix_554": {
       "inputs": {
         "nixpkgs": "nixpkgs_554",
-        "nixpkgs-windows": "nixpkgs-windows_501"
+        "nixpkgs-windows": "nixpkgs-windows_503"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23871,7 +24377,7 @@
     "logos-nix_555": {
       "inputs": {
         "nixpkgs": "nixpkgs_555",
-        "nixpkgs-windows": "nixpkgs-windows_502"
+        "nixpkgs-windows": "nixpkgs-windows_504"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23889,26 +24395,8 @@
     },
     "logos-nix_556": {
       "inputs": {
-        "nixpkgs": "nixpkgs_556"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_557": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_557",
-        "nixpkgs-windows": "nixpkgs-windows_503"
+        "nixpkgs": "nixpkgs_556",
+        "nixpkgs-windows": "nixpkgs-windows_505"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23924,10 +24412,29 @@
         "type": "github"
       }
     },
+    "logos-nix_557": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_557",
+        "nixpkgs-windows": "nixpkgs-windows_506"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_558": {
       "inputs": {
         "nixpkgs": "nixpkgs_558",
-        "nixpkgs-windows": "nixpkgs-windows_504"
+        "nixpkgs-windows": "nixpkgs-windows_507"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23945,15 +24452,14 @@
     },
     "logos-nix_559": {
       "inputs": {
-        "nixpkgs": "nixpkgs_559",
-        "nixpkgs-windows": "nixpkgs-windows_505"
+        "nixpkgs": "nixpkgs_559"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23984,7 +24490,7 @@
     "logos-nix_560": {
       "inputs": {
         "nixpkgs": "nixpkgs_560",
-        "nixpkgs-windows": "nixpkgs-windows_506"
+        "nixpkgs-windows": "nixpkgs-windows_508"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24003,7 +24509,7 @@
     "logos-nix_561": {
       "inputs": {
         "nixpkgs": "nixpkgs_561",
-        "nixpkgs-windows": "nixpkgs-windows_507"
+        "nixpkgs-windows": "nixpkgs-windows_509"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24022,7 +24528,7 @@
     "logos-nix_562": {
       "inputs": {
         "nixpkgs": "nixpkgs_562",
-        "nixpkgs-windows": "nixpkgs-windows_508"
+        "nixpkgs-windows": "nixpkgs-windows_510"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24041,7 +24547,7 @@
     "logos-nix_563": {
       "inputs": {
         "nixpkgs": "nixpkgs_563",
-        "nixpkgs-windows": "nixpkgs-windows_509"
+        "nixpkgs-windows": "nixpkgs-windows_511"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24060,7 +24566,7 @@
     "logos-nix_564": {
       "inputs": {
         "nixpkgs": "nixpkgs_564",
-        "nixpkgs-windows": "nixpkgs-windows_510"
+        "nixpkgs-windows": "nixpkgs-windows_512"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24079,7 +24585,7 @@
     "logos-nix_565": {
       "inputs": {
         "nixpkgs": "nixpkgs_565",
-        "nixpkgs-windows": "nixpkgs-windows_511"
+        "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24098,7 +24604,7 @@
     "logos-nix_566": {
       "inputs": {
         "nixpkgs": "nixpkgs_566",
-        "nixpkgs-windows": "nixpkgs-windows_512"
+        "nixpkgs-windows": "nixpkgs-windows_514"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24116,14 +24622,15 @@
     },
     "logos-nix_567": {
       "inputs": {
-        "nixpkgs": "nixpkgs_567"
+        "nixpkgs": "nixpkgs_567",
+        "nixpkgs-windows": "nixpkgs-windows_515"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24134,14 +24641,15 @@
     },
     "logos-nix_568": {
       "inputs": {
-        "nixpkgs": "nixpkgs_568"
+        "nixpkgs": "nixpkgs_568",
+        "nixpkgs-windows": "nixpkgs-windows_516"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24153,7 +24661,7 @@
     "logos-nix_569": {
       "inputs": {
         "nixpkgs": "nixpkgs_569",
-        "nixpkgs-windows": "nixpkgs-windows_513"
+        "nixpkgs-windows": "nixpkgs-windows_517"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24190,15 +24698,14 @@
     },
     "logos-nix_570": {
       "inputs": {
-        "nixpkgs": "nixpkgs_570",
-        "nixpkgs-windows": "nixpkgs-windows_514"
+        "nixpkgs": "nixpkgs_570"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24209,15 +24716,14 @@
     },
     "logos-nix_571": {
       "inputs": {
-        "nixpkgs": "nixpkgs_571",
-        "nixpkgs-windows": "nixpkgs-windows_515"
+        "nixpkgs": "nixpkgs_571"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24229,7 +24735,7 @@
     "logos-nix_572": {
       "inputs": {
         "nixpkgs": "nixpkgs_572",
-        "nixpkgs-windows": "nixpkgs-windows_516"
+        "nixpkgs-windows": "nixpkgs-windows_518"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24248,7 +24754,7 @@
     "logos-nix_573": {
       "inputs": {
         "nixpkgs": "nixpkgs_573",
-        "nixpkgs-windows": "nixpkgs-windows_517"
+        "nixpkgs-windows": "nixpkgs-windows_519"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24267,7 +24773,7 @@
     "logos-nix_574": {
       "inputs": {
         "nixpkgs": "nixpkgs_574",
-        "nixpkgs-windows": "nixpkgs-windows_518"
+        "nixpkgs-windows": "nixpkgs-windows_520"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24285,14 +24791,15 @@
     },
     "logos-nix_575": {
       "inputs": {
-        "nixpkgs": "nixpkgs_575"
+        "nixpkgs": "nixpkgs_575",
+        "nixpkgs-windows": "nixpkgs-windows_521"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24303,14 +24810,15 @@
     },
     "logos-nix_576": {
       "inputs": {
-        "nixpkgs": "nixpkgs_576"
+        "nixpkgs": "nixpkgs_576",
+        "nixpkgs-windows": "nixpkgs-windows_522"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24322,7 +24830,7 @@
     "logos-nix_577": {
       "inputs": {
         "nixpkgs": "nixpkgs_577",
-        "nixpkgs-windows": "nixpkgs-windows_519"
+        "nixpkgs-windows": "nixpkgs-windows_523"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24340,15 +24848,14 @@
     },
     "logos-nix_578": {
       "inputs": {
-        "nixpkgs": "nixpkgs_578",
-        "nixpkgs-windows": "nixpkgs-windows_520"
+        "nixpkgs": "nixpkgs_578"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24359,15 +24866,14 @@
     },
     "logos-nix_579": {
       "inputs": {
-        "nixpkgs": "nixpkgs_579",
-        "nixpkgs-windows": "nixpkgs-windows_521"
+        "nixpkgs": "nixpkgs_579"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24398,7 +24904,7 @@
     "logos-nix_580": {
       "inputs": {
         "nixpkgs": "nixpkgs_580",
-        "nixpkgs-windows": "nixpkgs-windows_522"
+        "nixpkgs-windows": "nixpkgs-windows_524"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24416,14 +24922,15 @@
     },
     "logos-nix_581": {
       "inputs": {
-        "nixpkgs": "nixpkgs_581"
+        "nixpkgs": "nixpkgs_581",
+        "nixpkgs-windows": "nixpkgs-windows_525"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24435,7 +24942,7 @@
     "logos-nix_582": {
       "inputs": {
         "nixpkgs": "nixpkgs_582",
-        "nixpkgs-windows": "nixpkgs-windows_523"
+        "nixpkgs-windows": "nixpkgs-windows_526"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24454,7 +24961,7 @@
     "logos-nix_583": {
       "inputs": {
         "nixpkgs": "nixpkgs_583",
-        "nixpkgs-windows": "nixpkgs-windows_524"
+        "nixpkgs-windows": "nixpkgs-windows_527"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24472,15 +24979,14 @@
     },
     "logos-nix_584": {
       "inputs": {
-        "nixpkgs": "nixpkgs_584",
-        "nixpkgs-windows": "nixpkgs-windows_525"
+        "nixpkgs": "nixpkgs_584"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24492,7 +24998,7 @@
     "logos-nix_585": {
       "inputs": {
         "nixpkgs": "nixpkgs_585",
-        "nixpkgs-windows": "nixpkgs-windows_526"
+        "nixpkgs-windows": "nixpkgs-windows_528"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24510,14 +25016,15 @@
     },
     "logos-nix_586": {
       "inputs": {
-        "nixpkgs": "nixpkgs_586"
+        "nixpkgs": "nixpkgs_586",
+        "nixpkgs-windows": "nixpkgs-windows_529"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24528,14 +25035,15 @@
     },
     "logos-nix_587": {
       "inputs": {
-        "nixpkgs": "nixpkgs_587"
+        "nixpkgs": "nixpkgs_587",
+        "nixpkgs-windows": "nixpkgs-windows_530"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24547,7 +25055,7 @@
     "logos-nix_588": {
       "inputs": {
         "nixpkgs": "nixpkgs_588",
-        "nixpkgs-windows": "nixpkgs-windows_527"
+        "nixpkgs-windows": "nixpkgs-windows_531"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24565,15 +25073,14 @@
     },
     "logos-nix_589": {
       "inputs": {
-        "nixpkgs": "nixpkgs_589",
-        "nixpkgs-windows": "nixpkgs-windows_528"
+        "nixpkgs": "nixpkgs_589"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -24603,15 +25110,14 @@
     },
     "logos-nix_590": {
       "inputs": {
-        "nixpkgs": "nixpkgs_590",
-        "nixpkgs-windows": "nixpkgs-windows_529"
+        "nixpkgs": "nixpkgs_590"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24623,7 +25129,7 @@
     "logos-nix_591": {
       "inputs": {
         "nixpkgs": "nixpkgs_591",
-        "nixpkgs-windows": "nixpkgs-windows_530"
+        "nixpkgs-windows": "nixpkgs-windows_532"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24641,14 +25147,15 @@
     },
     "logos-nix_592": {
       "inputs": {
-        "nixpkgs": "nixpkgs_592"
+        "nixpkgs": "nixpkgs_592",
+        "nixpkgs-windows": "nixpkgs-windows_533"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24659,14 +25166,15 @@
     },
     "logos-nix_593": {
       "inputs": {
-        "nixpkgs": "nixpkgs_593"
+        "nixpkgs": "nixpkgs_593",
+        "nixpkgs-windows": "nixpkgs-windows_534"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24678,7 +25186,7 @@
     "logos-nix_594": {
       "inputs": {
         "nixpkgs": "nixpkgs_594",
-        "nixpkgs-windows": "nixpkgs-windows_531"
+        "nixpkgs-windows": "nixpkgs-windows_535"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24696,15 +25204,14 @@
     },
     "logos-nix_595": {
       "inputs": {
-        "nixpkgs": "nixpkgs_595",
-        "nixpkgs-windows": "nixpkgs-windows_532"
+        "nixpkgs": "nixpkgs_595"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24715,15 +25222,14 @@
     },
     "logos-nix_596": {
       "inputs": {
-        "nixpkgs": "nixpkgs_596",
-        "nixpkgs-windows": "nixpkgs-windows_533"
+        "nixpkgs": "nixpkgs_596"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24735,7 +25241,7 @@
     "logos-nix_597": {
       "inputs": {
         "nixpkgs": "nixpkgs_597",
-        "nixpkgs-windows": "nixpkgs-windows_534"
+        "nixpkgs-windows": "nixpkgs-windows_536"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24753,14 +25259,34 @@
     },
     "logos-nix_598": {
       "inputs": {
-        "nixpkgs": "nixpkgs_598"
+        "nixpkgs": "nixpkgs_598",
+        "nixpkgs-windows": "nixpkgs-windows_537"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_599": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_599",
+        "nixpkgs-windows": "nixpkgs-windows_538"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24799,6 +25325,43 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_600": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_600",
+        "nixpkgs-windows": "nixpkgs-windows_539"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_601": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_601"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25631,10 +26194,10 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_244",
-        "logos-package": "logos-package_23",
-        "nix-bundle-appimage": "nix-bundle-appimage_17",
-        "nix-bundle-dir": "nix-bundle-dir_39",
+        "logos-nix": "logos-nix_329",
+        "logos-package": "logos-package_30",
+        "nix-bundle-appimage": "nix-bundle-appimage_22",
+        "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -25643,11 +26206,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786654381,
-        "narHash": "sha256-+ZGmuWlHZK6wB1L6a4jcSxslvZ82OE/3d8QCZv4/7pc=",
+        "lastModified": 1787836472,
+        "narHash": "sha256-qMp2t31tdkKNSIYuTu0s4AOzuzXCLUYW0VTNju5k+94=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "5514b0c30801ebdb6db85f89e12fc32eb1188f79",
+        "rev": "b6624a360812944a190945d681940eb911faa500",
         "type": "github"
       },
       "original": {
@@ -25662,44 +26225,16 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1787454917,
-        "narHash": "sha256-DjejFdZpf7WnJc1Qz5Q1L8P2L+IMxv7JQaVafYnFyBI=",
+        "lastModified": 1787838955,
+        "narHash": "sha256-z0amgHyySV7QjbkbME4z0mCH6FK9FaKIpK1VIWhmMTY=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "e226c6b5513339903784791b1c88a240516a1bb6",
+        "rev": "eb1e8ebccf2558d4872ed2457dc10018d5e5a264",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "type": "github"
-      }
-    },
-    "logos-package-downloader_2": {
-      "inputs": {
-        "logos-nix": "logos-nix_491",
-        "logos-package": "logos-package_48",
-        "nix-bundle-appimage": "nix-bundle-appimage_35",
-        "nix-bundle-dir": "nix-bundle-dir_81",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-package-downloader",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786654381,
-        "narHash": "sha256-+ZGmuWlHZK6wB1L6a4jcSxslvZ82OE/3d8QCZv4/7pc=",
-        "owner": "logos-co",
-        "repo": "logos-package-downloader",
-        "rev": "5514b0c30801ebdb6db85f89e12fc32eb1188f79",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-downloader",
         "type": "github"
       }
     },
@@ -25734,8 +26269,8 @@
     },
     "logos-package-manager-module": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_7",
-        "logos-package-manager": "logos-package-manager_14"
+        "logos-module-builder": "logos-module-builder_9",
+        "logos-package-manager": "logos-package-manager_17"
       },
       "locked": {
         "lastModified": 1787692588,
@@ -25753,9 +26288,11 @@
     },
     "logos-package-manager-ui": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_9",
-        "logos-package": "logos-package_40",
-        "package_downloader": "package_downloader",
+        "logos-module-builder": "logos-module-builder_11",
+        "logos-package": "logos-package_47",
+        "package_downloader": [
+          "logos-package-downloader-module"
+        ],
         "package_manager": "package_manager"
       },
       "locked": {
@@ -25774,22 +26311,29 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_249",
+        "logos-nix": "logos-nix_288",
         "logos-package": "logos-package_24",
-        "nix-bundle-appimage": "nix-bundle-appimage_18",
-        "nix-bundle-dir": "nix-bundle-dir_41",
+        "nix-bundle-appimage": "nix-bundle-appimage_19",
+        "nix-bundle-dir": "nix-bundle-dir_42",
         "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787428523,
-        "narHash": "sha256-WV30+aqn7MOnz9neSY1ni8AggRPROHsc3rrocx32/1U=",
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "7c5aad9ae59961a0e28b13ca37b2d18baf4f0e9d",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
         "type": "github"
       },
       "original": {
@@ -25800,29 +26344,26 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_290",
+        "logos-nix": "logos-nix_297",
         "logos-package": "logos-package_26",
-        "nix-bundle-appimage": "nix-bundle-appimage_21",
-        "nix-bundle-dir": "nix-bundle-dir_46",
+        "nix-bundle-appimage": "nix-bundle-appimage_20",
+        "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "lastModified": 1787819921,
+        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
         "type": "github"
       },
       "original": {
@@ -25833,26 +26374,25 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_321",
         "logos-package": "logos-package_28",
-        "nix-bundle-appimage": "nix-bundle-appimage_22",
-        "nix-bundle-dir": "nix-bundle-dir_49",
+        "nix-bundle-appimage": "nix-bundle-appimage_21",
+        "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "lastModified": 1787819921,
+        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
         "type": "github"
       },
       "original": {
@@ -25863,41 +26403,11 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_323",
-        "logos-package": "logos-package_30",
+        "logos-nix": "logos-nix_334",
+        "logos-package": "logos-package_31",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
-        "nix-bundle-dir": "nix-bundle-dir_52",
+        "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_14": {
-      "inputs": {
-        "logos-nix": "logos-nix_331",
-        "logos-package": "logos-package_32",
-        "nix-bundle-appimage": "nix-bundle-appimage_24",
-        "nix-bundle-dir": "nix-bundle-dir_55",
-        "nixpkgs": [
-          "logos-package-manager-module",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -25917,20 +26427,50 @@
         "type": "github"
       }
     },
-    "logos-package-manager_15": {
+    "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
-        "logos-package": "logos-package_34",
-        "nix-bundle-appimage": "nix-bundle-appimage_27",
-        "nix-bundle-dir": "nix-bundle-dir_60",
+        "logos-nix": "logos-nix_375",
+        "logos-package": "logos-package_33",
+        "nix-bundle-appimage": "nix-bundle-appimage_26",
+        "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_15": {
+      "inputs": {
+        "logos-nix": "logos-nix_388",
+        "logos-package": "logos-package_35",
+        "nix-bundle-appimage": "nix-bundle-appimage_27",
+        "nix-bundle-dir": "nix-bundle-dir_61",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -25952,42 +26492,12 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_385",
-        "logos-package": "logos-package_36",
+        "logos-nix": "logos-nix_408",
+        "logos-package": "logos-package_37",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
-        "nix-bundle-dir": "nix-bundle-dir_63",
+        "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_17": {
-      "inputs": {
-        "logos-nix": "logos-nix_405",
-        "logos-package": "logos-package_38",
-        "nix-bundle-appimage": "nix-bundle-appimage_29",
-        "nix-bundle-dir": "nix-bundle-dir_66",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -26009,15 +26519,41 @@
         "type": "github"
       }
     },
+    "logos-package-manager_17": {
+      "inputs": {
+        "logos-nix": "logos-nix_416",
+        "logos-package": "logos-package_39",
+        "nix-bundle-appimage": "nix-bundle-appimage_29",
+        "nix-bundle-dir": "nix-bundle-dir_67",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787428523,
+        "narHash": "sha256-WV30+aqn7MOnz9neSY1ni8AggRPROHsc3rrocx32/1U=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "7c5aad9ae59961a0e28b13ca37b2d18baf4f0e9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
-        "logos-package": "logos-package_42",
+        "logos-nix": "logos-nix_457",
+        "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26045,13 +26581,12 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
-        "logos-package": "logos-package_44",
+        "logos-nix": "logos-nix_470",
+        "logos-package": "logos-package_43",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26106,13 +26641,12 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_483",
-        "logos-package": "logos-package_46",
+        "logos-nix": "logos-nix_490",
+        "logos-package": "logos-package_45",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -26136,10 +26670,10 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
-        "logos-package": "logos-package_50",
-        "nix-bundle-appimage": "nix-bundle-appimage_38",
-        "nix-bundle-dir": "nix-bundle-dir_86",
+        "logos-nix": "logos-nix_535",
+        "logos-package": "logos-package_49",
+        "nix-bundle-appimage": "nix-bundle-appimage_37",
+        "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -26170,10 +26704,10 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_545",
-        "logos-package": "logos-package_52",
-        "nix-bundle-appimage": "nix-bundle-appimage_39",
-        "nix-bundle-dir": "nix-bundle-dir_89",
+        "logos-nix": "logos-nix_548",
+        "logos-package": "logos-package_51",
+        "nix-bundle-appimage": "nix-bundle-appimage_38",
+        "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -26201,10 +26735,10 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
-        "logos-package": "logos-package_54",
-        "nix-bundle-appimage": "nix-bundle-appimage_40",
-        "nix-bundle-dir": "nix-bundle-dir_92",
+        "logos-nix": "logos-nix_568",
+        "logos-package": "logos-package_53",
+        "nix-bundle-appimage": "nix-bundle-appimage_39",
+        "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -26231,10 +26765,10 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_573",
-        "logos-package": "logos-package_56",
-        "nix-bundle-appimage": "nix-bundle-appimage_41",
-        "nix-bundle-dir": "nix-bundle-dir_95",
+        "logos-nix": "logos-nix_576",
+        "logos-package": "logos-package_55",
+        "nix-bundle-appimage": "nix-bundle-appimage_40",
+        "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -26259,10 +26793,10 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_590",
-        "logos-package": "logos-package_57",
-        "nix-bundle-appimage": "nix-bundle-appimage_43",
-        "nix-bundle-dir": "nix-bundle-dir_99",
+        "logos-nix": "logos-nix_593",
+        "logos-package": "logos-package_56",
+        "nix-bundle-appimage": "nix-bundle-appimage_42",
+        "nix-bundle-dir": "nix-bundle-dir_97",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -26405,12 +26939,49 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_207",
         "logos-package": "logos-package_17",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
         "nix-bundle-dir": "nix-bundle-dir_30",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787819921,
+        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_8": {
+      "inputs": {
+        "logos-nix": "logos-nix_255",
+        "logos-package": "logos-package_20",
+        "nix-bundle-appimage": "nix-bundle-appimage_17",
+        "nix-bundle-dir": "nix-bundle-dir_36",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26436,46 +27007,21 @@
         "type": "github"
       }
     },
-    "logos-package-manager_8": {
+    "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
-        "logos-package": "logos-package_19",
-        "nix-bundle-appimage": "nix-bundle-appimage_15",
-        "nix-bundle-dir": "nix-bundle-dir_33",
+        "logos-nix": "logos-nix_268",
+        "logos-package": "logos-package_22",
+        "nix-bundle-appimage": "nix-bundle-appimage_18",
+        "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_9": {
-      "inputs": {
-        "logos-nix": "logos-nix_236",
-        "logos-package": "logos-package_21",
-        "nix-bundle-appimage": "nix-bundle-appimage_16",
-        "nix-bundle-dir": "nix-bundle-dir_36",
-        "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -26659,7 +27205,7 @@
     },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -26674,11 +27220,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -26689,7 +27235,7 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_208",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -26705,11 +27251,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -26720,7 +27266,7 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_209",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -26736,11 +27282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -26751,13 +27297,19 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_252",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -26806,35 +27358,17 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_256",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_21": {
-      "inputs": {
-        "logos-nix": "logos-nix_237",
-        "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -26857,11 +27391,19 @@
         "type": "github"
       }
     },
-    "logos-package_22": {
+    "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
+        "logos-nix": "logos-nix_261",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -26884,12 +27426,49 @@
         "type": "github"
       }
     },
-    "logos-package_23": {
+    "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
+        "logos-nix": "logos-nix_269",
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_23": {
+      "inputs": {
+        "logos-nix": "logos-nix_285",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -26911,8 +27490,15 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
+        "logos-nix": "logos-nix_289",
         "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -26935,14 +27521,15 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_294",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -26965,15 +27552,12 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
+        "logos-nix": "logos-nix_298",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -26981,11 +27565,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -26996,15 +27580,10 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_296",
+        "logos-nix": "logos-nix_318",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -27012,11 +27591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -27027,12 +27606,11 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_304",
+        "logos-nix": "logos-nix_322",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -27040,11 +27618,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -27055,10 +27633,11 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -27066,11 +27645,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -27108,23 +27687,21 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1787819133,
+        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
       "original": {
@@ -27135,12 +27712,9 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27162,10 +27736,15 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_332",
+        "logos-nix": "logos-nix_372",
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27187,15 +27766,16 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27217,16 +27797,16 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
+        "logos-nix": "logos-nix_381",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27248,16 +27828,13 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_378",
+        "logos-nix": "logos-nix_389",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27279,13 +27856,11 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_405",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27307,35 +27882,9 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_406",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -27358,14 +27907,39 @@
         "type": "github"
       }
     },
-    "logos-package_39": {
+    "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_414",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_417",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27414,20 +27988,26 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786629110,
-        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
         "type": "github"
       },
       "original": {
@@ -27438,16 +28018,16 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_458",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27469,17 +28049,16 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_463",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27501,17 +28080,13 @@
     },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27533,14 +28108,11 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_487",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27562,37 +28134,9 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_491",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_46": {
-      "inputs": {
-        "logos-nix": "logos-nix_484",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -27615,12 +28159,11 @@
         "type": "github"
       }
     },
-    "logos-package_47": {
+    "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_489",
+        "logos-nix": "logos-nix_496",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -27643,13 +28186,42 @@
         "type": "github"
       }
     },
-    "logos-package_48": {
+    "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-package-downloader",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786629110,
+        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_48": {
+      "inputs": {
+        "logos-nix": "logos-nix_532",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27671,7 +28243,7 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -27680,7 +28252,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27730,7 +28303,7 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -27740,7 +28313,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27762,17 +28335,14 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_549",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27794,14 +28364,12 @@
     },
     "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_565",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -27823,34 +28391,7 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_54": {
-      "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_569",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -27876,9 +28417,9 @@
         "type": "github"
       }
     },
-    "logos-package_55": {
+    "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_574",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -27904,12 +28445,37 @@
         "type": "github"
       }
     },
-    "logos-package_56": {
+    "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_577",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_56": {
+      "inputs": {
+        "logos-nix": "logos-nix_594",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -27932,32 +28498,7 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_591",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_599",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -28128,18 +28669,16 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_115",
-        "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_419",
+        "logos-lidl": "logos-lidl_117",
+        "logos-module": "logos-module_85",
+        "logos-nix": "logos-nix_426",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -28147,11 +28686,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -28162,12 +28701,11 @@
     },
     "logos-plugin-core_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_121",
-        "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_436",
+        "logos-lidl": "logos-lidl_123",
+        "logos-module": "logos-module_90",
+        "logos-nix": "logos-nix_443",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28177,7 +28715,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28204,9 +28741,9 @@
     },
     "logos-plugin-core_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_138",
-        "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_501",
+        "logos-lidl": "logos-lidl_140",
+        "logos-module": "logos-module_101",
+        "logos-nix": "logos-nix_504",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28238,9 +28775,9 @@
     },
     "logos-plugin-core_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_144",
-        "logos-module": "logos-module_104",
-        "logos-nix": "logos-nix_518",
+        "logos-lidl": "logos-lidl_146",
+        "logos-module": "logos-module_106",
+        "logos-nix": "logos-nix_521",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -28369,11 +28906,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787435195,
-        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -28384,9 +28921,9 @@
     },
     "logos-plugin-core_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_52",
-        "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_189",
+        "logos-lidl": "logos-lidl_54",
+        "logos-module": "logos-module_41",
+        "logos-nix": "logos-nix_193",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -28409,11 +28946,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -28424,16 +28961,24 @@
     },
     "logos-plugin-core_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_69",
-        "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_259",
+        "logos-lidl": "logos-lidl_64",
+        "logos-module": "logos-module_48",
+        "logos-nix": "logos-nix_224",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -28456,11 +29001,15 @@
     },
     "logos-plugin-core_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_75",
-        "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_276",
+        "logos-lidl": "logos-lidl_70",
+        "logos-module": "logos-module_53",
+        "logos-nix": "logos-nix_241",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28469,7 +29018,11 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28496,16 +29049,16 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_92",
-        "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_341",
+        "logos-lidl": "logos-lidl_94",
+        "logos-module": "logos-module_69",
+        "logos-nix": "logos-nix_344",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -28528,11 +29081,11 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_98",
-        "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_358",
+        "logos-lidl": "logos-lidl_100",
+        "logos-module": "logos-module_74",
+        "logos-nix": "logos-nix_361",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28541,7 +29094,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29126,11 +29679,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787435195,
-        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -29170,11 +29723,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -29185,9 +29738,65 @@
     },
     "logos-plugin-qt_23": {
       "inputs": {
-        "logos-lidl": "logos-lidl_53",
-        "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_191",
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_39",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_24": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_55",
+        "logos-module": "logos-module_42",
+        "logos-nix": "logos-nix_195",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -29210,11 +29819,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -29223,7 +29832,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_24": {
+    "logos-plugin-qt_25": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -29235,7 +29844,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_42",
+        "logos-module": "logos-module_43",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -29270,60 +29879,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_25": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_56",
-        "logos-module": "logos-module_43",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -29334,7 +29894,7 @@
     },
     "logos-plugin-qt_26": {
       "inputs": {
-        "logos-lidl": "logos-lidl_59",
+        "logos-lidl": "logos-lidl_58",
         "logos-module": "logos-module_44",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -29343,7 +29903,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -29353,7 +29913,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -29363,7 +29923,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -29384,12 +29944,15 @@
     "logos-plugin-qt_27": {
       "inputs": {
         "logos-lidl": "logos-lidl_61",
-        "logos-module": "logos-module_46",
+        "logos-module": "logos-module_45",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -29397,6 +29960,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -29404,15 +29970,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -29423,33 +29992,36 @@
     },
     "logos-plugin-qt_28": {
       "inputs": {
-        "logos-lidl": "logos-lidl_63",
-        "logos-module": "logos-module_47",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_65",
+        "logos-module": "logos-module_49",
+        "logos-nix": "logos-nix_226",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {
@@ -29460,24 +30032,47 @@
     },
     "logos-plugin-qt_29": {
       "inputs": {
-        "logos-lidl": "logos-lidl_64",
-        "logos-module": "logos-module_48",
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_50",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -29534,33 +30129,44 @@
     },
     "logos-plugin-qt_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_67",
-        "logos-module": "logos-module_49",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_71",
+        "logos-module": "logos-module_54",
+        "logos-nix": "logos-nix_243",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787346530,
-        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -29571,28 +30177,72 @@
     },
     "logos-plugin-qt_31": {
       "inputs": {
-        "logos-lidl": "logos-lidl_70",
-        "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_261",
-        "logos-protocol": [
-          "logos-package-manager-module",
+        "logos-lidl": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_55",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -29603,31 +30253,48 @@
     },
     "logos-plugin-qt_32": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_53",
+        "logos-lidl": "logos-lidl_74",
+        "logos-module": "logos-module_56",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -29647,27 +30314,48 @@
     },
     "logos-plugin-qt_33": {
       "inputs": {
-        "logos-lidl": "logos-lidl_76",
+        "logos-lidl": "logos-lidl_77",
         "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_278",
-        "logos-protocol": [
-          "logos-package-manager-module",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -29687,56 +30375,48 @@
     },
     "logos-plugin-qt_34": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_58",
+        "logos-lidl": "logos-lidl_79",
+        "logos-module": "logos-module_59",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-standalone-app",
+          "logos-liblogos",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -29747,45 +30427,45 @@
     },
     "logos-plugin-qt_35": {
       "inputs": {
-        "logos-lidl": "logos-lidl_79",
-        "logos-module": "logos-module_59",
+        "logos-lidl": "logos-lidl_81",
+        "logos-module": "logos-module_60",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -29797,35 +30477,35 @@
     "logos-plugin-qt_36": {
       "inputs": {
         "logos-lidl": "logos-lidl_82",
-        "logos-module": "logos-module_60",
+        "logos-module": "logos-module_61",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -29845,36 +30525,45 @@
     },
     "logos-plugin-qt_37": {
       "inputs": {
-        "logos-lidl": "logos-lidl_84",
+        "logos-lidl": "logos-lidl_85",
         "logos-module": "logos-module_62",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
         "type": "github"
       },
       "original": {
@@ -29887,31 +30576,24 @@
       "inputs": {
         "logos-lidl": "logos-lidl_86",
         "logos-module": "logos-module_63",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
+        "logos-nix": "logos-nix_303",
+        "logos-protocol": "logos-protocol_48",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -29922,33 +30604,48 @@
     },
     "logos-plugin-qt_39": {
       "inputs": {
-        "logos-lidl": "logos-lidl_87",
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_64",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -29996,33 +30693,25 @@
     },
     "logos-plugin-qt_40": {
       "inputs": {
-        "logos-lidl": "logos-lidl_90",
+        "logos-lidl": "logos-lidl_88",
         "logos-module": "logos-module_65",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
+        "logos-nix": "logos-nix_310",
+        "logos-protocol": "logos-protocol_51",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787346530,
-        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -30033,28 +30722,33 @@
     },
     "logos-plugin-qt_41": {
       "inputs": {
-        "logos-lidl": "logos-lidl_93",
-        "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_343",
-        "logos-protocol": [
-          "logos-package-manager-ui",
+        "logos-lidl": "logos-lidl_89",
+        "logos-module": "logos-module_66",
+        "logos-nix": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787435195,
-        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -30065,40 +30759,33 @@
     },
     "logos-plugin-qt_42": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_69",
+        "logos-lidl": "logos-lidl_92",
+        "logos-module": "logos-module_67",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -30109,24 +30796,16 @@
     },
     "logos-plugin-qt_43": {
       "inputs": {
-        "logos-lidl": "logos-lidl_99",
-        "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_360",
+        "logos-lidl": "logos-lidl_95",
+        "logos-module": "logos-module_70",
+        "logos-nix": "logos-nix_346",
         "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -30134,11 +30813,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -30150,42 +30829,26 @@
     "logos-plugin-qt_44": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_74",
+        "logos-module": "logos-module_71",
         "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -30209,36 +30872,27 @@
     },
     "logos-plugin-qt_45": {
       "inputs": {
-        "logos-lidl": "logos-lidl_102",
+        "logos-lidl": "logos-lidl_101",
         "logos-module": "logos-module_75",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_363",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -30258,36 +30912,47 @@
     },
     "logos-plugin-qt_46": {
       "inputs": {
-        "logos-lidl": "logos-lidl_105",
-        "logos-module": "logos-module_76",
-        "logos-nix": [
-          "logos-package-manager-ui",
+        "logos-lidl": [
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_76",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -30307,99 +30972,34 @@
     },
     "logos-plugin-qt_47": {
       "inputs": {
-        "logos-lidl": "logos-lidl_107",
-        "logos-module": "logos-module_78",
+        "logos-lidl": "logos-lidl_104",
+        "logos-module": "logos-module_77",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_48": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_109",
-        "logos-module": "logos-module_79",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_49": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_110",
-        "logos-module": "logos-module_80",
-        "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30411,6 +31011,95 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_48": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_107",
+        "logos-module": "logos-module_78",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_49": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_109",
+        "logos-module": "logos-module_80",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -30465,22 +31154,96 @@
     },
     "logos-plugin-qt_50": {
       "inputs": {
-        "logos-lidl": "logos-lidl_113",
+        "logos-lidl": "logos-lidl_111",
         "logos-module": "logos-module_81",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_51": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_112",
+        "logos-module": "logos-module_82",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_52": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_115",
+        "logos-module": "logos-module_83",
+        "logos-nix": [
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -30500,110 +31263,18 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_51": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_116",
-        "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_421",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_52": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_85",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
     "logos-plugin-qt_53": {
       "inputs": {
-        "logos-lidl": "logos-lidl_122",
-        "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_438",
+        "logos-lidl": "logos-lidl_118",
+        "logos-module": "logos-module_86",
+        "logos-nix": "logos-nix_428",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -30611,11 +31282,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -30628,45 +31299,25 @@
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_90",
+        "logos-module": "logos-module_87",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -30690,39 +31341,27 @@
     },
     "logos-plugin-qt_55": {
       "inputs": {
-        "logos-lidl": "logos-lidl_125",
+        "logos-lidl": "logos-lidl_124",
         "logos-module": "logos-module_91",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_445",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -30742,39 +31381,47 @@
     },
     "logos-plugin-qt_56": {
       "inputs": {
-        "logos-lidl": "logos-lidl_128",
-        "logos-module": "logos-module_92",
-        "logos-nix": [
+        "logos-lidl": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_92",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -30794,108 +31441,34 @@
     },
     "logos-plugin-qt_57": {
       "inputs": {
-        "logos-lidl": "logos-lidl_130",
-        "logos-module": "logos-module_94",
+        "logos-lidl": "logos-lidl_127",
+        "logos-module": "logos-module_93",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_58": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_132",
-        "logos-module": "logos-module_95",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_59": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_133",
-        "logos-module": "logos-module_96",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30907,6 +31480,95 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_58": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_130",
+        "logos-module": "logos-module_94",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_59": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_132",
+        "logos-module": "logos-module_96",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -30957,25 +31619,96 @@
     },
     "logos-plugin-qt_60": {
       "inputs": {
-        "logos-lidl": "logos-lidl_136",
+        "logos-lidl": "logos-lidl_134",
         "logos-module": "logos-module_97",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_61": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_135",
+        "logos-module": "logos-module_98",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_62": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_138",
+        "logos-module": "logos-module_99",
+        "logos-nix": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -30995,11 +31728,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_61": {
+    "logos-plugin-qt_63": {
       "inputs": {
-        "logos-lidl": "logos-lidl_139",
-        "logos-module": "logos-module_100",
-        "logos-nix": "logos-nix_503",
+        "logos-lidl": "logos-lidl_141",
+        "logos-module": "logos-module_102",
+        "logos-nix": "logos-nix_506",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31029,117 +31762,19 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_62": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_101",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_63": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_145",
-        "logos-module": "logos-module_105",
-        "logos-nix": "logos-nix_520",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
     "logos-plugin-qt_64": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_106",
+        "logos-module": "logos-module_103",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
@@ -31148,20 +31783,12 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -31185,19 +31812,9 @@
     },
     "logos-plugin-qt_65": {
       "inputs": {
-        "logos-lidl": "logos-lidl_148",
+        "logos-lidl": "logos-lidl_147",
         "logos-module": "logos-module_107",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_523",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31206,7 +31823,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -31217,7 +31833,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -31237,7 +31854,17 @@
     },
     "logos-plugin-qt_66": {
       "inputs": {
-        "logos-lidl": "logos-lidl_151",
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_108",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -31247,7 +31874,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -31258,7 +31885,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -31269,7 +31896,9 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -31289,94 +31918,15 @@
     },
     "logos-plugin-qt_67": {
       "inputs": {
-        "logos-lidl": "logos-lidl_153",
-        "logos-module": "logos-module_110",
+        "logos-lidl": "logos-lidl_150",
+        "logos-module": "logos-module_109",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_68": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_155",
-        "logos-module": "logos-module_111",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_69": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_156",
-        "logos-module": "logos-module_112",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
@@ -31385,12 +31935,20 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -31402,6 +31960,101 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_68": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_153",
+        "logos-module": "logos-module_110",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_69": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_155",
+        "logos-module": "logos-module_112",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -31448,8 +32101,88 @@
     },
     "logos-plugin-qt_70": {
       "inputs": {
-        "logos-lidl": "logos-lidl_159",
+        "logos-lidl": "logos-lidl_157",
         "logos-module": "logos-module_113",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_71": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_158",
+        "logos-module": "logos-module_114",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_72": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_161",
+        "logos-module": "logos-module_115",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31486,12 +32219,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_71": {
+    "logos-plugin-qt_73": {
       "inputs": {
-        "logos-lidl": "logos-lidl_160",
-        "logos-module": "logos-module_114",
-        "logos-nix": "logos-nix_579",
-        "logos-protocol": "logos-protocol_85",
+        "logos-lidl": "logos-lidl_162",
+        "logos-module": "logos-module_116",
+        "logos-nix": "logos-nix_582",
+        "logos-protocol": "logos-protocol_91",
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-nix",
@@ -31512,13 +32245,13 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_72": {
+    "logos-plugin-qt_74": {
       "inputs": {
         "logos-lidl": [
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_115",
+        "logos-module": "logos-module_117",
         "logos-nix": [
           "logos-qt-sdk",
           "logos-nix"
@@ -31548,10 +32281,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_73": {
+    "logos-plugin-qt_75": {
       "inputs": {
-        "logos-lidl": "logos-lidl_163",
-        "logos-module": "logos-module_116",
+        "logos-lidl": "logos-lidl_165",
+        "logos-module": "logos-module_118",
         "logos-nix": [
           "logos-view-module-runtime",
           "logos-nix"
@@ -32225,11 +32958,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787430480,
-        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -32256,11 +32989,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -32289,11 +33022,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -32333,7 +33066,35 @@
     },
     "logos-protocol_30": {
       "inputs": {
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_185",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_31": {
+      "inputs": {
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -32347,48 +33108,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_31": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -32406,8 +33130,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -32417,19 +33140,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -32447,7 +33169,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -32457,7 +33179,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -32477,93 +33199,12 @@
     },
     "logos-protocol_34": {
       "inputs": {
-        "logos-nix": "logos-nix_222",
-        "nixpkgs": [
+        "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275122,
-        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_35": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_36": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_37": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -32571,6 +33212,10 @@
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -32593,10 +33238,14 @@
         "type": "github"
       }
     },
-    "logos-protocol_38": {
+    "logos-protocol_35": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
@@ -32604,16 +33253,20 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -32622,11 +33275,15 @@
         "type": "github"
       }
     },
-    "logos-protocol_39": {
+    "logos-protocol_36": {
       "inputs": {
-        "logos-nix": "logos-nix_262",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -32639,6 +33296,119 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_37": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_38": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_244",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -32683,26 +33453,40 @@
     "logos-protocol_40": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -32714,106 +33498,11 @@
     "logos-protocol_41": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_42": {
-      "inputs": {
-        "logos-nix": "logos-nix_279",
-        "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_43": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_44": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32824,7 +33513,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32851,10 +33544,14 @@
         "type": "github"
       }
     },
-    "logos-protocol_45": {
+    "logos-protocol_42": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32864,7 +33561,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32888,11 +33589,15 @@
         "type": "github"
       }
     },
-    "logos-protocol_46": {
+    "logos-protocol_43": {
       "inputs": {
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_274",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32915,16 +33620,24 @@
         "type": "github"
       }
     },
-    "logos-protocol_47": {
+    "logos-protocol_44": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -32944,16 +33657,24 @@
         "type": "github"
       }
     },
-    "logos-protocol_48": {
+    "logos-protocol_45": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -32973,17 +33694,25 @@
         "type": "github"
       }
     },
-    "logos-protocol_49": {
+    "logos-protocol_46": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -32998,6 +33727,105 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_47": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_48": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_304",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -33038,24 +33866,30 @@
     "logos-protocol_50": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -33066,21 +33900,29 @@
     },
     "logos-protocol_51": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+        "logos-nix": [
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787430480,
-        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -33091,27 +33933,22 @@
     },
     "logos-protocol_52": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -33123,19 +33960,15 @@
     "logos-protocol_53": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -33155,89 +33988,15 @@
     },
     "logos-protocol_54": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_55": {
-      "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_56": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -33260,26 +34019,107 @@
         "type": "github"
       }
     },
-    "logos-protocol_57": {
+    "logos-protocol_55": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_56": {
+      "inputs": {
+        "logos-nix": "logos-nix_347",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_57": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_58": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -33297,54 +34137,27 @@
         "type": "github"
       }
     },
-    "logos-protocol_58": {
+    "logos-protocol_59": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_364",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275122,
-        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_59": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -33383,13 +34196,21 @@
     "logos-protocol_60": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -33412,14 +34233,22 @@
     "logos-protocol_61": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -33445,76 +34274,23 @@
     "logos-protocol_62": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_63": {
-      "inputs": {
-        "logos-nix": "logos-nix_422",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_64": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -33532,19 +34308,74 @@
         "type": "github"
       }
     },
-    "logos-protocol_65": {
+    "logos-protocol_63": {
       "inputs": {
-        "logos-nix": "logos-nix_439",
+        "logos-nix": "logos-nix_394",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275122,
+        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_64": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_65": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -33565,63 +34396,14 @@
     "logos-protocol_66": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_67": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -33644,37 +34426,52 @@
         "type": "github"
       }
     },
-    "logos-protocol_68": {
+    "logos-protocol_67": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_68": {
+      "inputs": {
+        "logos-nix": "logos-nix_429",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
         "type": "github"
       },
       "original": {
@@ -33685,24 +34482,27 @@
     },
     "logos-protocol_69": {
       "inputs": {
-        "logos-nix": "logos-nix_469",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275122,
-        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -33740,25 +34540,27 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -33769,18 +34571,16 @@
     },
     "logos-protocol_71": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -33802,7 +34602,47 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_73": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -33810,7 +34650,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -33833,29 +34676,35 @@
         "type": "github"
       }
     },
-    "logos-protocol_73": {
+    "logos-protocol_74": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -33864,15 +34713,45 @@
         "type": "github"
       }
     },
-    "logos-protocol_74": {
+    "logos-protocol_75": {
       "inputs": {
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275122,
+        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_76": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
           "nixpkgs"
         ]
       },
@@ -33890,91 +34769,16 @@
         "type": "github"
       }
     },
-    "logos-protocol_75": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_521",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_77": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -33998,11 +34802,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -34010,11 +34809,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -34041,33 +34835,23 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
         "type": "github"
       },
       "original": {
@@ -34113,7 +34897,219 @@
     },
     "logos-protocol_80": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
+        "logos-nix": "logos-nix_507",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_81": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_82": {
+      "inputs": {
+        "logos-nix": "logos-nix_524",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_83": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_84": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_85": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_86": {
+      "inputs": {
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34139,7 +35135,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_81": {
+    "logos-protocol_87": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -34170,7 +35166,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_82": {
+    "logos-protocol_88": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -34201,195 +35197,33 @@
         "type": "github"
       }
     },
-    "logos-protocol_83": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_84": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_85": {
-      "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_580",
-        "nixpkgs": [
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_87": {
-      "inputs": {
-        "logos-nix": [
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_88": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_89": {
       "inputs": {
         "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
         "type": "github"
       },
       "original": {
@@ -34429,6 +35263,168 @@
         "type": "github"
       }
     },
+    "logos-protocol_90": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_91": {
+      "inputs": {
+        "logos-nix": [
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_92": {
+      "inputs": {
+        "logos-nix": "logos-nix_583",
+        "nixpkgs": [
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_93": {
+      "inputs": {
+        "logos-nix": [
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_94": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_95": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-qt-mcp": {
       "inputs": {
         "logos-nix": "logos-nix_148",
@@ -34457,9 +35453,13 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -34483,9 +35483,9 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_312",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -34509,9 +35509,9 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_399",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -34535,10 +35535,9 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_474",
+        "logos-nix": "logos-nix_481",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -34562,7 +35561,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_559",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -34589,7 +35588,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_584",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -34761,11 +35760,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787442773,
-        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -34781,20 +35780,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_54",
-        "logos-nix": "logos-nix_193",
-        "logos-plugin-qt": "logos-plugin-qt_24",
+        "logos-lidl": "logos-lidl_52",
+        "logos-nix": "logos-nix_186",
+        "logos-plugin-qt": "logos-plugin-qt_23",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -34802,19 +35799,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "lastModified": 1787668712,
+        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
         "type": "github"
       },
       "original": {
@@ -34832,30 +35828,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_57",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
+        "logos-lidl": "logos-lidl_56",
+        "logos-nix": "logos-nix_197",
+        "logos-plugin-qt": "logos-plugin-qt_25",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -34863,7 +35840,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -34873,16 +35849,17 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -34898,52 +35875,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_62",
-        "logos-nix": "logos-nix_223",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786469121,
-        "narHash": "sha256-8sM8d98dquIUOcu9YRlAnpRZ5zcTqWCZii5AyhCwi1k=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "c6be61d0ba3f1c06c1a5ff7ad6d42f3eda254877",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_16": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_65",
+        "logos-lidl": "logos-lidl_59",
         "logos-nix": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
@@ -34951,17 +35894,29 @@
         "logos-plugin-qt": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -34981,23 +35936,35 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_17": {
+    "logos-qt-sdk_16": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_71",
-        "logos-nix": "logos-nix_263",
-        "logos-plugin-qt": "logos-plugin-qt_32",
+        "logos-lidl": "logos-lidl_66",
+        "logos-nix": "logos-nix_228",
+        "logos-plugin-qt": "logos-plugin-qt_29",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -35018,10 +35985,14 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_18": {
+    "logos-qt-sdk_17": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35029,11 +36000,15 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_77",
-        "logos-nix": "logos-nix_280",
-        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-lidl": "logos-lidl_72",
+        "logos-nix": "logos-nix_245",
+        "logos-plugin-qt": "logos-plugin-qt_31",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35042,7 +36017,11 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35067,10 +36046,14 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_19": {
+    "logos-qt-sdk_18": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35079,9 +36062,13 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_80",
+        "logos-lidl": "logos-lidl_75",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35091,7 +36078,11 @@
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35101,7 +36092,11 @@
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35111,7 +36106,11 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35127,6 +36126,60 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_19": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_80",
+        "logos-nix": "logos-nix_275",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786469121,
+        "narHash": "sha256-8sM8d98dquIUOcu9YRlAnpRZ5zcTqWCZii5AyhCwi1k=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "c6be61d0ba3f1c06c1a5ff7ad6d42f3eda254877",
         "type": "github"
       },
       "original": {
@@ -35186,14 +36239,315 @@
     "logos-qt-sdk_20": {
       "inputs": {
         "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_83",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_21": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-lidl": "logos-lidl_87",
+        "logos-nix": "logos-nix_305",
+        "logos-plugin-qt": "logos-plugin-qt_39",
+        "logos-protocol": "logos-protocol_50",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_22": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_90",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_23": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_96",
+        "logos-nix": "logos-nix_348",
+        "logos-plugin-qt": "logos-plugin-qt_44",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_24": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_102",
+        "logos-nix": "logos-nix_365",
+        "logos-plugin-qt": "logos-plugin-qt_46",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_25": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_105",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_26": {
+      "inputs": {
+        "logos-cpp-sdk": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_85",
-        "logos-nix": "logos-nix_310",
+        "logos-lidl": "logos-lidl_110",
+        "logos-nix": "logos-nix_395",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35225,7 +36579,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_21": {
+    "logos-qt-sdk_27": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -35233,7 +36587,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_88",
+        "logos-lidl": "logos-lidl_113",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35273,16 +36627,16 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_22": {
+    "logos-qt-sdk_28": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_94",
-        "logos-nix": "logos-nix_345",
-        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-lidl": "logos-lidl_119",
+        "logos-nix": "logos-nix_430",
+        "logos-plugin-qt": "logos-plugin-qt_54",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -35310,361 +36664,38 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_23": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_100",
-        "logos-nix": "logos-nix_362",
-        "logos-plugin-qt": "logos-plugin-qt_44",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_24": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_103",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_25": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_108",
-        "logos-nix": "logos-nix_392",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786469121,
-        "narHash": "sha256-8sM8d98dquIUOcu9YRlAnpRZ5zcTqWCZii5AyhCwi1k=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "c6be61d0ba3f1c06c1a5ff7ad6d42f3eda254877",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_26": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_111",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_27": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_117",
-        "logos-nix": "logos-nix_423",
-        "logos-plugin-qt": "logos-plugin-qt_52",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787268585,
-        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_28": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_123",
-        "logos-nix": "logos-nix_440",
-        "logos-plugin-qt": "logos-plugin-qt_54",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
     "logos-qt-sdk_29": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_126",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
+        "logos-lidl": "logos-lidl_125",
+        "logos-nix": "logos-nix_447",
+        "logos-plugin-qt": "logos-plugin-qt_56",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -35723,17 +36754,83 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_128",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_31": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_131",
-        "logos-nix": "logos-nix_470",
+        "logos-lidl": "logos-lidl_133",
+        "logos-nix": "logos-nix_477",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35741,7 +36838,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35764,40 +36860,35 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_31": {
+    "logos-qt-sdk_32": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_134",
+        "logos-lidl": "logos-lidl_136",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-plugin-qt": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -35817,7 +36908,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_32": {
+    "logos-qt-sdk_33": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -35825,9 +36916,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_140",
-        "logos-nix": "logos-nix_505",
-        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-lidl": "logos-lidl_142",
+        "logos-nix": "logos-nix_508",
+        "logos-plugin-qt": "logos-plugin-qt_64",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -35857,7 +36948,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_33": {
+    "logos-qt-sdk_34": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -35869,9 +36960,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_146",
-        "logos-nix": "logos-nix_522",
-        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-lidl": "logos-lidl_148",
+        "logos-nix": "logos-nix_525",
+        "logos-plugin-qt": "logos-plugin-qt_66",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -35909,7 +37000,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_34": {
+    "logos-qt-sdk_35": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -35922,7 +37013,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_149",
+        "logos-lidl": "logos-lidl_151",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
@@ -35982,7 +37073,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_35": {
+    "logos-qt-sdk_36": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -35992,8 +37083,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_154",
-        "logos-nix": "logos-nix_552",
+        "logos-lidl": "logos-lidl_156",
+        "logos-nix": "logos-nix_555",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36027,7 +37118,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_36": {
+    "logos-qt-sdk_37": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -36036,7 +37127,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_157",
+        "logos-lidl": "logos-lidl_159",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36080,13 +37171,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_37": {
+    "logos-qt-sdk_38": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
-        "logos-lidl": "logos-lidl_161",
-        "logos-nix": "logos-nix_582",
-        "logos-plugin-qt": "logos-plugin-qt_72",
-        "logos-protocol": "logos-protocol_87",
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
+        "logos-lidl": "logos-lidl_163",
+        "logos-nix": "logos-nix_585",
+        "logos-plugin-qt": "logos-plugin-qt_74",
+        "logos-protocol": "logos-protocol_93",
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-nix",
@@ -36411,9 +37502,9 @@
     },
     "logos-rust-sdk_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_101",
+        "logos-lidl": "logos-lidl_103",
         "logos-logoscore-cli": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36422,7 +37513,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36431,7 +37522,7 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36440,7 +37531,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36467,28 +37558,25 @@
     },
     "logos-rust-sdk_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_118",
+        "logos-lidl": "logos-lidl_120",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_69",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -36496,11 +37584,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312984,
-        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -36511,10 +37599,9 @@
     },
     "logos-rust-sdk_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_124",
+        "logos-lidl": "logos-lidl_126",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36524,7 +37611,6 @@
         ],
         "logos-module-builder": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36534,7 +37620,6 @@
         ],
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36544,7 +37629,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36571,7 +37655,7 @@
     },
     "logos-rust-sdk_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_141",
+        "logos-lidl": "logos-lidl_143",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36615,7 +37699,7 @@
     },
     "logos-rust-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_147",
+        "logos-lidl": "logos-lidl_149",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_manager",
@@ -36842,11 +37926,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787432825,
-        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
+        "lastModified": 1787605292,
+        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
+        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
         "type": "github"
       },
       "original": {
@@ -36857,7 +37941,7 @@
     },
     "logos-rust-sdk_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_55",
+        "logos-lidl": "logos-lidl_57",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36885,6 +37969,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_32",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36898,11 +37983,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787192832,
-        "narHash": "sha256-OOKWEtVLRZ0an2mMLGb/V1bCwVnW/vJkzNqln5KQvN0=",
+        "lastModified": 1787605292,
+        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "a3d0d719e396bb5a8805527eb88702bcb400d2e5",
+        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
         "type": "github"
       },
       "original": {
@@ -36913,25 +37998,41 @@
     },
     "logos-rust-sdk_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_72",
+        "logos-lidl": "logos-lidl_67",
         "logos-logoscore-cli": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_40",
+        "logos-protocol": "logos-protocol_37",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -36954,9 +38055,13 @@
     },
     "logos-rust-sdk_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_78",
+        "logos-lidl": "logos-lidl_73",
         "logos-logoscore-cli": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36965,7 +38070,11 @@
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36974,7 +38083,11 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36983,7 +38096,11 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37010,25 +38127,25 @@
     },
     "logos-rust-sdk_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_95",
+        "logos-lidl": "logos-lidl_97",
         "logos-logoscore-cli": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_52",
+        "logos-protocol": "logos-protocol_57",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -37036,11 +38153,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787432825,
-        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
+        "lastModified": 1787605292,
+        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
+        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
         "type": "github"
       },
       "original": {
@@ -37098,10 +38215,10 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_3",
-        "logos-nix": "logos-nix_225",
-        "logos-plugin-qt": "logos-plugin-qt_28",
-        "logos-protocol": "logos-protocol_35",
-        "logos-qt-mcp": "logos-qt-mcp_2",
+        "logos-nix": "logos-nix_308",
+        "logos-plugin-qt": "logos-plugin-qt_40",
+        "logos-protocol": "logos-protocol_52",
+        "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37116,11 +38233,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787361051,
-        "narHash": "sha256-q3RlsjdM3wIgnZVQg17xC9/1AgW2Jla/QmN3RsIU8wY=",
+        "lastModified": 1787829985,
+        "narHash": "sha256-z5CMTnMiiIBMBVFaW5lWOAST//cW4voc3iv1Y7zKZNU=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "9c0aabef5b68cf5ab88d1bab6b375e23a4f9d2a4",
+        "rev": "2e101b05156d5eeda659e1e5566b9bbf93a9fb4b",
         "type": "github"
       },
       "original": {
@@ -37133,22 +38250,34 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-design-system": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
-        "logos-nix": "logos-nix_312",
-        "logos-plugin-qt": "logos-plugin-qt_38",
-        "logos-protocol": "logos-protocol_47",
-        "logos-qt-mcp": "logos-qt-mcp_3",
+        "logos-nix": "logos-nix_277",
+        "logos-plugin-qt": "logos-plugin-qt_35",
+        "logos-protocol": "logos-protocol_44",
+        "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -37171,24 +38300,24 @@
     },
     "logos-standalone-app_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
         "logos-design-system": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_394",
-        "logos-plugin-qt": "logos-plugin-qt_48",
-        "logos-protocol": "logos-protocol_59",
+        "logos-nix": "logos-nix_397",
+        "logos-plugin-qt": "logos-plugin-qt_50",
+        "logos-protocol": "logos-protocol_64",
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -37211,27 +38340,24 @@
     },
     "logos-standalone-app_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-design-system": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_472",
-        "logos-plugin-qt": "logos-plugin-qt_58",
-        "logos-protocol": "logos-protocol_70",
+        "logos-nix": "logos-nix_479",
+        "logos-plugin-qt": "logos-plugin-qt_60",
+        "logos-protocol": "logos-protocol_76",
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -37254,7 +38380,7 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-design-system": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37262,9 +38388,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_7",
-        "logos-nix": "logos-nix_554",
-        "logos-plugin-qt": "logos-plugin-qt_68",
-        "logos-protocol": "logos-protocol_81",
+        "logos-nix": "logos-nix_557",
+        "logos-plugin-qt": "logos-plugin-qt_70",
+        "logos-protocol": "logos-protocol_87",
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -37331,16 +38457,16 @@
     "logos-test-framework_10": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_397",
-        "logos-plugin-qt": "logos-plugin-qt_49",
-        "logos-protocol": "logos-protocol_60",
-        "logos-qt-sdk": "logos-qt-sdk_26",
+        "logos-nix": "logos-nix_400",
+        "logos-plugin-qt": "logos-plugin-qt_51",
+        "logos-protocol": "logos-protocol_65",
+        "logos-qt-sdk": "logos-qt-sdk_27",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -37365,7 +38491,6 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37373,13 +38498,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_442",
-        "logos-plugin-qt": "logos-plugin-qt_55",
-        "logos-protocol": "logos-protocol_66",
-        "logos-qt-sdk": "logos-qt-sdk_29",
+        "logos-nix": "logos-nix_449",
+        "logos-plugin-qt": "logos-plugin-qt_57",
+        "logos-protocol": "logos-protocol_72",
+        "logos-qt-sdk": "logos-qt-sdk_30",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37408,17 +38532,15 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_475",
-        "logos-plugin-qt": "logos-plugin-qt_59",
-        "logos-protocol": "logos-protocol_71",
-        "logos-qt-sdk": "logos-qt-sdk_31",
+        "logos-nix": "logos-nix_482",
+        "logos-plugin-qt": "logos-plugin-qt_61",
+        "logos-protocol": "logos-protocol_77",
+        "logos-qt-sdk": "logos-qt-sdk_32",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -37451,10 +38573,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_524",
-        "logos-plugin-qt": "logos-plugin-qt_65",
-        "logos-protocol": "logos-protocol_77",
-        "logos-qt-sdk": "logos-qt-sdk_34",
+        "logos-nix": "logos-nix_527",
+        "logos-plugin-qt": "logos-plugin-qt_67",
+        "logos-protocol": "logos-protocol_83",
+        "logos-qt-sdk": "logos-qt-sdk_35",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37490,10 +38612,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_557",
-        "logos-plugin-qt": "logos-plugin-qt_69",
-        "logos-protocol": "logos-protocol_82",
-        "logos-qt-sdk": "logos-qt-sdk_36",
+        "logos-nix": "logos-nix_560",
+        "logos-plugin-qt": "logos-plugin-qt_71",
+        "logos-protocol": "logos-protocol_88",
+        "logos-qt-sdk": "logos-qt-sdk_37",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37647,10 +38769,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_195",
-        "logos-plugin-qt": "logos-plugin-qt_25",
-        "logos-protocol": "logos-protocol_31",
-        "logos-qt-sdk": "logos-qt-sdk_14",
+        "logos-nix": "logos-nix_199",
+        "logos-plugin-qt": "logos-plugin-qt_26",
+        "logos-protocol": "logos-protocol_33",
+        "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37664,11 +38786,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787175653,
-        "narHash": "sha256-LWTrfyl7RTAeG51kxUy4rHKzDJ8CtyUgISYK5hLJFMw=",
+        "lastModified": 1787614290,
+        "narHash": "sha256-NUpZo9F9MbUaxYIdeI4u+Mp4e33DaV8dCK80hgrJ9Dg=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5f75c9418b7c842f1750bfde31accf3d0cba283d",
+        "rev": "31008b6a5622bc4acce4b1e4e9bfc035e1d4f50f",
         "type": "github"
       },
       "original": {
@@ -37682,14 +38804,30 @@
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_228",
-        "logos-plugin-qt": "logos-plugin-qt_29",
-        "logos-protocol": "logos-protocol_36",
-        "logos-qt-sdk": "logos-qt-sdk_16",
+        "logos-nix": "logos-nix_247",
+        "logos-plugin-qt": "logos-plugin-qt_32",
+        "logos-protocol": "logos-protocol_40",
+        "logos-qt-sdk": "logos-qt-sdk_18",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -37713,24 +38851,24 @@
     "logos-test-framework_7": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_282",
-        "logos-plugin-qt": "logos-plugin-qt_35",
-        "logos-protocol": "logos-protocol_43",
-        "logos-qt-sdk": "logos-qt-sdk_19",
+        "logos-nix": "logos-nix_280",
+        "logos-plugin-qt": "logos-plugin-qt_36",
+        "logos-protocol": "logos-protocol_45",
+        "logos-qt-sdk": "logos-qt-sdk_20",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -37754,16 +38892,16 @@
     "logos-test-framework_8": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_315",
-        "logos-plugin-qt": "logos-plugin-qt_39",
-        "logos-protocol": "logos-protocol_48",
-        "logos-qt-sdk": "logos-qt-sdk_21",
+        "logos-nix": "logos-nix_313",
+        "logos-plugin-qt": "logos-plugin-qt_41",
+        "logos-protocol": "logos-protocol_53",
+        "logos-qt-sdk": "logos-qt-sdk_22",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -37771,11 +38909,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787175653,
-        "narHash": "sha256-LWTrfyl7RTAeG51kxUy4rHKzDJ8CtyUgISYK5hLJFMw=",
+        "lastModified": 1787614290,
+        "narHash": "sha256-NUpZo9F9MbUaxYIdeI4u+Mp4e33DaV8dCK80hgrJ9Dg=",
         "owner": "logos-co",
         "repo": "logos-test-framework",
-        "rev": "5f75c9418b7c842f1750bfde31accf3d0cba283d",
+        "rev": "31008b6a5622bc4acce4b1e4e9bfc035e1d4f50f",
         "type": "github"
       },
       "original": {
@@ -37787,7 +38925,7 @@
     "logos-test-framework_9": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37795,12 +38933,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_364",
-        "logos-plugin-qt": "logos-plugin-qt_45",
-        "logos-protocol": "logos-protocol_55",
-        "logos-qt-sdk": "logos-qt-sdk_24",
+        "logos-nix": "logos-nix_367",
+        "logos-plugin-qt": "logos-plugin-qt_47",
+        "logos-protocol": "logos-protocol_60",
+        "logos-qt-sdk": "logos-qt-sdk_25",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37884,12 +39022,12 @@
     },
     "logos-view-module-runtime_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-nix": "logos-nix_399",
-        "logos-plugin-qt": "logos-plugin-qt_50",
-        "logos-protocol": "logos-protocol_62",
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-nix": "logos-nix_402",
+        "logos-plugin-qt": "logos-plugin-qt_52",
+        "logos-protocol": "logos-protocol_67",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -37912,13 +39050,12 @@
     },
     "logos-view-module-runtime_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
-        "logos-nix": "logos-nix_444",
-        "logos-plugin-qt": "logos-plugin-qt_56",
-        "logos-protocol": "logos-protocol_68",
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
+        "logos-nix": "logos-nix_451",
+        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-protocol": "logos-protocol_74",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37945,13 +39082,12 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-nix": "logos-nix_477",
-        "logos-plugin-qt": "logos-plugin-qt_60",
-        "logos-protocol": "logos-protocol_73",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-nix": "logos-nix_484",
+        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-protocol": "logos-protocol_79",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -37974,10 +39110,10 @@
     },
     "logos-view-module-runtime_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
-        "logos-nix": "logos-nix_526",
-        "logos-plugin-qt": "logos-plugin-qt_66",
-        "logos-protocol": "logos-protocol_79",
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-nix": "logos-nix_529",
+        "logos-plugin-qt": "logos-plugin-qt_68",
+        "logos-protocol": "logos-protocol_85",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -38007,10 +39143,10 @@
     },
     "logos-view-module-runtime_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
-        "logos-nix": "logos-nix_559",
-        "logos-plugin-qt": "logos-plugin-qt_70",
-        "logos-protocol": "logos-protocol_84",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-nix": "logos-nix_562",
+        "logos-plugin-qt": "logos-plugin-qt_72",
+        "logos-protocol": "logos-protocol_90",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -38036,10 +39172,10 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-nix": "logos-nix_584",
-        "logos-plugin-qt": "logos-plugin-qt_73",
-        "logos-protocol": "logos-protocol_89",
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-nix": "logos-nix_587",
+        "logos-plugin-qt": "logos-plugin-qt_75",
+        "logos-protocol": "logos-protocol_95",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-nix",
@@ -38151,10 +39287,10 @@
     },
     "logos-view-module-runtime_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_19",
-        "logos-nix": "logos-nix_197",
-        "logos-plugin-qt": "logos-plugin-qt_26",
-        "logos-protocol": "logos-protocol_33",
+        "logos-cpp-sdk": "logos-cpp-sdk_20",
+        "logos-nix": "logos-nix_201",
+        "logos-plugin-qt": "logos-plugin-qt_27",
+        "logos-protocol": "logos-protocol_35",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38168,11 +39304,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787172850,
-        "narHash": "sha256-p5MReDNu3sSosuGYzEeD+wVP4dYUL2KKHA6dtCBsTN8=",
+        "lastModified": 1787818733,
+        "narHash": "sha256-+cRFdDCpKAARSGIpSP3qZmsu5LWZeK+v6SblJIc3Z0g=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "b9a6778fff2f5714ddb556647ab961f4689a9937",
+        "rev": "3ab072eadf516fd2c335305d8f330c7a7621e95d",
         "type": "github"
       },
       "original": {
@@ -38183,40 +39319,16 @@
     },
     "logos-view-module-runtime_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
-        "logos-nix": "logos-nix_230",
-        "logos-plugin-qt": "logos-plugin-qt_30",
-        "logos-protocol": "logos-protocol_38",
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-nix": "logos-nix_249",
+        "logos-plugin-qt": "logos-plugin-qt_33",
+        "logos-protocol": "logos-protocol_42",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787356738,
-        "narHash": "sha256-icN5SY1+l3xcup/9cvWnden6JW7n/mdDYm3bYHkcAO4=",
-        "owner": "logos-co",
-        "repo": "logos-view-module-runtime",
-        "rev": "7cbc5a6ed3ba5ccffd584c25b966dbf67868d841",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-view-module-runtime",
-        "type": "github"
-      }
-    },
-    "logos-view-module-runtime_7": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
-        "logos-nix": "logos-nix_284",
-        "logos-plugin-qt": "logos-plugin-qt_36",
-        "logos-protocol": "logos-protocol_45",
-        "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38241,14 +39353,18 @@
         "type": "github"
       }
     },
-    "logos-view-module-runtime_8": {
+    "logos-view-module-runtime_7": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_27",
-        "logos-nix": "logos-nix_317",
-        "logos-plugin-qt": "logos-plugin-qt_40",
-        "logos-protocol": "logos-protocol_50",
+        "logos-nix": "logos-nix_282",
+        "logos-plugin-qt": "logos-plugin-qt_37",
+        "logos-protocol": "logos-protocol_47",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -38269,14 +39385,42 @@
         "type": "github"
       }
     },
+    "logos-view-module-runtime_8": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-nix": "logos-nix_315",
+        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-protocol": "logos-protocol_55",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787818733,
+        "narHash": "sha256-+cRFdDCpKAARSGIpSP3qZmsu5LWZeK+v6SblJIc3Z0g=",
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "rev": "3ab072eadf516fd2c335305d8f330c7a7621e95d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "type": "github"
+      }
+    },
     "logos-view-module-runtime_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-nix": "logos-nix_366",
-        "logos-plugin-qt": "logos-plugin-qt_46",
-        "logos-protocol": "logos-protocol_57",
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
+        "logos-nix": "logos-nix_369",
+        "logos-plugin-qt": "logos-plugin-qt_48",
+        "logos-protocol": "logos-protocol_62",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38304,12 +39448,12 @@
     "logos-view-module_10": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -38334,7 +39478,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38344,7 +39487,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38373,13 +39515,11 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -38387,11 +39527,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
         "owner": "logos-co",
         "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
         "type": "github"
       },
       "original": {
@@ -38591,11 +39731,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
         "owner": "logos-co",
         "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
         "type": "github"
       },
       "original": {
@@ -38609,10 +39749,63 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787164758,
+        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "type": "github"
+      }
+    },
+    "logos-view-module_7": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -38633,52 +39826,15 @@
         "type": "github"
       }
     },
-    "logos-view-module_7": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787164758,
-        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
-        "owner": "logos-co",
-        "repo": "logos-view-module",
-        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-view-module",
-        "type": "github"
-      }
-    },
     "logos-view-module_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -38702,7 +39858,7 @@
     "logos-view-module_9": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38711,7 +39867,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38912,10 +40068,152 @@
     },
     "nix-bundle-appimage_14": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_209",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785798386,
+        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_15": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_16": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_17": {
+      "inputs": {
+        "logos-nix": "logos-nix_257",
+        "nix-bundle-dir": "nix-bundle-dir_35",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38942,12 +40240,16 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_15": {
+    "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_218",
-        "nix-bundle-dir": "nix-bundle-dir_32",
+        "logos-nix": "logos-nix_270",
+        "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38971,12 +40273,16 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_16": {
+    "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_238",
-        "nix-bundle-dir": "nix-bundle-dir_35",
+        "logos-nix": "logos-nix_290",
+        "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -38991,92 +40297,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
         "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_17": {
-      "inputs": {
-        "logos-nix": "logos-nix_246",
-        "nix-bundle-dir": "nix-bundle-dir_38",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_18": {
-      "inputs": {
-        "logos-nix": "logos-nix_251",
-        "nix-bundle-dir": "nix-bundle-dir_40",
-        "nixpkgs": [
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_19": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -39115,43 +40335,25 @@
     },
     "nix-bundle-appimage_20": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
+        "logos-nix": "logos-nix_299",
+        "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1785798386,
+        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
         "type": "github"
       },
       "original": {
@@ -39162,14 +40364,10 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_292",
-        "nix-bundle-dir": "nix-bundle-dir_45",
+        "logos-nix": "logos-nix_323",
+        "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -39179,11 +40377,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1785798386,
+        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
         "type": "github"
       },
       "original": {
@@ -39194,25 +40392,22 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
-        "nix-bundle-dir": "nix-bundle-dir_48",
+        "logos-nix": "logos-nix_331",
+        "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
           "nix-bundle-appimage",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1785798386,
+        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
         "type": "github"
       },
       "original": {
@@ -39223,12 +40418,9 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
-        "nix-bundle-dir": "nix-bundle-dir_51",
+        "logos-nix": "logos-nix_336",
+        "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39251,22 +40443,31 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
-        "nix-bundle-dir": "nix-bundle-dir_54",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -39278,19 +40479,31 @@
     "nix-bundle-appimage_25": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -39312,43 +40525,28 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
+        "logos-nix": "logos-nix_377",
+        "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -39359,16 +40557,13 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_374",
-        "nix-bundle-dir": "nix-bundle-dir_59",
+        "logos-nix": "logos-nix_390",
+        "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39391,13 +40586,12 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_387",
-        "nix-bundle-dir": "nix-bundle-dir_62",
+        "logos-nix": "logos-nix_410",
+        "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39420,12 +40614,10 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
-        "nix-bundle-dir": "nix-bundle-dir_65",
+        "logos-nix": "logos-nix_418",
+        "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-package-manager-module",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39479,21 +40671,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -39517,7 +40706,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -39528,7 +40716,6 @@
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -39539,7 +40726,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -39565,11 +40751,10 @@
     },
     "nix-bundle-appimage_32": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_459",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -39598,11 +40783,10 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_472",
         "nix-bundle-dir": "nix-bundle-dir_74",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -39628,11 +40812,10 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_492",
         "nix-bundle-dir": "nix-bundle-dir_77",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -39657,14 +40840,25 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
-        "nix-bundle-dir": "nix-bundle-dir_80",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -39688,6 +40882,10 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
@@ -39695,12 +40893,20 @@
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -39722,58 +40928,8 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_534",
-        "nix-bundle-dir": "nix-bundle-dir_85",
+        "logos-nix": "logos-nix_537",
+        "nix-bundle-dir": "nix-bundle-dir_83",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -39803,16 +40959,45 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_39": {
+    "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
-        "nix-bundle-dir": "nix-bundle-dir_88",
+        "logos-nix": "logos-nix_550",
+        "nix-bundle-dir": "nix-bundle-dir_86",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_570",
+        "nix-bundle-dir": "nix-bundle-dir_89",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39873,13 +41058,11 @@
     },
     "nix-bundle-appimage_40": {
       "inputs": {
-        "logos-nix": "logos-nix_567",
-        "nix-bundle-dir": "nix-bundle-dir_91",
+        "logos-nix": "logos-nix_578",
+        "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -39902,35 +41085,8 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_589",
         "nix-bundle-dir": "nix-bundle-dir_94",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_42": {
-      "inputs": {
-        "logos-nix": "logos-nix_586",
-        "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
           "nix-bundle-appimage",
           "logos-nix",
@@ -39951,10 +41107,10 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_43": {
+    "nix-bundle-appimage_42": {
       "inputs": {
-        "logos-nix": "logos-nix_592",
-        "nix-bundle-dir": "nix-bundle-dir_98",
+        "logos-nix": "logos-nix_595",
+        "nix-bundle-dir": "nix-bundle-dir_96",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -40184,31 +41340,6 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_100": {
-      "inputs": {
-        "logos-nix": "logos-nix_597",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -40748,7 +41879,7 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_205",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40778,7 +41909,7 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_210",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40793,11 +41924,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
         "type": "github"
       },
       "original": {
@@ -40834,7 +41965,7 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40850,11 +41981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
         "type": "github"
       },
       "original": {
@@ -40865,7 +41996,7 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_214",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40896,23 +42027,33 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -40923,15 +42064,32 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_220",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -40951,9 +42109,17 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_253",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -40977,9 +42143,17 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_258",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -41003,9 +42177,17 @@
     },
     "nix-bundle-dir_36": {
       "inputs": {
-        "logos-nix": "logos-nix_240",
+        "logos-nix": "logos-nix_259",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -41030,9 +42212,17 @@
     },
     "nix-bundle-dir_37": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_262",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -41057,20 +42247,27 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_271",
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -41081,10 +42278,17 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_248",
+        "logos-nix": "logos-nix_272",
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41133,126 +42337,13 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_252",
+        "logos-nix": "logos-nix_286",
         "nixpkgs": [
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_41": {
-      "inputs": {
-        "logos-nix": "logos-nix_253",
-        "nixpkgs": [
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_42": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_43": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_44": {
-      "inputs": {
-        "logos-nix": "logos-nix_288",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -41274,15 +42365,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_45": {
+    "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_293",
+        "logos-nix": "logos-nix_291",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -41304,18 +42395,130 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_46": {
+    "nix-bundle-dir_42": {
       "inputs": {
-        "logos-nix": "logos-nix_294",
+        "logos-nix": "logos-nix_292",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_43": {
+      "inputs": {
+        "logos-nix": "logos-nix_295",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_44": {
+      "inputs": {
+        "logos-nix": "logos-nix_300",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_45": {
+      "inputs": {
+        "logos-nix": "logos-nix_301",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_319",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41337,27 +42540,22 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_297",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
         "type": "github"
       },
       "original": {
@@ -41368,23 +42566,23 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-appimage",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
         "type": "github"
       },
       "original": {
@@ -41395,13 +42593,12 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_307",
+        "logos-nix": "logos-nix_328",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41450,22 +42647,20 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_332",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
         "type": "github"
       },
       "original": {
@@ -41476,11 +42671,33 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_337",
+        "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -41500,41 +42717,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_327",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41556,20 +42743,25 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -41580,12 +42772,24 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_335",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -41605,75 +42809,9 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_57": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_370",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -41699,11 +42837,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_59": {
+    "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_378",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -41721,6 +42859,68 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_379",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_382",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -41756,27 +42956,23 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_376",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -41787,16 +42983,13 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_379",
+        "logos-nix": "logos-nix_392",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41818,40 +43011,11 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_406",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_63": {
-      "inputs": {
-        "logos-nix": "logos-nix_389",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41871,13 +43035,40 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_63": {
+      "inputs": {
+        "logos-nix": "logos-nix_411",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41899,38 +43090,12 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_415",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_66": {
-      "inputs": {
-        "logos-nix": "logos-nix_409",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41950,14 +43115,36 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_66": {
+      "inputs": {
+        "logos-nix": "logos-nix_419",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager-module",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -41981,14 +43168,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -42012,7 +43197,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42023,7 +43207,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42080,10 +43263,9 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_455",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42111,10 +43293,9 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_460",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42142,10 +43323,9 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_461",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42174,10 +43354,9 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_464",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42206,10 +43385,9 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42234,10 +43412,9 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -42263,10 +43440,9 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_488",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -42290,10 +43466,9 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_493",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -42317,10 +43492,9 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -42345,10 +43519,9 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_497",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -42400,21 +43573,27 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_494",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -42425,13 +43604,26 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-package-downloader",
-          "nix-bundle-dir",
-          "logos-nix",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -42451,18 +43643,18 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_533",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "logos-design-system",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -42482,17 +43674,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_538",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42501,16 +43683,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -42521,7 +43705,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_539",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42530,7 +43714,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -42552,70 +43737,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_535",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_536",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_87": {
-      "inputs": {
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_542",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42645,9 +43767,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_88": {
+    "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_548",
+        "logos-nix": "logos-nix_551",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42673,9 +43795,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_89": {
+    "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42694,6 +43816,60 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_88": {
+      "inputs": {
+        "logos-nix": "logos-nix_566",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_571",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -42731,12 +43907,13 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -42758,62 +43935,7 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_92": {
-      "inputs": {
-        "logos-nix": "logos-nix_569",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_93": {
-      "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_575",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42839,9 +43961,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_94": {
+    "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_579",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42864,9 +43986,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_95": {
+    "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
+        "logos-nix": "logos-nix_580",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -42890,9 +44012,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_96": {
+    "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_590",
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -42912,9 +44034,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_97": {
+    "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
+        "logos-nix": "logos-nix_591",
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -42935,9 +44057,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_98": {
+    "nix-bundle-dir_96": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -42959,12 +44081,37 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_99": {
+    "nix-bundle-dir_97": {
       "inputs": {
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_597",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_600",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -43013,7 +44160,7 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_212",
         "logos-package": "logos-package_18",
         "nix-bundle-dir": "nix-bundle-dir_31",
         "nixpkgs": [
@@ -43030,11 +44177,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "lastModified": 1787819509,
+        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
         "type": "github"
       },
       "original": {
@@ -43045,11 +44192,19 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
-        "logos-package": "logos-package_20",
+        "logos-nix": "logos-nix_251",
+        "logos-package": "logos-package_19",
         "nix-bundle-dir": "nix-bundle-dir_34",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -43072,11 +44227,19 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_241",
-        "logos-package": "logos-package_22",
+        "logos-nix": "logos-nix_260",
+        "logos-package": "logos-package_21",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43100,15 +44263,15 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
-        "logos-package": "logos-package_25",
-        "nix-bundle-dir": "nix-bundle-dir_44",
+        "logos-nix": "logos-nix_284",
+        "logos-package": "logos-package_23",
+        "nix-bundle-dir": "nix-bundle-dir_40",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -43131,15 +44294,15 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
-        "logos-package": "logos-package_27",
-        "nix-bundle-dir": "nix-bundle-dir_47",
+        "logos-nix": "logos-nix_293",
+        "logos-package": "logos-package_25",
+        "nix-bundle-dir": "nix-bundle-dir_43",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43163,11 +44326,11 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_319",
-        "logos-package": "logos-package_29",
-        "nix-bundle-dir": "nix-bundle-dir_50",
+        "logos-nix": "logos-nix_317",
+        "logos-package": "logos-package_27",
+        "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -43175,11 +44338,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "lastModified": 1787819509,
+        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
         "type": "github"
       },
       "original": {
@@ -43190,11 +44353,11 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
-        "logos-package": "logos-package_31",
-        "nix-bundle-dir": "nix-bundle-dir_53",
+        "logos-nix": "logos-nix_326",
+        "logos-package": "logos-package_29",
+        "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43203,11 +44366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "lastModified": 1787819509,
+        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
         "type": "github"
       },
       "original": {
@@ -43218,11 +44381,11 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
-        "logos-package": "logos-package_33",
-        "nix-bundle-dir": "nix-bundle-dir_58",
+        "logos-nix": "logos-nix_371",
+        "logos-package": "logos-package_32",
+        "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43249,11 +44412,11 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
-        "logos-package": "logos-package_35",
-        "nix-bundle-dir": "nix-bundle-dir_61",
+        "logos-nix": "logos-nix_380",
+        "logos-package": "logos-package_34",
+        "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43281,11 +44444,11 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
-        "logos-package": "logos-package_37",
-        "nix-bundle-dir": "nix-bundle-dir_64",
+        "logos-nix": "logos-nix_404",
+        "logos-package": "logos-package_36",
+        "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -43336,11 +44499,11 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
-        "logos-package": "logos-package_39",
-        "nix-bundle-dir": "nix-bundle-dir_67",
+        "logos-nix": "logos-nix_413",
+        "logos-package": "logos-package_38",
+        "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43364,12 +44527,11 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
-        "logos-package": "logos-package_41",
+        "logos-nix": "logos-nix_453",
+        "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43396,12 +44558,11 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
-        "logos-package": "logos-package_43",
+        "logos-nix": "logos-nix_462",
+        "logos-package": "logos-package_42",
         "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43429,12 +44590,11 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
-        "logos-package": "logos-package_45",
+        "logos-nix": "logos-nix_486",
+        "logos-package": "logos-package_44",
         "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -43457,12 +44617,11 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_488",
-        "logos-package": "logos-package_47",
+        "logos-nix": "logos-nix_495",
+        "logos-package": "logos-package_46",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43486,9 +44645,9 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
-        "logos-package": "logos-package_49",
-        "nix-bundle-dir": "nix-bundle-dir_84",
+        "logos-nix": "logos-nix_531",
+        "logos-package": "logos-package_48",
+        "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -43518,9 +44677,9 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_537",
-        "logos-package": "logos-package_51",
-        "nix-bundle-dir": "nix-bundle-dir_87",
+        "logos-nix": "logos-nix_540",
+        "logos-package": "logos-package_50",
+        "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -43551,9 +44710,9 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_561",
-        "logos-package": "logos-package_53",
-        "nix-bundle-dir": "nix-bundle-dir_90",
+        "logos-nix": "logos-nix_564",
+        "logos-package": "logos-package_52",
+        "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -43579,9 +44738,9 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_570",
-        "logos-package": "logos-package_55",
-        "nix-bundle-dir": "nix-bundle-dir_93",
+        "logos-nix": "logos-nix_573",
+        "logos-package": "logos-package_54",
+        "nix-bundle-dir": "nix-bundle-dir_91",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -43608,9 +44767,9 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_595",
-        "logos-package": "logos-package_58",
-        "nix-bundle-dir": "nix-bundle-dir_100",
+        "logos-nix": "logos-nix_598",
+        "logos-package": "logos-package_57",
+        "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43809,7 +44968,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_203",
         "logos-package": "logos-package_16",
         "nix-bundle-dir": "nix-bundle-dir_28",
         "nixpkgs": [
@@ -43825,11 +44984,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "lastModified": 1787819509,
+        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
         "type": "github"
       },
       "original": {
@@ -43867,11 +45026,11 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
-        "logos-package-manager": "logos-package-manager_17",
+        "logos-nix": "logos-nix_407",
+        "logos-package-manager": "logos-package-manager_16",
         "nix-bundle-lgx": "nix-bundle-lgx_20",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -43894,12 +45053,11 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_456",
         "logos-package-manager": "logos-package-manager_18",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43926,12 +45084,11 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_489",
         "logos-package-manager": "logos-package-manager_20",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -43954,7 +45111,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_534",
         "logos-package-manager": "logos-package-manager_21",
         "nix-bundle-lgx": "nix-bundle-lgx_26",
         "nixpkgs": [
@@ -43986,7 +45143,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
+        "logos-nix": "logos-nix_567",
         "logos-package-manager": "logos-package-manager_23",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
@@ -44014,7 +45171,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_592",
         "logos-package-manager": "logos-package-manager_25",
         "nix-bundle-lgx": "nix-bundle-lgx_29",
         "nixpkgs": [
@@ -44125,7 +45282,7 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_206",
         "logos-package-manager": "logos-package-manager_7",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
         "nixpkgs": [
@@ -44141,11 +45298,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468957,
-        "narHash": "sha256-4RHdcjR9s6sJATHyPWz1zr+9Il2IIbkUown37jtrNAk=",
+        "lastModified": 1787820205,
+        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "e1947b07a88548cfff605bf335e0342c2e98bbaf",
+        "rev": "63815316970587b730f626f3541045bf09c08cfa",
         "type": "github"
       },
       "original": {
@@ -44156,11 +45313,19 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_235",
-        "logos-package-manager": "logos-package-manager_9",
+        "logos-nix": "logos-nix_254",
+        "logos-package-manager": "logos-package-manager_8",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -44183,15 +45348,15 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
-        "logos-package-manager": "logos-package-manager_11",
+        "logos-nix": "logos-nix_287",
+        "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -44214,11 +45379,11 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_322",
-        "logos-package-manager": "logos-package-manager_13",
+        "logos-nix": "logos-nix_320",
+        "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -44226,11 +45391,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468957,
-        "narHash": "sha256-4RHdcjR9s6sJATHyPWz1zr+9Il2IIbkUown37jtrNAk=",
+        "lastModified": 1787820205,
+        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "e1947b07a88548cfff605bf335e0342c2e98bbaf",
+        "rev": "63815316970587b730f626f3541045bf09c08cfa",
         "type": "github"
       },
       "original": {
@@ -44241,11 +45406,11 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_371",
-        "logos-package-manager": "logos-package-manager_15",
+        "logos-nix": "logos-nix_374",
+        "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44308,19 +45473,19 @@
     "nix-bundle-macos-app_10": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -44343,7 +45508,7 @@
     "nix-bundle-macos-app_11": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44353,7 +45518,7 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44363,7 +45528,7 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44391,21 +45556,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -44429,7 +45591,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44440,7 +45601,6 @@
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44451,7 +45611,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44565,7 +45724,7 @@
     },
     "nix-bundle-macos-app_16": {
       "inputs": {
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_601",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -44821,19 +45980,31 @@
     "nix-bundle-macos-app_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -44856,7 +46027,11 @@
     "nix-bundle-macos-app_9": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44866,7 +46041,11 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44876,7 +46055,11 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -52645,6 +53828,86 @@
       }
     },
     "nixpkgs-windows_534": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_535": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_536": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_537": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_538": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_539": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -62308,6 +63571,22 @@
         "type": "github"
       }
     },
+    "nixpkgs_599": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_6": {
       "locked": {
         "lastModified": 1759036355,
@@ -62325,6 +63604,38 @@
       }
     },
     "nixpkgs_60": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_600": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_601": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -63012,25 +64323,6 @@
         "type": "github"
       }
     },
-    "package_downloader": {
-      "inputs": {
-        "logos-module-builder": "logos-module-builder_11",
-        "logos-package-downloader": "logos-package-downloader_2"
-      },
-      "locked": {
-        "lastModified": 1787434685,
-        "narHash": "sha256-KbrEldxiYDrvAHsssV9L0+PVN2TSJN+HfbgEVrelgo0=",
-        "owner": "logos-co",
-        "repo": "logos-package-downloader-module",
-        "rev": "50dafbf3913c007d28346c4f714162cccf552eaf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-downloader-module",
-        "type": "github"
-      }
-    },
     "package_manager": {
       "inputs": {
         "logos-module-builder": "logos-module-builder_13",
@@ -63103,9 +64395,13 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63130,9 +64426,9 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_307",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63157,9 +64453,9 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63184,10 +64480,9 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_471",
+        "logos-nix": "logos-nix_478",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63212,7 +64507,7 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_553",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -63250,16 +64545,16 @@
         "logos-nix": "logos-nix_165",
         "logos-package": "logos-package_15",
         "logos-package-downloader-module": "logos-package-downloader-module",
-        "logos-package-manager": "logos-package-manager_10",
+        "logos-package-manager": "logos-package-manager_13",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-        "logos-plugin-qt": "logos-plugin-qt_71",
-        "logos-protocol": "logos-protocol_86",
+        "logos-plugin-qt": "logos-plugin-qt_73",
+        "logos-protocol": "logos-protocol_92",
         "logos-qt-mcp": "logos-qt-mcp_7",
-        "logos-qt-sdk": "logos-qt-sdk_37",
+        "logos-qt-sdk": "logos-qt-sdk_38",
         "logos-view-module-runtime": "logos-view-module-runtime_15",
-        "nix-bundle-appimage": "nix-bundle-appimage_42",
-        "nix-bundle-dir": "nix-bundle-dir_97",
+        "nix-bundle-appimage": "nix-bundle-appimage_41",
+        "nix-bundle-dir": "nix-bundle-dir_95",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
         "nix-bundle-macos-app": "nix-bundle-macos-app_16",
         "nixpkgs": [
@@ -63293,7 +64588,7 @@
     "rust-overlay_10": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -63316,7 +64611,6 @@
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63343,7 +64637,6 @@
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -63496,11 +64789,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784870759,
-        "narHash": "sha256-ZaS89rj5u6pygXKDRfCzPMGm7isJxLsSeIAR5EaSyu8=",
+        "lastModified": 1787713867,
+        "narHash": "sha256-ZRYTEvDb8QZLCHRoMyIZle9V3Bvw905m0teeo1RvI7M=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "471286a5fadc690e2408ad854eb32325f5e74da7",
+        "rev": "494680f9ffa2b4bf9f2df0f442c7096e44adfa00",
         "type": "github"
       },
       "original": {
@@ -63514,27 +64807,9 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1784870759,
-        "narHash": "sha256-ZaS89rj5u6pygXKDRfCzPMGm7isJxLsSeIAR5EaSyu8=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "471286a5fadc690e2408ad854eb32325f5e74da7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "rust-overlay_7": {
-      "inputs": {
-        "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -63557,10 +64832,14 @@
         "type": "github"
       }
     },
-    "rust-overlay_8": {
+    "rust-overlay_7": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -63579,10 +64858,32 @@
         "type": "github"
       }
     },
+    "rust-overlay_8": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787713867,
+        "narHash": "sha256-ZRYTEvDb8QZLCHRoMyIZle9V3Bvw905m0teeo1RvI7M=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "494680f9ffa2b4bf9f2df0f442c7096e44adfa00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
     "rust-overlay_9": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",

--- a/flake.nix
+++ b/flake.nix
@@ -19,6 +19,10 @@
     logos-modules-state-module.url = "github:logos-co/logos-modules-state-module";
     logos-package.url = "github:logos-co/logos-package";
     logos-package-manager-ui.url = "github:logos-co/logos-package-manager-ui";
+    # Without this the UI brings its own package_downloader and the closure
+    # carries two logos-package-downloader revisions, with the UI that drives
+    # installs on the older one.
+    logos-package-manager-ui.inputs.package_downloader.follows = "logos-package-downloader-module";
     logos-design-system.url = "github:logos-co/logos-design-system";
     logos-view-module-runtime.url = "github:logos-co/logos-view-module-runtime";
     nix-bundle-logos-module-install.url = "github:logos-co/nix-bundle-logos-module-install";


### PR DESCRIPTION
**Wave 1 — independent, mergeable now.** Carries none of the version-range work.

## What this actually fixes — and it is not what the title first suggested

Basecamp has **no direct `logos-package-downloader` input**; it reaches the downloader only
through `logos-package-downloader-module`. But it had **two paths** to it, and they disagreed:

```
logos-package-downloader-module                        -> downloader 5514b0c   (stale)
logos-package-manager-ui/package_downloader            -> downloader 5514b0c   (stale)
```

`logos-package-manager-ui` declares **no follows at all**, so it brings its own
`package_downloader`. Relocking the root input alone leaves the closure carrying **two**
`logos-package-downloader-module` and **two** `logos-package-downloader` revisions — with the UI
that actually drives installs sitting on the older one.

That is worse than not taking the fix at all, because the path that misses it is the install UI.

## Why the downloader rev matters

`lgpd`'s resolver is the **only** component in the whole stack that evaluates a dependency's
version range or signer pin. Every other layer carries them as data and compares nothing. Master's
downloader carries `52d3da8`, *"an empty signer pin selected exactly the UNSIGNED releases"*.

## After

Exactly one of each: `logos-package-downloader 52d3da8`,
`logos-package-downloader-module 1585bad`.

Same defect class as two `logos-qt-host` in one closure — invisible to the flake graph, and the
lock is the only place it shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
