### PR TITLE
feat: bundle modules_state

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,9 +28,9 @@
     "default-container_2": {
       "inputs": {
         "logos-container": "logos-container_8",
-        "logos-nix": "logos-nix_102",
+        "logos-nix": "logos-nix_100",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -56,9 +56,9 @@
     "default-container_3": {
       "inputs": {
         "logos-container": "logos-container_13",
-        "logos-nix": "logos-nix_189",
+        "logos-nix": "logos-nix_179",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -84,9 +84,9 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
-        "logos-nix": "logos-nix_271",
+        "logos-nix": "logos-nix_266",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -112,10 +112,9 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_348",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -141,7 +140,36 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
-        "logos-nix": "logos-nix_431",
+        "logos-nix": "logos-nix_426",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467070,
+        "narHash": "sha256-bJLHdyQBld4AryXbSsKr+jcMf6os4xD+WL97ibdBn3A=",
+        "owner": "logos-co",
+        "repo": "logos-container-subprocess",
+        "rev": "5c6aefcf4f185c94a92fa1345221c211fde8ef84",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container-subprocess",
+        "type": "github"
+      }
+    },
+    "default-container_7": {
+      "inputs": {
+        "logos-container": "logos-container_33",
+        "logos-nix": "logos-nix_508",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -201,7 +229,7 @@
       "inputs": {
         "logos-container": "logos-container_9",
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -209,23 +237,23 @@
         ],
         "logos-module": "logos-module_22",
         "logos-module-loader": "logos-module-loader_4",
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_104",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "logos-qt-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -252,7 +280,7 @@
       "inputs": {
         "logos-container": "logos-container_14",
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -260,23 +288,23 @@
         ],
         "logos-module": "logos-module_38",
         "logos-module-loader": "logos-module-loader_6",
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_183",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "logos-qt-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -303,7 +331,7 @@
       "inputs": {
         "logos-container": "logos-container_19",
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -311,23 +339,23 @@
         ],
         "logos-module": "logos-module_54",
         "logos-module-loader": "logos-module-loader_8",
-        "logos-nix": "logos-nix_275",
+        "logos-nix": "logos-nix_270",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "logos-qt-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -355,7 +383,6 @@
         "logos-container": "logos-container_24",
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -363,7 +390,59 @@
         ],
         "logos-module": "logos-module_70",
         "logos-module-loader": "logos-module-loader_10",
-        "logos-nix": "logos-nix_353",
+        "logos-nix": "logos-nix_352",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787264581,
+        "narHash": "sha256-qqmat4okKyimPdas+X212Ehz+Vp2dT2ZeXBjbjYW/OQ=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader-qt",
+        "rev": "dece0c8aa3b5a29a3457196988d672eda58750d7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader-qt",
+        "type": "github"
+      }
+    },
+    "default-module-loader_6": {
+      "inputs": {
+        "logos-container": "logos-container_29",
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_86",
+        "logos-module-loader": "logos-module-loader_12",
+        "logos-nix": "logos-nix_430",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -405,9 +484,9 @@
         "type": "github"
       }
     },
-    "default-module-loader_6": {
+    "default-module-loader_7": {
       "inputs": {
-        "logos-container": "logos-container_29",
+        "logos-container": "logos-container_34",
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "package_manager",
@@ -416,9 +495,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_86",
-        "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_435",
+        "logos-module": "logos-module_102",
+        "logos-module-loader": "logos-module-loader_14",
+        "logos-nix": "logos-nix_512",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -592,6 +671,24 @@
         "type": "github"
       }
     },
+    "logos-capability-module_8": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_14"
+      },
+      "locked": {
+        "lastModified": 1787279924,
+        "narHash": "sha256-niJhiT0YeCpI5MUjVp4UimVig6tcmLD1Zlj7dRBhybo=",
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "rev": "973f71badd0c25bcf0c4b51c54f289862d304bab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-capability-module",
+        "type": "github"
+      }
+    },
     "logos-container": {
       "inputs": {
         "logos-nix": [
@@ -624,7 +721,7 @@
     "logos-container_10": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -633,7 +730,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -660,9 +757,9 @@
     },
     "logos-container_11": {
       "inputs": {
-        "logos-nix": "logos-nix_134",
+        "logos-nix": "logos-nix_132",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -688,7 +785,7 @@
     "logos-container_12": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -696,7 +793,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -723,7 +820,7 @@
     "logos-container_13": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -731,7 +828,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -757,9 +854,9 @@
     },
     "logos-container_14": {
       "inputs": {
-        "logos-nix": "logos-nix_190",
+        "logos-nix": "logos-nix_180",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -786,7 +883,7 @@
     "logos-container_15": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -795,7 +892,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -822,9 +919,9 @@
     },
     "logos-container_16": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -850,7 +947,7 @@
     "logos-container_17": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -858,7 +955,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -885,7 +982,7 @@
     "logos-container_18": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -893,7 +990,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -919,9 +1016,9 @@
     },
     "logos-container_19": {
       "inputs": {
-        "logos-nix": "logos-nix_272",
+        "logos-nix": "logos-nix_267",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -973,7 +1070,7 @@
     "logos-container_20": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -982,7 +1079,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1009,9 +1106,9 @@
     },
     "logos-container_21": {
       "inputs": {
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_298",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1037,7 +1134,7 @@
     "logos-container_22": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1045,7 +1142,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1073,7 +1170,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1082,7 +1178,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1108,10 +1203,9 @@
     },
     "logos-container_24": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_349",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1139,7 +1233,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1149,7 +1242,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1176,10 +1268,9 @@
     },
     "logos-container_26": {
       "inputs": {
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1206,7 +1297,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1215,7 +1305,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1243,7 +1332,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1252,7 +1341,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1278,10 +1367,10 @@
     },
     "logos-container_29": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1340,6 +1429,176 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module-loader",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415287,
+        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_31": {
+      "inputs": {
+        "logos-nix": "logos-nix_458",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415287,
+        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_32": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module-loader",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415287,
+        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_33": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-container",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-container",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415287,
+        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_34": {
+      "inputs": {
+        "logos-nix": "logos-nix_509",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-container",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415287,
+        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-container",
+        "type": "github"
+      }
+    },
+    "logos-container_35": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-standalone-app",
@@ -1375,9 +1634,9 @@
         "type": "github"
       }
     },
-    "logos-container_31": {
+    "logos-container_36": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_540",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -1403,7 +1662,7 @@
         "type": "github"
       }
     },
-    "logos-container_32": {
+    "logos-container_37": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -1549,7 +1808,7 @@
     "logos-container_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1557,7 +1816,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1583,9 +1842,9 @@
     },
     "logos-container_9": {
       "inputs": {
-        "logos-nix": "logos-nix_103",
+        "logos-nix": "logos-nix_101",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1643,14 +1902,14 @@
     "logos-cpp-sdk_10": {
       "inputs": {
         "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_90",
+        "logos-nix": "logos-nix_88",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -1658,11 +1917,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787433464,
-        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -1674,10 +1933,10 @@
     "logos-cpp-sdk_11": {
       "inputs": {
         "logos-lidl": "logos-lidl_27",
-        "logos-nix": "logos-nix_101",
+        "logos-nix": "logos-nix_99",
         "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -1702,9 +1961,9 @@
     "logos-cpp-sdk_12": {
       "inputs": {
         "logos-lidl": "logos-lidl_28",
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_105",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1713,7 +1972,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1742,7 +2001,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_35",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1753,7 +2012,7 @@
         ],
         "logos-protocol": "logos-protocol_20",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1782,16 +2041,16 @@
     "logos-cpp-sdk_14": {
       "inputs": {
         "logos-lidl": "logos-lidl_37",
-        "logos-nix": "logos-nix_135",
+        "logos-nix": "logos-nix_133",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1818,14 +2077,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_43",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_25",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -1850,14 +2109,14 @@
     "logos-cpp-sdk_16": {
       "inputs": {
         "logos-lidl": "logos-lidl_45",
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_167",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -1865,11 +2124,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
         "type": "github"
       },
       "original": {
@@ -1881,10 +2140,10 @@
     "logos-cpp-sdk_17": {
       "inputs": {
         "logos-lidl": "logos-lidl_50",
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_178",
         "logos-protocol": "logos-protocol_29",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -1909,9 +2168,9 @@
     "logos-cpp-sdk_18": {
       "inputs": {
         "logos-lidl": "logos-lidl_51",
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_184",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1920,7 +2179,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1949,7 +2208,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_58",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -1960,7 +2219,7 @@
         ],
         "logos-protocol": "logos-protocol_32",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2022,16 +2281,16 @@
     "logos-cpp-sdk_20": {
       "inputs": {
         "logos-lidl": "logos-lidl_60",
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_212",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2058,14 +2317,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_66",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_37",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2090,14 +2349,14 @@
     "logos-cpp-sdk_22": {
       "inputs": {
         "logos-lidl": "logos-lidl_68",
-        "logos-nix": "logos-nix_259",
+        "logos-nix": "logos-nix_254",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2105,11 +2364,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787433464,
-        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2121,10 +2380,10 @@
     "logos-cpp-sdk_23": {
       "inputs": {
         "logos-lidl": "logos-lidl_73",
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_265",
         "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -2149,9 +2408,9 @@
     "logos-cpp-sdk_24": {
       "inputs": {
         "logos-lidl": "logos-lidl_74",
-        "logos-nix": "logos-nix_276",
+        "logos-nix": "logos-nix_271",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2160,7 +2419,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2189,7 +2448,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_81",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2200,7 +2459,7 @@
         ],
         "logos-protocol": "logos-protocol_44",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2229,16 +2488,16 @@
     "logos-cpp-sdk_26": {
       "inputs": {
         "logos-lidl": "logos-lidl_83",
-        "logos-nix": "logos-nix_304",
+        "logos-nix": "logos-nix_299",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2265,14 +2524,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_89",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_49",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2297,16 +2556,14 @@
     "logos-cpp-sdk_28": {
       "inputs": {
         "logos-lidl": "logos-lidl_91",
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_336",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2314,11 +2571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787270089,
-        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "lastModified": 1787433464,
+        "narHash": "sha256-ZSJp2KorECpaDI1k88r8NiQcZzSjF5GzSS2HU7B5nZM=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "rev": "acea0d24e2bcf9a11973aac15df4dc12913f9b02",
         "type": "github"
       },
       "original": {
@@ -2330,11 +2587,10 @@
     "logos-cpp-sdk_29": {
       "inputs": {
         "logos-lidl": "logos-lidl_96",
-        "logos-nix": "logos-nix_348",
-        "logos-protocol": "logos-protocol_52",
+        "logos-nix": "logos-nix_347",
+        "logos-protocol": "logos-protocol_53",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -2384,10 +2640,9 @@
     "logos-cpp-sdk_30": {
       "inputs": {
         "logos-lidl": "logos-lidl_97",
-        "logos-nix": "logos-nix_354",
+        "logos-nix": "logos-nix_353",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2397,7 +2652,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2427,7 +2681,6 @@
         "logos-lidl": "logos-lidl_104",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2436,10 +2689,9 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_55",
+        "logos-protocol": "logos-protocol_56",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2468,10 +2720,9 @@
     "logos-cpp-sdk_32": {
       "inputs": {
         "logos-lidl": "logos-lidl_106",
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_381",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2479,7 +2730,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2507,15 +2757,13 @@
         "logos-lidl": "logos-lidl_112",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_60",
+        "logos-protocol": "logos-protocol_61",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2540,16 +2788,16 @@
     "logos-cpp-sdk_34": {
       "inputs": {
         "logos-lidl": "logos-lidl_114",
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_414",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2573,11 +2821,11 @@
     "logos-cpp-sdk_35": {
       "inputs": {
         "logos-lidl": "logos-lidl_119",
-        "logos-nix": "logos-nix_430",
-        "logos-protocol": "logos-protocol_63",
+        "logos-nix": "logos-nix_425",
+        "logos-protocol": "logos-protocol_64",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -2602,10 +2850,10 @@
     "logos-cpp-sdk_36": {
       "inputs": {
         "logos-lidl": "logos-lidl_120",
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_431",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2615,7 +2863,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2645,7 +2893,7 @@
         "logos-lidl": "logos-lidl_127",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2654,10 +2902,10 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_66",
+        "logos-protocol": "logos-protocol_67",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2686,10 +2934,10 @@
     "logos-cpp-sdk_38": {
       "inputs": {
         "logos-lidl": "logos-lidl_129",
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_459",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2697,7 +2945,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -2725,15 +2973,15 @@
         "logos-lidl": "logos-lidl_135",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_71",
+        "logos-protocol": "logos-protocol_72",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2788,6 +3036,224 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
+        "logos-lidl": "logos-lidl_137",
+        "logos-nix": "logos-nix_496",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787270089,
+        "narHash": "sha256-GYaGET2WTGChyl3bJVXE4ioapC3aLILK4tQI/C29FSY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "667990f28c1736ac902ac1d2cb46a0aeaf42467a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_41": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_142",
+        "logos-nix": "logos-nix_507",
+        "logos-protocol": "logos-protocol_75",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_42": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_143",
+        "logos-nix": "logos-nix_513",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_43": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_150",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_78",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_44": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_152",
+        "logos-nix": "logos-nix_541",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_45": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_158",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_83",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_46": {
+      "inputs": {
         "logos-lidl": [
           "logos-qt-sdk",
           "logos-lidl"
@@ -2821,14 +3287,14 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_41": {
+    "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-lidl": "logos-lidl_139",
+        "logos-lidl": "logos-lidl_162",
         "logos-nix": [
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_76",
+        "logos-protocol": "logos-protocol_88",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3047,10 +3513,70 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_337",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787211886,
+        "narHash": "sha256-zHPfxY0EOxTJBwQA8V0gtBRljq6QkqN1M5ELhCLpVsM=",
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "rev": "3312444e96076b8786e3e21a000676fc4e851350",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "type": "github"
+      }
+    },
+    "logos-design-system_11": {
+      "inputs": {
+        "logos-nix": "logos-nix_354",
+        "nix-bundle-appimage": "nix-bundle-appimage_26",
+        "nix-bundle-dir": "nix-bundle-dir_57",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_11",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787211886,
+        "narHash": "sha256-zHPfxY0EOxTJBwQA8V0gtBRljq6QkqN1M5ELhCLpVsM=",
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "rev": "3312444e96076b8786e3e21a000676fc4e851350",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-design-system",
+        "type": "github"
+      }
+    },
+    "logos-design-system_12": {
+      "inputs": {
+        "logos-nix": "logos-nix_415",
+        "nix-bundle-appimage": "nix-bundle-appimage_30",
+        "nix-bundle-dir": "nix-bundle-dir_68",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_12",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3074,12 +3600,12 @@
         "type": "github"
       }
     },
-    "logos-design-system_11": {
+    "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
-        "nix-bundle-appimage": "nix-bundle-appimage_26",
-        "nix-bundle-dir": "nix-bundle-dir_57",
-        "nix-bundle-macos-app": "nix-bundle-macos-app_11",
+        "logos-nix": "logos-nix_432",
+        "nix-bundle-appimage": "nix-bundle-appimage_31",
+        "nix-bundle-dir": "nix-bundle-dir_69",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_13",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -3107,12 +3633,12 @@
         "type": "github"
       }
     },
-    "logos-design-system_12": {
+    "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
-        "nix-bundle-appimage": "nix-bundle-appimage_31",
-        "nix-bundle-dir": "nix-bundle-dir_70",
-        "nix-bundle-macos-app": "nix-bundle-macos-app_12",
+        "logos-nix": "logos-nix_497",
+        "nix-bundle-appimage": "nix-bundle-appimage_36",
+        "nix-bundle-dir": "nix-bundle-dir_82",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_14",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3136,12 +3662,12 @@
         "type": "github"
       }
     },
-    "logos-design-system_13": {
+    "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_437",
-        "nix-bundle-appimage": "nix-bundle-appimage_32",
-        "nix-bundle-dir": "nix-bundle-dir_71",
-        "nix-bundle-macos-app": "nix-bundle-macos-app_13",
+        "logos-nix": "logos-nix_514",
+        "nix-bundle-appimage": "nix-bundle-appimage_37",
+        "nix-bundle-dir": "nix-bundle-dir_83",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_15",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3226,12 +3752,12 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_91",
+        "logos-nix": "logos-nix_89",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_14",
         "nix-bundle-macos-app": "nix-bundle-macos-app_4",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3254,12 +3780,12 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_106",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_15",
         "nix-bundle-macos-app": "nix-bundle-macos-app_5",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3286,12 +3812,12 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_178",
-        "nix-bundle-appimage": "nix-bundle-appimage_14",
-        "nix-bundle-dir": "nix-bundle-dir_30",
+        "logos-nix": "logos-nix_168",
+        "nix-bundle-appimage": "nix-bundle-appimage_12",
+        "nix-bundle-dir": "nix-bundle-dir_26",
         "nix-bundle-macos-app": "nix-bundle-macos-app_6",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3314,12 +3840,12 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_195",
-        "nix-bundle-appimage": "nix-bundle-appimage_15",
-        "nix-bundle-dir": "nix-bundle-dir_31",
+        "logos-nix": "logos-nix_185",
+        "nix-bundle-appimage": "nix-bundle-appimage_13",
+        "nix-bundle-dir": "nix-bundle-dir_27",
         "nix-bundle-macos-app": "nix-bundle-macos-app_7",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3346,12 +3872,12 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_260",
-        "nix-bundle-appimage": "nix-bundle-appimage_20",
-        "nix-bundle-dir": "nix-bundle-dir_44",
+        "logos-nix": "logos-nix_255",
+        "nix-bundle-appimage": "nix-bundle-appimage_19",
+        "nix-bundle-dir": "nix-bundle-dir_42",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix",
@@ -3374,12 +3900,12 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
-        "nix-bundle-appimage": "nix-bundle-appimage_21",
-        "nix-bundle-dir": "nix-bundle-dir_45",
+        "logos-nix": "logos-nix_272",
+        "nix-bundle-appimage": "nix-bundle-appimage_20",
+        "nix-bundle-dir": "nix-bundle-dir_43",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3448,13 +3974,13 @@
         "logos-cpp-sdk": "logos-cpp-sdk_14",
         "logos-module": "logos-module_29",
         "logos-module-loader": "logos-module-loader_5",
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_136",
         "logos-package-manager": "logos-package-manager_5",
         "logos-plugin-qt": "logos-plugin-qt_17",
         "logos-protocol": "logos-protocol_22",
         "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3486,13 +4012,13 @@
         "logos-cpp-sdk": "logos-cpp-sdk_20",
         "logos-module": "logos-module_45",
         "logos-module-loader": "logos-module-loader_7",
-        "logos-nix": "logos-nix_225",
-        "logos-package-manager": "logos-package-manager_9",
+        "logos-nix": "logos-nix_215",
+        "logos-package-manager": "logos-package-manager_8",
         "logos-plugin-qt": "logos-plugin-qt_27",
         "logos-protocol": "logos-protocol_34",
         "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3524,13 +4050,13 @@
         "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-module": "logos-module_61",
         "logos-module-loader": "logos-module-loader_9",
-        "logos-nix": "logos-nix_307",
-        "logos-package-manager": "logos-package-manager_13",
+        "logos-nix": "logos-nix_302",
+        "logos-package-manager": "logos-package-manager_12",
         "logos-plugin-qt": "logos-plugin-qt_37",
         "logos-protocol": "logos-protocol_46",
         "logos-qt-sdk": "logos-qt-sdk_20",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3562,14 +4088,13 @@
         "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-module": "logos-module_77",
         "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_385",
+        "logos-nix": "logos-nix_384",
         "logos-package-manager": "logos-package-manager_16",
         "logos-plugin-qt": "logos-plugin-qt_47",
-        "logos-protocol": "logos-protocol_57",
+        "logos-protocol": "logos-protocol_58",
         "logos-qt-sdk": "logos-qt-sdk_25",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3601,11 +4126,50 @@
         "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-module": "logos-module_93",
         "logos-module-loader": "logos-module-loader_13",
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_462",
         "logos-package-manager": "logos-package-manager_19",
         "logos-plugin-qt": "logos-plugin-qt_57",
-        "logos-protocol": "logos-protocol_68",
+        "logos-protocol": "logos-protocol_69",
         "logos-qt-sdk": "logos-qt-sdk_30",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "process-stats": "process-stats_6"
+      },
+      "locked": {
+        "lastModified": 1787316686,
+        "narHash": "sha256-FRC6SYKwzoQLkSdiiiJ9Ov8Tn6k6hai33ey4PtjgdUY=",
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "rev": "b2a9a0ba9dca51dc0d96651989fab21cd249c5fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-liblogos",
+        "type": "github"
+      }
+    },
+    "logos-liblogos_7": {
+      "inputs": {
+        "default-container": "default-container_7",
+        "default-module-loader": "default-module-loader_7",
+        "logos-capability-module": "logos-capability-module_8",
+        "logos-container": "logos-container_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-module": "logos-module_109",
+        "logos-module-loader": "logos-module-loader_15",
+        "logos-nix": "logos-nix_544",
+        "logos-package-manager": "logos-package-manager_22",
+        "logos-plugin-qt": "logos-plugin-qt_67",
+        "logos-protocol": "logos-protocol_80",
+        "logos-qt-sdk": "logos-qt-sdk_35",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -3615,7 +4179,7 @@
           "logos-nix",
           "nixpkgs"
         ],
-        "process-stats": "process-stats_6"
+        "process-stats": "process-stats_7"
       },
       "locked": {
         "lastModified": 1787316686,
@@ -3693,7 +4257,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3704,7 +4267,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3734,7 +4296,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3745,7 +4306,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3775,7 +4335,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3787,7 +4346,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3818,7 +4376,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3830,7 +4387,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3861,7 +4417,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3873,7 +4428,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3904,7 +4458,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3916,7 +4469,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3947,7 +4499,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3956,7 +4507,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3984,7 +4534,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3993,7 +4542,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4021,7 +4569,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4030,7 +4577,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4058,7 +4604,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -4066,7 +4611,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -4124,7 +4668,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -4132,7 +4675,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -4159,7 +4701,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -4167,7 +4708,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -4194,7 +4734,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -4202,7 +4741,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -4229,7 +4767,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -4237,7 +4774,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -4264,14 +4800,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -4297,14 +4833,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-lidl",
@@ -4330,14 +4866,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-lidl",
@@ -4363,14 +4899,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
@@ -4396,14 +4932,14 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-lidl",
@@ -4429,7 +4965,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -4437,7 +4973,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -4495,7 +5031,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4506,7 +5042,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4536,7 +5072,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4547,7 +5083,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4577,7 +5113,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4588,7 +5124,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4618,7 +5154,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4629,7 +5165,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4659,7 +5195,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4670,7 +5206,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4700,7 +5236,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4712,7 +5248,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4743,7 +5279,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4755,7 +5291,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4786,7 +5322,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4798,7 +5334,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4829,7 +5365,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4841,7 +5377,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4872,7 +5408,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4881,7 +5417,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4934,7 +5470,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4943,7 +5479,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4971,7 +5507,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4980,7 +5516,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5008,7 +5544,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -5016,7 +5552,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -5043,7 +5579,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -5051,7 +5587,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -5078,7 +5614,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -5086,7 +5622,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -5113,7 +5649,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -5121,7 +5657,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -5148,7 +5684,7 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -5156,7 +5692,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -5182,11 +5718,17 @@
     "logos-lidl_137": {
       "inputs": {
         "logos-nix": [
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5209,22 +5751,28 @@
     "logos-lidl_138": {
       "inputs": {
         "logos-nix": [
-          "logos-qt-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-qt-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -5236,13 +5784,17 @@
     "logos-lidl_139": {
       "inputs": {
         "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5298,13 +5850,17 @@
     "logos-lidl_140": {
       "inputs": {
         "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5316,6 +5872,365 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_141": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_142": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_143": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_144": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_145": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_146": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_147": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_148": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_149": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -5340,6 +6255,378 @@
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_150": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_151": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_152": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_153": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_154": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_155": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_156": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_157": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_158": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_159": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5386,6 +6673,118 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_160": {
+      "inputs": {
+        "logos-nix": [
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_161": {
+      "inputs": {
+        "logos-nix": [
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_162": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_163": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -5573,13 +6972,13 @@
     "logos-lidl_22": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -5604,13 +7003,13 @@
     "logos-lidl_23": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-lidl",
@@ -5635,13 +7034,13 @@
     "logos-lidl_24": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-lidl",
@@ -5666,13 +7065,13 @@
     "logos-lidl_25": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
@@ -5697,13 +7096,13 @@
     "logos-lidl_26": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-lidl",
@@ -5728,14 +7127,14 @@
     "logos-lidl_27": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -5761,7 +7160,7 @@
     "logos-lidl_28": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5771,7 +7170,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5800,7 +7199,7 @@
     "logos-lidl_29": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5810,7 +7209,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5870,7 +7269,7 @@
     "logos-lidl_30": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5880,7 +7279,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5909,7 +7308,7 @@
     "logos-lidl_31": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5919,7 +7318,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5948,7 +7347,7 @@
     "logos-lidl_32": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5958,7 +7357,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5987,7 +7386,7 @@
     "logos-lidl_33": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -5998,7 +7397,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6028,7 +7427,7 @@
     "logos-lidl_34": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6039,7 +7438,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6069,7 +7468,7 @@
     "logos-lidl_35": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6080,7 +7479,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6110,7 +7509,7 @@
     "logos-lidl_36": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6121,7 +7520,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6151,7 +7550,7 @@
     "logos-lidl_37": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6159,7 +7558,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6186,7 +7585,7 @@
     "logos-lidl_38": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6194,7 +7593,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6221,7 +7620,7 @@
     "logos-lidl_39": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6229,7 +7628,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6287,14 +7686,14 @@
     "logos-lidl_40": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -6320,14 +7719,14 @@
     "logos-lidl_41": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -6353,14 +7752,14 @@
     "logos-lidl_42": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -6386,14 +7785,14 @@
     "logos-lidl_43": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -6419,14 +7818,14 @@
     "logos-lidl_44": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -6452,13 +7851,13 @@
     "logos-lidl_45": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -6483,13 +7882,13 @@
     "logos-lidl_46": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-lidl",
@@ -6514,13 +7913,13 @@
     "logos-lidl_47": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-lidl",
@@ -6545,13 +7944,13 @@
     "logos-lidl_48": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
@@ -6576,13 +7975,13 @@
     "logos-lidl_49": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-lidl",
@@ -6638,14 +8037,14 @@
     "logos-lidl_50": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -6671,7 +8070,7 @@
     "logos-lidl_51": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6681,7 +8080,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6710,7 +8109,7 @@
     "logos-lidl_52": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6720,7 +8119,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6749,7 +8148,7 @@
     "logos-lidl_53": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6759,7 +8158,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6788,7 +8187,7 @@
     "logos-lidl_54": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6798,7 +8197,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6827,7 +8226,7 @@
     "logos-lidl_55": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6837,7 +8236,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6866,7 +8265,7 @@
     "logos-lidl_56": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6877,7 +8276,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6907,7 +8306,7 @@
     "logos-lidl_57": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6918,7 +8317,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6948,7 +8347,7 @@
     "logos-lidl_58": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6959,7 +8358,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -6989,7 +8388,7 @@
     "logos-lidl_59": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7000,7 +8399,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7063,7 +8462,7 @@
     "logos-lidl_60": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7071,7 +8470,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7098,7 +8497,7 @@
     "logos-lidl_61": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7106,7 +8505,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7133,7 +8532,7 @@
     "logos-lidl_62": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7141,7 +8540,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7168,14 +8567,14 @@
     "logos-lidl_63": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -7201,14 +8600,14 @@
     "logos-lidl_64": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -7234,14 +8633,14 @@
     "logos-lidl_65": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -7267,14 +8666,14 @@
     "logos-lidl_66": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -7300,14 +8699,14 @@
     "logos-lidl_67": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -7333,13 +8732,13 @@
     "logos-lidl_68": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -7364,13 +8763,13 @@
     "logos-lidl_69": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-lidl",
@@ -7428,13 +8827,13 @@
     "logos-lidl_70": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-lidl",
@@ -7459,13 +8858,13 @@
     "logos-lidl_71": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
@@ -7490,13 +8889,13 @@
     "logos-lidl_72": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-lidl",
@@ -7521,14 +8920,14 @@
     "logos-lidl_73": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -7554,7 +8953,7 @@
     "logos-lidl_74": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7564,7 +8963,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7593,7 +8992,7 @@
     "logos-lidl_75": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7603,7 +9002,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7632,7 +9031,7 @@
     "logos-lidl_76": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7642,7 +9041,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7671,7 +9070,7 @@
     "logos-lidl_77": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7681,7 +9080,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7710,7 +9109,7 @@
     "logos-lidl_78": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7720,7 +9119,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7749,7 +9148,7 @@
     "logos-lidl_79": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7760,7 +9159,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7823,7 +9222,7 @@
     "logos-lidl_80": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7834,7 +9233,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7864,7 +9263,7 @@
     "logos-lidl_81": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7875,7 +9274,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7905,7 +9304,7 @@
     "logos-lidl_82": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7916,7 +9315,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7946,7 +9345,7 @@
     "logos-lidl_83": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7954,7 +9353,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7981,7 +9380,7 @@
     "logos-lidl_84": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -7989,7 +9388,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8016,7 +9415,7 @@
     "logos-lidl_85": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8024,7 +9423,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8051,14 +9450,14 @@
     "logos-lidl_86": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -8084,14 +9483,14 @@
     "logos-lidl_87": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -8117,14 +9516,14 @@
     "logos-lidl_88": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
@@ -8150,14 +9549,14 @@
     "logos-lidl_89": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -8216,14 +9615,14 @@
     "logos-lidl_90": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -8250,14 +9649,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -8283,14 +9680,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-lidl",
@@ -8299,11 +9694,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8316,14 +9711,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-lidl",
@@ -8332,11 +9725,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8349,14 +9742,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl",
@@ -8382,14 +9773,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-lidl",
@@ -8415,7 +9804,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -8423,7 +9811,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -8450,7 +9837,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8461,7 +9847,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8491,7 +9876,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8502,7 +9886,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8532,7 +9915,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8543,7 +9925,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8640,15 +10021,14 @@
         "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-design-system": "logos-design-system_11",
         "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_356",
         "logos-plugin-core": "logos-plugin-core_9",
         "logos-plugin-qt": "logos-plugin-qt_43",
-        "logos-protocol": "logos-protocol_53",
+        "logos-protocol": "logos-protocol_54",
         "logos-qt-sdk": "logos-qt-sdk_23",
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8661,7 +10041,6 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_9",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8691,10 +10070,10 @@
         "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-design-system": "logos-design-system_12",
         "logos-module": "logos-module_82",
-        "logos-nix": "logos-nix_422",
+        "logos-nix": "logos-nix_417",
         "logos-plugin-core": "logos-plugin-core_10",
         "logos-plugin-qt": "logos-plugin-qt_51",
-        "logos-protocol": "logos-protocol_62",
+        "logos-protocol": "logos-protocol_63",
         "logos-qt-sdk": "logos-qt-sdk_27",
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
@@ -8705,7 +10084,7 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_12",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -8731,15 +10110,15 @@
         "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-design-system": "logos-design-system_13",
         "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_439",
+        "logos-nix": "logos-nix_434",
         "logos-plugin-core": "logos-plugin-core_11",
         "logos-plugin-qt": "logos-plugin-qt_53",
-        "logos-protocol": "logos-protocol_64",
+        "logos-protocol": "logos-protocol_65",
         "logos-qt-sdk": "logos-qt-sdk_28",
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8752,7 +10131,7 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_11",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8762,6 +10141,97 @@
           "nixpkgs"
         ],
         "rust-overlay": "rust-overlay_11"
+      },
+      "locked": {
+        "lastModified": 1787211948,
+        "narHash": "sha256-Ijr7Vz2ISDdOhJT80rL9eDNkBPbf9522IMk0LEb3n/w=",
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "rev": "378bdba4ed633c79555b50aad22233c42f4f32e7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "type": "github"
+      }
+    },
+    "logos-module-builder_13": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-design-system": "logos-design-system_14",
+        "logos-module": "logos-module_98",
+        "logos-nix": "logos-nix_499",
+        "logos-plugin-core": "logos-plugin-core_12",
+        "logos-plugin-qt": "logos-plugin-qt_61",
+        "logos-protocol": "logos-protocol_74",
+        "logos-qt-sdk": "logos-qt-sdk_32",
+        "logos-rust-sdk": "logos-rust-sdk_13",
+        "logos-standalone-app": "logos-standalone-app_6",
+        "logos-test-framework": "logos-test-framework_14",
+        "logos-view-module": "logos-view-module_14",
+        "logos-view-module-runtime": "logos-view-module-runtime_14",
+        "nix-bundle-lgx": "nix-bundle-lgx_27",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_14",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_14"
+      },
+      "locked": {
+        "lastModified": 1787365695,
+        "narHash": "sha256-f20KxGSgoll2cvtgxnASooKuZx87Ly9K7p5XtkN0V1Y=",
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "rev": "352df67cd6cfa441397495876e21b0d5df93d9f6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-builder",
+        "type": "github"
+      }
+    },
+    "logos-module-builder_14": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-design-system": "logos-design-system_15",
+        "logos-module": "logos-module_103",
+        "logos-nix": "logos-nix_516",
+        "logos-plugin-core": "logos-plugin-core_13",
+        "logos-plugin-qt": "logos-plugin-qt_63",
+        "logos-protocol": "logos-protocol_76",
+        "logos-qt-sdk": "logos-qt-sdk_33",
+        "logos-rust-sdk": "logos-rust-sdk_14",
+        "logos-standalone-app": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module"
+        ],
+        "logos-test-framework": "logos-test-framework_13",
+        "logos-view-module": "logos-view-module_13",
+        "logos-view-module-runtime": "logos-view-module-runtime_13",
+        "nix-bundle-lgx": "nix-bundle-lgx_25",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_13",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-nix",
+          "nixpkgs"
+        ],
+        "rust-overlay": "rust-overlay_13"
       },
       "locked": {
         "lastModified": 1787211948,
@@ -8849,7 +10319,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_10",
         "logos-design-system": "logos-design-system_4",
         "logos-module": "logos-module_18",
-        "logos-nix": "logos-nix_93",
+        "logos-nix": "logos-nix_91",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-protocol": "logos-protocol_15",
@@ -8862,7 +10332,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_7",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_4",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -8870,11 +10340,11 @@
         "rust-overlay": "rust-overlay_4"
       },
       "locked": {
-        "lastModified": 1787447341,
-        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
+        "lastModified": 1787752231,
+        "narHash": "sha256-JoiJB06qUeCP3xlDspf6ra2eL7clpbiGnAeyYpgvtmA=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
+        "rev": "464a75d95f3d4e5d1121437480f608ec0a798499",
         "type": "github"
       },
       "original": {
@@ -8888,14 +10358,14 @@
         "logos-cpp-sdk": "logos-cpp-sdk_12",
         "logos-design-system": "logos-design-system_5",
         "logos-module": "logos-module_23",
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_108",
         "logos-plugin-core": "logos-plugin-core_3",
         "logos-plugin-qt": "logos-plugin-qt_13",
         "logos-protocol": "logos-protocol_18",
         "logos-qt-sdk": "logos-qt-sdk_8",
         "logos-rust-sdk": "logos-rust-sdk_4",
         "logos-standalone-app": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8907,7 +10377,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_5",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_3",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8937,7 +10407,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_16",
         "logos-design-system": "logos-design-system_6",
         "logos-module": "logos-module_34",
-        "logos-nix": "logos-nix_180",
+        "logos-nix": "logos-nix_170",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_21",
         "logos-protocol": "logos-protocol_27",
@@ -8950,7 +10420,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_11",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_6",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -8958,11 +10428,11 @@
         "rust-overlay": "rust-overlay_6"
       },
       "locked": {
-        "lastModified": 1787680752,
-        "narHash": "sha256-WAtpLO5o4XO9aiF1mjq6eq69selq7vm6qXel6BGk7iI=",
+        "lastModified": 1787447341,
+        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "b06c287b20bb538a952e6f44efbf07d0ce973701",
+        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
         "type": "github"
       },
       "original": {
@@ -8976,14 +10446,14 @@
         "logos-cpp-sdk": "logos-cpp-sdk_18",
         "logos-design-system": "logos-design-system_7",
         "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_187",
         "logos-plugin-core": "logos-plugin-core_5",
         "logos-plugin-qt": "logos-plugin-qt_23",
         "logos-protocol": "logos-protocol_30",
         "logos-qt-sdk": "logos-qt-sdk_13",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -8995,7 +10465,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_9",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_5",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9025,7 +10495,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-design-system": "logos-design-system_8",
         "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_262",
+        "logos-nix": "logos-nix_257",
         "logos-plugin-core": "logos-plugin-core_6",
         "logos-plugin-qt": "logos-plugin-qt_31",
         "logos-protocol": "logos-protocol_39",
@@ -9038,7 +10508,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_15",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_8",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -9046,11 +10516,11 @@
         "rust-overlay": "rust-overlay_8"
       },
       "locked": {
-        "lastModified": 1787447341,
-        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
+        "lastModified": 1787680752,
+        "narHash": "sha256-WAtpLO5o4XO9aiF1mjq6eq69selq7vm6qXel6BGk7iI=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
+        "rev": "b06c287b20bb538a952e6f44efbf07d0ce973701",
         "type": "github"
       },
       "original": {
@@ -9064,14 +10534,14 @@
         "logos-cpp-sdk": "logos-cpp-sdk_24",
         "logos-design-system": "logos-design-system_9",
         "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_274",
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_33",
         "logos-protocol": "logos-protocol_42",
         "logos-qt-sdk": "logos-qt-sdk_18",
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9083,7 +10553,7 @@
         "nix-bundle-lgx": "nix-bundle-lgx_13",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_7",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9113,7 +10583,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-design-system": "logos-design-system_10",
         "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_339",
         "logos-plugin-core": "logos-plugin-core_8",
         "logos-plugin-qt": "logos-plugin-qt_41",
         "logos-protocol": "logos-protocol_51",
@@ -9127,7 +10597,6 @@
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_10",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-nix",
           "nixpkgs"
@@ -9135,11 +10604,11 @@
         "rust-overlay": "rust-overlay_10"
       },
       "locked": {
-        "lastModified": 1787365695,
-        "narHash": "sha256-f20KxGSgoll2cvtgxnASooKuZx87Ly9K7p5XtkN0V1Y=",
+        "lastModified": 1787447341,
+        "narHash": "sha256-I3BQnjqFns7ffilm2Z/hzsPMwwLnqvcLaV0o6OkVenc=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "352df67cd6cfa441397495876e21b0d5df93d9f6",
+        "rev": "e45caf147bdb938a2e2025ef52f1a25070841711",
         "type": "github"
       },
       "original": {
@@ -9206,10 +10675,9 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_351",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9236,10 +10704,9 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
-        "logos-nix": "logos-nix_384",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9265,10 +10732,10 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-        "logos-nix": "logos-nix_434",
+        "logos-nix": "logos-nix_429",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9295,7 +10762,66 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_461",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467099,
+        "narHash": "sha256-91JadGkNDW05TfyDvRbOD9rVsn6iG3VsuLt9Fo64F90=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "rev": "3628b97a32cb2edb30e7d26c0c5113a487e3e993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "type": "github"
+      }
+    },
+    "logos-module-loader_14": {
+      "inputs": {
+        "logos-container": "logos-container_35",
+        "logos-nix": "logos-nix_511",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module-loader",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467099,
+        "narHash": "sha256-91JadGkNDW05TfyDvRbOD9rVsn6iG3VsuLt9Fo64F90=",
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "rev": "3628b97a32cb2edb30e7d26c0c5113a487e3e993",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module-loader",
+        "type": "github"
+      }
+    },
+    "logos-module-loader_15": {
+      "inputs": {
+        "logos-container": "logos-container_37",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -9374,9 +10900,9 @@
     "logos-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_10",
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_103",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9403,9 +10929,9 @@
     "logos-module-loader_5": {
       "inputs": {
         "logos-container": "logos-container_12",
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_135",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9431,9 +10957,9 @@
     "logos-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_15",
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_182",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9460,9 +10986,9 @@
     "logos-module-loader_7": {
       "inputs": {
         "logos-container": "logos-container_17",
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_214",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9488,9 +11014,9 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
-        "logos-nix": "logos-nix_274",
+        "logos-nix": "logos-nix_269",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9517,9 +11043,9 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_301",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9572,10 +11098,285 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_101": {
+      "inputs": {
+        "logos-nix": "logos-nix_506",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_102": {
+      "inputs": {
+        "logos-nix": "logos-nix_510",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_103": {
+      "inputs": {
+        "logos-nix": "logos-nix_515",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_104": {
+      "inputs": {
+        "logos-nix": "logos-nix_517",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_105": {
+      "inputs": {
+        "logos-nix": "logos-nix_519",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_106": {
+      "inputs": {
+        "logos-nix": "logos-nix_523",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_107": {
+      "inputs": {
+        "logos-nix": "logos-nix_525",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_108": {
+      "inputs": {
+        "logos-nix": "logos-nix_527",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_109": {
+      "inputs": {
+        "logos-nix": "logos-nix_542",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -9601,6 +11402,193 @@
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_110": {
+      "inputs": {
+        "logos-nix": "logos-nix_550",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_111": {
+      "inputs": {
+        "logos-nix": "logos-nix_555",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_112": {
+      "inputs": {
+        "logos-nix": "logos-nix_558",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_113": {
+      "inputs": {
+        "logos-nix": "logos-nix_560",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_114": {
+      "inputs": {
+        "logos-nix": "logos-nix_578",
+        "nixpkgs": [
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_115": {
+      "inputs": {
+        "logos-nix": "logos-nix_583",
+        "nixpkgs": [
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_116": {
+      "inputs": {
+        "logos-nix": "logos-nix_585",
+        "nixpkgs": [
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -9771,9 +11759,9 @@
     },
     "logos-module_18": {
       "inputs": {
-        "logos-nix": "logos-nix_92",
+        "logos-nix": "logos-nix_90",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -9796,9 +11784,9 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_94",
+        "logos-nix": "logos-nix_92",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -9848,9 +11836,9 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_96",
+        "logos-nix": "logos-nix_94",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -9874,9 +11862,9 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_100",
+        "logos-nix": "logos-nix_98",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -9901,9 +11889,9 @@
     },
     "logos-module_22": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_102",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9929,9 +11917,9 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_107",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9958,9 +11946,9 @@
     },
     "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_111",
+        "logos-nix": "logos-nix_109",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -9988,9 +11976,9 @@
     },
     "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10018,9 +12006,9 @@
     },
     "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_115",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10049,9 +12037,9 @@
     },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_117",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10080,9 +12068,9 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10111,9 +12099,9 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_134",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10164,9 +12152,9 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_142",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10192,9 +12180,9 @@
     },
     "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_149",
+        "logos-nix": "logos-nix_147",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -10219,9 +12207,9 @@
     },
     "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_152",
+        "logos-nix": "logos-nix_150",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -10246,9 +12234,9 @@
     },
     "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_154",
+        "logos-nix": "logos-nix_152",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -10273,9 +12261,9 @@
     },
     "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_179",
+        "logos-nix": "logos-nix_169",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -10298,9 +12286,9 @@
     },
     "logos-module_35": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_171",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -10324,9 +12312,9 @@
     },
     "logos-module_36": {
       "inputs": {
-        "logos-nix": "logos-nix_183",
+        "logos-nix": "logos-nix_173",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -10350,9 +12338,9 @@
     },
     "logos-module_37": {
       "inputs": {
-        "logos-nix": "logos-nix_187",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -10377,9 +12365,9 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_191",
+        "logos-nix": "logos-nix_181",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10405,9 +12393,9 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_186",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10461,9 +12449,9 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_188",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10491,9 +12479,9 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10521,9 +12509,9 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_194",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10552,9 +12540,9 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10583,9 +12571,9 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10614,9 +12602,9 @@
     },
     "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_223",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10641,9 +12629,9 @@
     },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_221",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10669,9 +12657,9 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_236",
+        "logos-nix": "logos-nix_226",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -10696,9 +12684,9 @@
     },
     "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -10723,9 +12711,9 @@
     },
     "logos-module_49": {
       "inputs": {
-        "logos-nix": "logos-nix_241",
+        "logos-nix": "logos-nix_231",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -10777,9 +12765,9 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_261",
+        "logos-nix": "logos-nix_256",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -10802,9 +12790,9 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_263",
+        "logos-nix": "logos-nix_258",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -10828,9 +12816,9 @@
     },
     "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_265",
+        "logos-nix": "logos-nix_260",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -10854,9 +12842,9 @@
     },
     "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_269",
+        "logos-nix": "logos-nix_264",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -10881,9 +12869,9 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_268",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10909,9 +12897,9 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_278",
+        "logos-nix": "logos-nix_273",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10938,9 +12926,9 @@
     },
     "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_280",
+        "logos-nix": "logos-nix_275",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10968,9 +12956,9 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_282",
+        "logos-nix": "logos-nix_277",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -10998,9 +12986,9 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_281",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11029,9 +13017,9 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11087,9 +13075,9 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_290",
+        "logos-nix": "logos-nix_285",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11118,9 +13106,9 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11145,9 +13133,9 @@
     },
     "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_313",
+        "logos-nix": "logos-nix_308",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11173,9 +13161,9 @@
     },
     "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_313",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -11200,9 +13188,9 @@
     },
     "logos-module_64": {
       "inputs": {
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_316",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -11227,9 +13215,9 @@
     },
     "logos-module_65": {
       "inputs": {
-        "logos-nix": "logos-nix_323",
+        "logos-nix": "logos-nix_318",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -11254,10 +13242,9 @@
     },
     "logos-module_66": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -11280,10 +13267,9 @@
     },
     "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -11307,10 +13293,9 @@
     },
     "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_343",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -11334,10 +13319,9 @@
     },
     "logos-module_69": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_346",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -11387,10 +13371,9 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_350",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11416,10 +13399,9 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_356",
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11446,10 +13428,9 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_357",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11477,10 +13458,9 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_359",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11508,10 +13488,9 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_363",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11540,10 +13519,9 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_365",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11572,10 +13550,9 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11604,10 +13581,9 @@
     },
     "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_382",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11632,10 +13608,9 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_390",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11661,10 +13636,9 @@
     },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_395",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -11716,10 +13690,9 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_398",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -11744,10 +13717,9 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_400",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -11772,10 +13744,10 @@
     },
     "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_416",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -11798,10 +13770,10 @@
     },
     "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -11825,10 +13797,10 @@
     },
     "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_425",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
@@ -11852,10 +13824,10 @@
     },
     "logos-module_85": {
       "inputs": {
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_424",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -11880,10 +13852,10 @@
     },
     "logos-module_86": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_428",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11909,10 +13881,10 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_438",
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11939,10 +13911,10 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_440",
+        "logos-nix": "logos-nix_435",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -11970,10 +13942,10 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_437",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12027,10 +13999,10 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12059,10 +14031,10 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_443",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12091,10 +14063,10 @@
     },
     "logos-module_92": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_445",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12123,10 +14095,10 @@
     },
     "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_460",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12151,10 +14123,10 @@
     },
     "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_473",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -12180,10 +14152,10 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-plugin-qt",
@@ -12208,10 +14180,10 @@
     },
     "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -12236,10 +14208,10 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_483",
+        "logos-nix": "logos-nix_478",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -12264,9 +14236,11 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12288,10 +14262,12 @@
     },
     "logos-module_99": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_500",
         "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -12308,6 +14284,24 @@
       "original": {
         "owner": "logos-co",
         "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-modules-state-module": {
+      "inputs": {
+        "logos-module-builder": "logos-module-builder_3"
+      },
+      "locked": {
+        "lastModified": 1787794574,
+        "narHash": "sha256-wDjH3pE/72LK5DeK7l8Kl4m16ngUqFRebhvGa55sY0U=",
+        "owner": "logos-co",
+        "repo": "logos-modules-state-module",
+        "rev": "2370bcb11a46f1c7929864cbb699ec9fb8ce79e8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-modules-state-module",
         "type": "github"
       }
     },
@@ -12431,11 +14425,11 @@
         "nixpkgs-windows": "nixpkgs-windows_98"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -12469,11 +14463,11 @@
         "nixpkgs-windows": "nixpkgs-windows_100"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -12883,7 +14877,43 @@
     },
     "logos-nix_126": {
       "inputs": {
-        "nixpkgs": "nixpkgs_126",
+        "nixpkgs": "nixpkgs_126"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_127": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_127"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_128": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_128",
         "nixpkgs-windows": "nixpkgs-windows_120"
       },
       "locked": {
@@ -12900,9 +14930,9 @@
         "type": "github"
       }
     },
-    "logos-nix_127": {
+    "logos-nix_129": {
       "inputs": {
-        "nixpkgs": "nixpkgs_127",
+        "nixpkgs": "nixpkgs_129",
         "nixpkgs-windows": "nixpkgs-windows_121"
       },
       "locked": {
@@ -12911,42 +14941,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_128": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_128"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_129": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_129"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13147,15 +15141,14 @@
     },
     "logos-nix_139": {
       "inputs": {
-        "nixpkgs": "nixpkgs_139",
-        "nixpkgs-windows": "nixpkgs-windows_131"
+        "nixpkgs": "nixpkgs_139"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13185,8 +15178,26 @@
     },
     "logos-nix_140": {
       "inputs": {
-        "nixpkgs": "nixpkgs_140",
-        "nixpkgs-windows": "nixpkgs-windows_132"
+        "nixpkgs": "nixpkgs_140"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_141": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_141",
+        "nixpkgs-windows": "nixpkgs-windows_131"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13202,34 +15213,17 @@
         "type": "github"
       }
     },
-    "logos-nix_141": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_141"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_142": {
       "inputs": {
-        "nixpkgs": "nixpkgs_142"
+        "nixpkgs": "nixpkgs_142",
+        "nixpkgs-windows": "nixpkgs-windows_132"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13301,11 +15295,11 @@
         "nixpkgs-windows": "nixpkgs-windows_136"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -13335,15 +15329,14 @@
     },
     "logos-nix_148": {
       "inputs": {
-        "nixpkgs": "nixpkgs_148",
-        "nixpkgs-windows": "nixpkgs-windows_138"
+        "nixpkgs": "nixpkgs_148"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13355,7 +15348,7 @@
     "logos-nix_149": {
       "inputs": {
         "nixpkgs": "nixpkgs_149",
-        "nixpkgs-windows": "nixpkgs-windows_139"
+        "nixpkgs-windows": "nixpkgs-windows_138"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13392,14 +15385,15 @@
     },
     "logos-nix_150": {
       "inputs": {
-        "nixpkgs": "nixpkgs_150"
+        "nixpkgs": "nixpkgs_150",
+        "nixpkgs-windows": "nixpkgs-windows_139"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13562,15 +15556,14 @@
     },
     "logos-nix_159": {
       "inputs": {
-        "nixpkgs": "nixpkgs_159",
-        "nixpkgs-windows": "nixpkgs-windows_148"
+        "nixpkgs": "nixpkgs_159"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -13600,8 +15593,26 @@
     },
     "logos-nix_160": {
       "inputs": {
-        "nixpkgs": "nixpkgs_160",
-        "nixpkgs-windows": "nixpkgs-windows_149"
+        "nixpkgs": "nixpkgs_160"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_161": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_161",
+        "nixpkgs-windows": "nixpkgs-windows_148"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13617,34 +15628,17 @@
         "type": "github"
       }
     },
-    "logos-nix_161": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_161"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_162": {
       "inputs": {
-        "nixpkgs": "nixpkgs_162"
+        "nixpkgs": "nixpkgs_162",
+        "nixpkgs-windows": "nixpkgs-windows_149"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13697,11 +15691,11 @@
         "nixpkgs-windows": "nixpkgs-windows_152"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -13769,14 +15763,15 @@
     },
     "logos-nix_169": {
       "inputs": {
-        "nixpkgs": "nixpkgs_169"
+        "nixpkgs": "nixpkgs_169",
+        "nixpkgs-windows": "nixpkgs-windows_156"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13806,14 +15801,15 @@
     },
     "logos-nix_170": {
       "inputs": {
-        "nixpkgs": "nixpkgs_170"
+        "nixpkgs": "nixpkgs_170",
+        "nixpkgs-windows": "nixpkgs-windows_157"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13825,7 +15821,7 @@
     "logos-nix_171": {
       "inputs": {
         "nixpkgs": "nixpkgs_171",
-        "nixpkgs-windows": "nixpkgs-windows_156"
+        "nixpkgs-windows": "nixpkgs-windows_158"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13844,7 +15840,7 @@
     "logos-nix_172": {
       "inputs": {
         "nixpkgs": "nixpkgs_172",
-        "nixpkgs-windows": "nixpkgs-windows_157"
+        "nixpkgs-windows": "nixpkgs-windows_159"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13863,7 +15859,7 @@
     "logos-nix_173": {
       "inputs": {
         "nixpkgs": "nixpkgs_173",
-        "nixpkgs-windows": "nixpkgs-windows_158"
+        "nixpkgs-windows": "nixpkgs-windows_160"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13881,14 +15877,15 @@
     },
     "logos-nix_174": {
       "inputs": {
-        "nixpkgs": "nixpkgs_174"
+        "nixpkgs": "nixpkgs_174",
+        "nixpkgs-windows": "nixpkgs-windows_161"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13899,14 +15896,15 @@
     },
     "logos-nix_175": {
       "inputs": {
-        "nixpkgs": "nixpkgs_175"
+        "nixpkgs": "nixpkgs_175",
+        "nixpkgs-windows": "nixpkgs-windows_162"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -13918,7 +15916,7 @@
     "logos-nix_176": {
       "inputs": {
         "nixpkgs": "nixpkgs_176",
-        "nixpkgs-windows": "nixpkgs-windows_159"
+        "nixpkgs-windows": "nixpkgs-windows_163"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13937,7 +15935,7 @@
     "logos-nix_177": {
       "inputs": {
         "nixpkgs": "nixpkgs_177",
-        "nixpkgs-windows": "nixpkgs-windows_160"
+        "nixpkgs-windows": "nixpkgs-windows_164"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13956,7 +15954,7 @@
     "logos-nix_178": {
       "inputs": {
         "nixpkgs": "nixpkgs_178",
-        "nixpkgs-windows": "nixpkgs-windows_161"
+        "nixpkgs-windows": "nixpkgs-windows_165"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -13975,7 +15973,7 @@
     "logos-nix_179": {
       "inputs": {
         "nixpkgs": "nixpkgs_179",
-        "nixpkgs-windows": "nixpkgs-windows_162"
+        "nixpkgs-windows": "nixpkgs-windows_166"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14013,7 +16011,7 @@
     "logos-nix_180": {
       "inputs": {
         "nixpkgs": "nixpkgs_180",
-        "nixpkgs-windows": "nixpkgs-windows_163"
+        "nixpkgs-windows": "nixpkgs-windows_167"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14032,7 +16030,7 @@
     "logos-nix_181": {
       "inputs": {
         "nixpkgs": "nixpkgs_181",
-        "nixpkgs-windows": "nixpkgs-windows_164"
+        "nixpkgs-windows": "nixpkgs-windows_168"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14051,7 +16049,7 @@
     "logos-nix_182": {
       "inputs": {
         "nixpkgs": "nixpkgs_182",
-        "nixpkgs-windows": "nixpkgs-windows_165"
+        "nixpkgs-windows": "nixpkgs-windows_169"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14070,14 +16068,14 @@
     "logos-nix_183": {
       "inputs": {
         "nixpkgs": "nixpkgs_183",
-        "nixpkgs-windows": "nixpkgs-windows_166"
+        "nixpkgs-windows": "nixpkgs-windows_170"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -14089,7 +16087,7 @@
     "logos-nix_184": {
       "inputs": {
         "nixpkgs": "nixpkgs_184",
-        "nixpkgs-windows": "nixpkgs-windows_167"
+        "nixpkgs-windows": "nixpkgs-windows_171"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14108,7 +16106,7 @@
     "logos-nix_185": {
       "inputs": {
         "nixpkgs": "nixpkgs_185",
-        "nixpkgs-windows": "nixpkgs-windows_168"
+        "nixpkgs-windows": "nixpkgs-windows_172"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14127,7 +16125,7 @@
     "logos-nix_186": {
       "inputs": {
         "nixpkgs": "nixpkgs_186",
-        "nixpkgs-windows": "nixpkgs-windows_169"
+        "nixpkgs-windows": "nixpkgs-windows_173"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14146,7 +16144,7 @@
     "logos-nix_187": {
       "inputs": {
         "nixpkgs": "nixpkgs_187",
-        "nixpkgs-windows": "nixpkgs-windows_170"
+        "nixpkgs-windows": "nixpkgs-windows_174"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14165,7 +16163,7 @@
     "logos-nix_188": {
       "inputs": {
         "nixpkgs": "nixpkgs_188",
-        "nixpkgs-windows": "nixpkgs-windows_171"
+        "nixpkgs-windows": "nixpkgs-windows_175"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14184,7 +16182,7 @@
     "logos-nix_189": {
       "inputs": {
         "nixpkgs": "nixpkgs_189",
-        "nixpkgs-windows": "nixpkgs-windows_172"
+        "nixpkgs-windows": "nixpkgs-windows_176"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14222,7 +16220,7 @@
     "logos-nix_190": {
       "inputs": {
         "nixpkgs": "nixpkgs_190",
-        "nixpkgs-windows": "nixpkgs-windows_173"
+        "nixpkgs-windows": "nixpkgs-windows_177"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14241,7 +16239,7 @@
     "logos-nix_191": {
       "inputs": {
         "nixpkgs": "nixpkgs_191",
-        "nixpkgs-windows": "nixpkgs-windows_174"
+        "nixpkgs-windows": "nixpkgs-windows_178"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14260,7 +16258,7 @@
     "logos-nix_192": {
       "inputs": {
         "nixpkgs": "nixpkgs_192",
-        "nixpkgs-windows": "nixpkgs-windows_175"
+        "nixpkgs-windows": "nixpkgs-windows_179"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14279,14 +16277,14 @@
     "logos-nix_193": {
       "inputs": {
         "nixpkgs": "nixpkgs_193",
-        "nixpkgs-windows": "nixpkgs-windows_176"
+        "nixpkgs-windows": "nixpkgs-windows_180"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -14298,7 +16296,7 @@
     "logos-nix_194": {
       "inputs": {
         "nixpkgs": "nixpkgs_194",
-        "nixpkgs-windows": "nixpkgs-windows_177"
+        "nixpkgs-windows": "nixpkgs-windows_181"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14317,7 +16315,7 @@
     "logos-nix_195": {
       "inputs": {
         "nixpkgs": "nixpkgs_195",
-        "nixpkgs-windows": "nixpkgs-windows_178"
+        "nixpkgs-windows": "nixpkgs-windows_182"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14336,7 +16334,7 @@
     "logos-nix_196": {
       "inputs": {
         "nixpkgs": "nixpkgs_196",
-        "nixpkgs-windows": "nixpkgs-windows_179"
+        "nixpkgs-windows": "nixpkgs-windows_183"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14355,7 +16353,7 @@
     "logos-nix_197": {
       "inputs": {
         "nixpkgs": "nixpkgs_197",
-        "nixpkgs-windows": "nixpkgs-windows_180"
+        "nixpkgs-windows": "nixpkgs-windows_184"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14374,7 +16372,7 @@
     "logos-nix_198": {
       "inputs": {
         "nixpkgs": "nixpkgs_198",
-        "nixpkgs-windows": "nixpkgs-windows_181"
+        "nixpkgs-windows": "nixpkgs-windows_185"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14393,7 +16391,7 @@
     "logos-nix_199": {
       "inputs": {
         "nixpkgs": "nixpkgs_199",
-        "nixpkgs-windows": "nixpkgs-windows_182"
+        "nixpkgs-windows": "nixpkgs-windows_186"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14450,7 +16448,7 @@
     "logos-nix_200": {
       "inputs": {
         "nixpkgs": "nixpkgs_200",
-        "nixpkgs-windows": "nixpkgs-windows_183"
+        "nixpkgs-windows": "nixpkgs-windows_187"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14469,7 +16467,7 @@
     "logos-nix_201": {
       "inputs": {
         "nixpkgs": "nixpkgs_201",
-        "nixpkgs-windows": "nixpkgs-windows_184"
+        "nixpkgs-windows": "nixpkgs-windows_188"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14488,7 +16486,7 @@
     "logos-nix_202": {
       "inputs": {
         "nixpkgs": "nixpkgs_202",
-        "nixpkgs-windows": "nixpkgs-windows_185"
+        "nixpkgs-windows": "nixpkgs-windows_189"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14507,7 +16505,7 @@
     "logos-nix_203": {
       "inputs": {
         "nixpkgs": "nixpkgs_203",
-        "nixpkgs-windows": "nixpkgs-windows_186"
+        "nixpkgs-windows": "nixpkgs-windows_190"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14526,7 +16524,7 @@
     "logos-nix_204": {
       "inputs": {
         "nixpkgs": "nixpkgs_204",
-        "nixpkgs-windows": "nixpkgs-windows_187"
+        "nixpkgs-windows": "nixpkgs-windows_191"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14544,15 +16542,14 @@
     },
     "logos-nix_205": {
       "inputs": {
-        "nixpkgs": "nixpkgs_205",
-        "nixpkgs-windows": "nixpkgs-windows_188"
+        "nixpkgs": "nixpkgs_205"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14563,15 +16560,14 @@
     },
     "logos-nix_206": {
       "inputs": {
-        "nixpkgs": "nixpkgs_206",
-        "nixpkgs-windows": "nixpkgs-windows_189"
+        "nixpkgs": "nixpkgs_206"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14583,7 +16579,7 @@
     "logos-nix_207": {
       "inputs": {
         "nixpkgs": "nixpkgs_207",
-        "nixpkgs-windows": "nixpkgs-windows_190"
+        "nixpkgs-windows": "nixpkgs-windows_192"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14602,7 +16598,7 @@
     "logos-nix_208": {
       "inputs": {
         "nixpkgs": "nixpkgs_208",
-        "nixpkgs-windows": "nixpkgs-windows_191"
+        "nixpkgs-windows": "nixpkgs-windows_193"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14621,7 +16617,7 @@
     "logos-nix_209": {
       "inputs": {
         "nixpkgs": "nixpkgs_209",
-        "nixpkgs-windows": "nixpkgs-windows_192"
+        "nixpkgs-windows": "nixpkgs-windows_194"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14659,7 +16655,7 @@
     "logos-nix_210": {
       "inputs": {
         "nixpkgs": "nixpkgs_210",
-        "nixpkgs-windows": "nixpkgs-windows_193"
+        "nixpkgs-windows": "nixpkgs-windows_195"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14678,7 +16674,7 @@
     "logos-nix_211": {
       "inputs": {
         "nixpkgs": "nixpkgs_211",
-        "nixpkgs-windows": "nixpkgs-windows_194"
+        "nixpkgs-windows": "nixpkgs-windows_196"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14697,7 +16693,7 @@
     "logos-nix_212": {
       "inputs": {
         "nixpkgs": "nixpkgs_212",
-        "nixpkgs-windows": "nixpkgs-windows_195"
+        "nixpkgs-windows": "nixpkgs-windows_197"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14716,7 +16712,7 @@
     "logos-nix_213": {
       "inputs": {
         "nixpkgs": "nixpkgs_213",
-        "nixpkgs-windows": "nixpkgs-windows_196"
+        "nixpkgs-windows": "nixpkgs-windows_198"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14735,7 +16731,7 @@
     "logos-nix_214": {
       "inputs": {
         "nixpkgs": "nixpkgs_214",
-        "nixpkgs-windows": "nixpkgs-windows_197"
+        "nixpkgs-windows": "nixpkgs-windows_199"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14753,14 +16749,15 @@
     },
     "logos-nix_215": {
       "inputs": {
-        "nixpkgs": "nixpkgs_215"
+        "nixpkgs": "nixpkgs_215",
+        "nixpkgs-windows": "nixpkgs-windows_200"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -14771,14 +16768,15 @@
     },
     "logos-nix_216": {
       "inputs": {
-        "nixpkgs": "nixpkgs_216"
+        "nixpkgs": "nixpkgs_216",
+        "nixpkgs-windows": "nixpkgs-windows_201"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -14790,7 +16788,7 @@
     "logos-nix_217": {
       "inputs": {
         "nixpkgs": "nixpkgs_217",
-        "nixpkgs-windows": "nixpkgs-windows_198"
+        "nixpkgs-windows": "nixpkgs-windows_202"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14808,15 +16806,14 @@
     },
     "logos-nix_218": {
       "inputs": {
-        "nixpkgs": "nixpkgs_218",
-        "nixpkgs-windows": "nixpkgs-windows_199"
+        "nixpkgs": "nixpkgs_218"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14827,15 +16824,14 @@
     },
     "logos-nix_219": {
       "inputs": {
-        "nixpkgs": "nixpkgs_219",
-        "nixpkgs-windows": "nixpkgs-windows_200"
+        "nixpkgs": "nixpkgs_219"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -14865,7 +16861,7 @@
     "logos-nix_220": {
       "inputs": {
         "nixpkgs": "nixpkgs_220",
-        "nixpkgs-windows": "nixpkgs-windows_201"
+        "nixpkgs-windows": "nixpkgs-windows_203"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14884,7 +16880,7 @@
     "logos-nix_221": {
       "inputs": {
         "nixpkgs": "nixpkgs_221",
-        "nixpkgs-windows": "nixpkgs-windows_202"
+        "nixpkgs-windows": "nixpkgs-windows_204"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14903,7 +16899,7 @@
     "logos-nix_222": {
       "inputs": {
         "nixpkgs": "nixpkgs_222",
-        "nixpkgs-windows": "nixpkgs-windows_203"
+        "nixpkgs-windows": "nixpkgs-windows_205"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14922,7 +16918,7 @@
     "logos-nix_223": {
       "inputs": {
         "nixpkgs": "nixpkgs_223",
-        "nixpkgs-windows": "nixpkgs-windows_204"
+        "nixpkgs-windows": "nixpkgs-windows_206"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14941,7 +16937,7 @@
     "logos-nix_224": {
       "inputs": {
         "nixpkgs": "nixpkgs_224",
-        "nixpkgs-windows": "nixpkgs-windows_205"
+        "nixpkgs-windows": "nixpkgs-windows_207"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14960,14 +16956,14 @@
     "logos-nix_225": {
       "inputs": {
         "nixpkgs": "nixpkgs_225",
-        "nixpkgs-windows": "nixpkgs-windows_206"
+        "nixpkgs-windows": "nixpkgs-windows_208"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -14979,7 +16975,7 @@
     "logos-nix_226": {
       "inputs": {
         "nixpkgs": "nixpkgs_226",
-        "nixpkgs-windows": "nixpkgs-windows_207"
+        "nixpkgs-windows": "nixpkgs-windows_209"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -14997,8 +16993,26 @@
     },
     "logos-nix_227": {
       "inputs": {
-        "nixpkgs": "nixpkgs_227",
-        "nixpkgs-windows": "nixpkgs-windows_208"
+        "nixpkgs": "nixpkgs_227"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_228": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_228",
+        "nixpkgs-windows": "nixpkgs-windows_210"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15014,34 +17028,17 @@
         "type": "github"
       }
     },
-    "logos-nix_228": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_228"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_229": {
       "inputs": {
-        "nixpkgs": "nixpkgs_229"
+        "nixpkgs": "nixpkgs_229",
+        "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -15071,7 +17068,7 @@
     "logos-nix_230": {
       "inputs": {
         "nixpkgs": "nixpkgs_230",
-        "nixpkgs-windows": "nixpkgs-windows_209"
+        "nixpkgs-windows": "nixpkgs-windows_212"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15090,7 +17087,7 @@
     "logos-nix_231": {
       "inputs": {
         "nixpkgs": "nixpkgs_231",
-        "nixpkgs-windows": "nixpkgs-windows_210"
+        "nixpkgs-windows": "nixpkgs-windows_213"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15109,7 +17106,7 @@
     "logos-nix_232": {
       "inputs": {
         "nixpkgs": "nixpkgs_232",
-        "nixpkgs-windows": "nixpkgs-windows_211"
+        "nixpkgs-windows": "nixpkgs-windows_214"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15128,7 +17125,7 @@
     "logos-nix_233": {
       "inputs": {
         "nixpkgs": "nixpkgs_233",
-        "nixpkgs-windows": "nixpkgs-windows_212"
+        "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15147,7 +17144,7 @@
     "logos-nix_234": {
       "inputs": {
         "nixpkgs": "nixpkgs_234",
-        "nixpkgs-windows": "nixpkgs-windows_213"
+        "nixpkgs-windows": "nixpkgs-windows_216"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15166,14 +17163,14 @@
     "logos-nix_235": {
       "inputs": {
         "nixpkgs": "nixpkgs_235",
-        "nixpkgs-windows": "nixpkgs-windows_214"
+        "nixpkgs-windows": "nixpkgs-windows_217"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -15185,7 +17182,7 @@
     "logos-nix_236": {
       "inputs": {
         "nixpkgs": "nixpkgs_236",
-        "nixpkgs-windows": "nixpkgs-windows_215"
+        "nixpkgs-windows": "nixpkgs-windows_218"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15203,7 +17200,26 @@
     },
     "logos-nix_237": {
       "inputs": {
-        "nixpkgs": "nixpkgs_237"
+        "nixpkgs": "nixpkgs_237",
+        "nixpkgs-windows": "nixpkgs-windows_219"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_238": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_238"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -15219,36 +17235,16 @@
         "type": "github"
       }
     },
-    "logos-nix_238": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_238",
-        "nixpkgs-windows": "nixpkgs-windows_216"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_239": {
       "inputs": {
-        "nixpkgs": "nixpkgs_239",
-        "nixpkgs-windows": "nixpkgs-windows_217"
+        "nixpkgs": "nixpkgs_239"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15279,7 +17275,7 @@
     "logos-nix_240": {
       "inputs": {
         "nixpkgs": "nixpkgs_240",
-        "nixpkgs-windows": "nixpkgs-windows_218"
+        "nixpkgs-windows": "nixpkgs-windows_220"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15298,7 +17294,7 @@
     "logos-nix_241": {
       "inputs": {
         "nixpkgs": "nixpkgs_241",
-        "nixpkgs-windows": "nixpkgs-windows_219"
+        "nixpkgs-windows": "nixpkgs-windows_221"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15317,7 +17313,7 @@
     "logos-nix_242": {
       "inputs": {
         "nixpkgs": "nixpkgs_242",
-        "nixpkgs-windows": "nixpkgs-windows_220"
+        "nixpkgs-windows": "nixpkgs-windows_222"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15336,7 +17332,7 @@
     "logos-nix_243": {
       "inputs": {
         "nixpkgs": "nixpkgs_243",
-        "nixpkgs-windows": "nixpkgs-windows_221"
+        "nixpkgs-windows": "nixpkgs-windows_223"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15355,7 +17351,7 @@
     "logos-nix_244": {
       "inputs": {
         "nixpkgs": "nixpkgs_244",
-        "nixpkgs-windows": "nixpkgs-windows_222"
+        "nixpkgs-windows": "nixpkgs-windows_224"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15374,7 +17370,7 @@
     "logos-nix_245": {
       "inputs": {
         "nixpkgs": "nixpkgs_245",
-        "nixpkgs-windows": "nixpkgs-windows_223"
+        "nixpkgs-windows": "nixpkgs-windows_225"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15392,15 +17388,14 @@
     },
     "logos-nix_246": {
       "inputs": {
-        "nixpkgs": "nixpkgs_246",
-        "nixpkgs-windows": "nixpkgs-windows_224"
+        "nixpkgs": "nixpkgs_246"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -15411,8 +17406,26 @@
     },
     "logos-nix_247": {
       "inputs": {
-        "nixpkgs": "nixpkgs_247",
-        "nixpkgs-windows": "nixpkgs-windows_225"
+        "nixpkgs": "nixpkgs_247"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_248": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_248",
+        "nixpkgs-windows": "nixpkgs-windows_226"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15428,34 +17441,17 @@
         "type": "github"
       }
     },
-    "logos-nix_248": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_248"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_249": {
       "inputs": {
-        "nixpkgs": "nixpkgs_249"
+        "nixpkgs": "nixpkgs_249",
+        "nixpkgs-windows": "nixpkgs-windows_227"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -15486,7 +17482,7 @@
     "logos-nix_250": {
       "inputs": {
         "nixpkgs": "nixpkgs_250",
-        "nixpkgs-windows": "nixpkgs-windows_226"
+        "nixpkgs-windows": "nixpkgs-windows_228"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15504,15 +17500,14 @@
     },
     "logos-nix_251": {
       "inputs": {
-        "nixpkgs": "nixpkgs_251",
-        "nixpkgs-windows": "nixpkgs-windows_227"
+        "nixpkgs": "nixpkgs_251"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15523,15 +17518,14 @@
     },
     "logos-nix_252": {
       "inputs": {
-        "nixpkgs": "nixpkgs_252",
-        "nixpkgs-windows": "nixpkgs-windows_228"
+        "nixpkgs": "nixpkgs_252"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -15599,14 +17593,15 @@
     },
     "logos-nix_256": {
       "inputs": {
-        "nixpkgs": "nixpkgs_256"
+        "nixpkgs": "nixpkgs_256",
+        "nixpkgs-windows": "nixpkgs-windows_232"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -15617,14 +17612,15 @@
     },
     "logos-nix_257": {
       "inputs": {
-        "nixpkgs": "nixpkgs_257"
+        "nixpkgs": "nixpkgs_257",
+        "nixpkgs-windows": "nixpkgs-windows_233"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -15636,7 +17632,7 @@
     "logos-nix_258": {
       "inputs": {
         "nixpkgs": "nixpkgs_258",
-        "nixpkgs-windows": "nixpkgs-windows_232"
+        "nixpkgs-windows": "nixpkgs-windows_234"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15655,7 +17651,7 @@
     "logos-nix_259": {
       "inputs": {
         "nixpkgs": "nixpkgs_259",
-        "nixpkgs-windows": "nixpkgs-windows_233"
+        "nixpkgs-windows": "nixpkgs-windows_235"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15693,7 +17689,7 @@
     "logos-nix_260": {
       "inputs": {
         "nixpkgs": "nixpkgs_260",
-        "nixpkgs-windows": "nixpkgs-windows_234"
+        "nixpkgs-windows": "nixpkgs-windows_236"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15712,7 +17708,7 @@
     "logos-nix_261": {
       "inputs": {
         "nixpkgs": "nixpkgs_261",
-        "nixpkgs-windows": "nixpkgs-windows_235"
+        "nixpkgs-windows": "nixpkgs-windows_237"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15731,7 +17727,7 @@
     "logos-nix_262": {
       "inputs": {
         "nixpkgs": "nixpkgs_262",
-        "nixpkgs-windows": "nixpkgs-windows_236"
+        "nixpkgs-windows": "nixpkgs-windows_238"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15750,7 +17746,7 @@
     "logos-nix_263": {
       "inputs": {
         "nixpkgs": "nixpkgs_263",
-        "nixpkgs-windows": "nixpkgs-windows_237"
+        "nixpkgs-windows": "nixpkgs-windows_239"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15769,7 +17765,7 @@
     "logos-nix_264": {
       "inputs": {
         "nixpkgs": "nixpkgs_264",
-        "nixpkgs-windows": "nixpkgs-windows_238"
+        "nixpkgs-windows": "nixpkgs-windows_240"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15788,7 +17784,7 @@
     "logos-nix_265": {
       "inputs": {
         "nixpkgs": "nixpkgs_265",
-        "nixpkgs-windows": "nixpkgs-windows_239"
+        "nixpkgs-windows": "nixpkgs-windows_241"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15807,7 +17803,7 @@
     "logos-nix_266": {
       "inputs": {
         "nixpkgs": "nixpkgs_266",
-        "nixpkgs-windows": "nixpkgs-windows_240"
+        "nixpkgs-windows": "nixpkgs-windows_242"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15826,7 +17822,7 @@
     "logos-nix_267": {
       "inputs": {
         "nixpkgs": "nixpkgs_267",
-        "nixpkgs-windows": "nixpkgs-windows_241"
+        "nixpkgs-windows": "nixpkgs-windows_243"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15845,7 +17841,7 @@
     "logos-nix_268": {
       "inputs": {
         "nixpkgs": "nixpkgs_268",
-        "nixpkgs-windows": "nixpkgs-windows_242"
+        "nixpkgs-windows": "nixpkgs-windows_244"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15864,7 +17860,7 @@
     "logos-nix_269": {
       "inputs": {
         "nixpkgs": "nixpkgs_269",
-        "nixpkgs-windows": "nixpkgs-windows_243"
+        "nixpkgs-windows": "nixpkgs-windows_245"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15902,14 +17898,14 @@
     "logos-nix_270": {
       "inputs": {
         "nixpkgs": "nixpkgs_270",
-        "nixpkgs-windows": "nixpkgs-windows_244"
+        "nixpkgs-windows": "nixpkgs-windows_246"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -15921,7 +17917,7 @@
     "logos-nix_271": {
       "inputs": {
         "nixpkgs": "nixpkgs_271",
-        "nixpkgs-windows": "nixpkgs-windows_245"
+        "nixpkgs-windows": "nixpkgs-windows_247"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15940,7 +17936,7 @@
     "logos-nix_272": {
       "inputs": {
         "nixpkgs": "nixpkgs_272",
-        "nixpkgs-windows": "nixpkgs-windows_246"
+        "nixpkgs-windows": "nixpkgs-windows_248"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15959,7 +17955,7 @@
     "logos-nix_273": {
       "inputs": {
         "nixpkgs": "nixpkgs_273",
-        "nixpkgs-windows": "nixpkgs-windows_247"
+        "nixpkgs-windows": "nixpkgs-windows_249"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15978,7 +17974,7 @@
     "logos-nix_274": {
       "inputs": {
         "nixpkgs": "nixpkgs_274",
-        "nixpkgs-windows": "nixpkgs-windows_248"
+        "nixpkgs-windows": "nixpkgs-windows_250"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -15997,14 +17993,14 @@
     "logos-nix_275": {
       "inputs": {
         "nixpkgs": "nixpkgs_275",
-        "nixpkgs-windows": "nixpkgs-windows_249"
+        "nixpkgs-windows": "nixpkgs-windows_251"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16016,7 +18012,7 @@
     "logos-nix_276": {
       "inputs": {
         "nixpkgs": "nixpkgs_276",
-        "nixpkgs-windows": "nixpkgs-windows_250"
+        "nixpkgs-windows": "nixpkgs-windows_252"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16035,7 +18031,7 @@
     "logos-nix_277": {
       "inputs": {
         "nixpkgs": "nixpkgs_277",
-        "nixpkgs-windows": "nixpkgs-windows_251"
+        "nixpkgs-windows": "nixpkgs-windows_253"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16054,7 +18050,7 @@
     "logos-nix_278": {
       "inputs": {
         "nixpkgs": "nixpkgs_278",
-        "nixpkgs-windows": "nixpkgs-windows_252"
+        "nixpkgs-windows": "nixpkgs-windows_254"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16073,7 +18069,7 @@
     "logos-nix_279": {
       "inputs": {
         "nixpkgs": "nixpkgs_279",
-        "nixpkgs-windows": "nixpkgs-windows_253"
+        "nixpkgs-windows": "nixpkgs-windows_255"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16111,7 +18107,7 @@
     "logos-nix_280": {
       "inputs": {
         "nixpkgs": "nixpkgs_280",
-        "nixpkgs-windows": "nixpkgs-windows_254"
+        "nixpkgs-windows": "nixpkgs-windows_256"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16130,7 +18126,7 @@
     "logos-nix_281": {
       "inputs": {
         "nixpkgs": "nixpkgs_281",
-        "nixpkgs-windows": "nixpkgs-windows_255"
+        "nixpkgs-windows": "nixpkgs-windows_257"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16149,7 +18145,7 @@
     "logos-nix_282": {
       "inputs": {
         "nixpkgs": "nixpkgs_282",
-        "nixpkgs-windows": "nixpkgs-windows_256"
+        "nixpkgs-windows": "nixpkgs-windows_258"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16168,7 +18164,7 @@
     "logos-nix_283": {
       "inputs": {
         "nixpkgs": "nixpkgs_283",
-        "nixpkgs-windows": "nixpkgs-windows_257"
+        "nixpkgs-windows": "nixpkgs-windows_259"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16187,7 +18183,7 @@
     "logos-nix_284": {
       "inputs": {
         "nixpkgs": "nixpkgs_284",
-        "nixpkgs-windows": "nixpkgs-windows_258"
+        "nixpkgs-windows": "nixpkgs-windows_260"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16206,7 +18202,7 @@
     "logos-nix_285": {
       "inputs": {
         "nixpkgs": "nixpkgs_285",
-        "nixpkgs-windows": "nixpkgs-windows_259"
+        "nixpkgs-windows": "nixpkgs-windows_261"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16225,7 +18221,7 @@
     "logos-nix_286": {
       "inputs": {
         "nixpkgs": "nixpkgs_286",
-        "nixpkgs-windows": "nixpkgs-windows_260"
+        "nixpkgs-windows": "nixpkgs-windows_262"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16244,7 +18240,7 @@
     "logos-nix_287": {
       "inputs": {
         "nixpkgs": "nixpkgs_287",
-        "nixpkgs-windows": "nixpkgs-windows_261"
+        "nixpkgs-windows": "nixpkgs-windows_263"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16263,7 +18259,7 @@
     "logos-nix_288": {
       "inputs": {
         "nixpkgs": "nixpkgs_288",
-        "nixpkgs-windows": "nixpkgs-windows_262"
+        "nixpkgs-windows": "nixpkgs-windows_264"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16282,7 +18278,7 @@
     "logos-nix_289": {
       "inputs": {
         "nixpkgs": "nixpkgs_289",
-        "nixpkgs-windows": "nixpkgs-windows_263"
+        "nixpkgs-windows": "nixpkgs-windows_265"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16320,7 +18316,7 @@
     "logos-nix_290": {
       "inputs": {
         "nixpkgs": "nixpkgs_290",
-        "nixpkgs-windows": "nixpkgs-windows_264"
+        "nixpkgs-windows": "nixpkgs-windows_266"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16339,7 +18335,7 @@
     "logos-nix_291": {
       "inputs": {
         "nixpkgs": "nixpkgs_291",
-        "nixpkgs-windows": "nixpkgs-windows_265"
+        "nixpkgs-windows": "nixpkgs-windows_267"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16357,15 +18353,14 @@
     },
     "logos-nix_292": {
       "inputs": {
-        "nixpkgs": "nixpkgs_292",
-        "nixpkgs-windows": "nixpkgs-windows_266"
+        "nixpkgs": "nixpkgs_292"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16376,15 +18371,14 @@
     },
     "logos-nix_293": {
       "inputs": {
-        "nixpkgs": "nixpkgs_293",
-        "nixpkgs-windows": "nixpkgs-windows_267"
+        "nixpkgs": "nixpkgs_293"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16452,14 +18446,15 @@
     },
     "logos-nix_297": {
       "inputs": {
-        "nixpkgs": "nixpkgs_297"
+        "nixpkgs": "nixpkgs_297",
+        "nixpkgs-windows": "nixpkgs-windows_271"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16470,14 +18465,15 @@
     },
     "logos-nix_298": {
       "inputs": {
-        "nixpkgs": "nixpkgs_298"
+        "nixpkgs": "nixpkgs_298",
+        "nixpkgs-windows": "nixpkgs-windows_272"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16489,7 +18485,7 @@
     "logos-nix_299": {
       "inputs": {
         "nixpkgs": "nixpkgs_299",
-        "nixpkgs-windows": "nixpkgs-windows_271"
+        "nixpkgs-windows": "nixpkgs-windows_273"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16546,7 +18542,7 @@
     "logos-nix_300": {
       "inputs": {
         "nixpkgs": "nixpkgs_300",
-        "nixpkgs-windows": "nixpkgs-windows_272"
+        "nixpkgs-windows": "nixpkgs-windows_274"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16565,7 +18561,7 @@
     "logos-nix_301": {
       "inputs": {
         "nixpkgs": "nixpkgs_301",
-        "nixpkgs-windows": "nixpkgs-windows_273"
+        "nixpkgs-windows": "nixpkgs-windows_275"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16584,7 +18580,7 @@
     "logos-nix_302": {
       "inputs": {
         "nixpkgs": "nixpkgs_302",
-        "nixpkgs-windows": "nixpkgs-windows_274"
+        "nixpkgs-windows": "nixpkgs-windows_276"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16603,7 +18599,7 @@
     "logos-nix_303": {
       "inputs": {
         "nixpkgs": "nixpkgs_303",
-        "nixpkgs-windows": "nixpkgs-windows_275"
+        "nixpkgs-windows": "nixpkgs-windows_277"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16622,7 +18618,7 @@
     "logos-nix_304": {
       "inputs": {
         "nixpkgs": "nixpkgs_304",
-        "nixpkgs-windows": "nixpkgs-windows_276"
+        "nixpkgs-windows": "nixpkgs-windows_278"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16640,15 +18636,14 @@
     },
     "logos-nix_305": {
       "inputs": {
-        "nixpkgs": "nixpkgs_305",
-        "nixpkgs-windows": "nixpkgs-windows_277"
+        "nixpkgs": "nixpkgs_305"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16659,15 +18654,14 @@
     },
     "logos-nix_306": {
       "inputs": {
-        "nixpkgs": "nixpkgs_306",
-        "nixpkgs-windows": "nixpkgs-windows_278"
+        "nixpkgs": "nixpkgs_306"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16754,43 +18748,7 @@
     },
     "logos-nix_310": {
       "inputs": {
-        "nixpkgs": "nixpkgs_310"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_311": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_311"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_312": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_312",
+        "nixpkgs": "nixpkgs_310",
         "nixpkgs-windows": "nixpkgs-windows_282"
       },
       "locked": {
@@ -16807,10 +18765,48 @@
         "type": "github"
       }
     },
+    "logos-nix_311": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_311",
+        "nixpkgs-windows": "nixpkgs-windows_283"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_312": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_312",
+        "nixpkgs-windows": "nixpkgs-windows_284"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_313": {
       "inputs": {
         "nixpkgs": "nixpkgs_313",
-        "nixpkgs-windows": "nixpkgs-windows_283"
+        "nixpkgs-windows": "nixpkgs-windows_285"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16828,15 +18824,14 @@
     },
     "logos-nix_314": {
       "inputs": {
-        "nixpkgs": "nixpkgs_314",
-        "nixpkgs-windows": "nixpkgs-windows_284"
+        "nixpkgs": "nixpkgs_314"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -16848,7 +18843,7 @@
     "logos-nix_315": {
       "inputs": {
         "nixpkgs": "nixpkgs_315",
-        "nixpkgs-windows": "nixpkgs-windows_285"
+        "nixpkgs-windows": "nixpkgs-windows_286"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16867,7 +18862,7 @@
     "logos-nix_316": {
       "inputs": {
         "nixpkgs": "nixpkgs_316",
-        "nixpkgs-windows": "nixpkgs-windows_286"
+        "nixpkgs-windows": "nixpkgs-windows_287"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16886,14 +18881,14 @@
     "logos-nix_317": {
       "inputs": {
         "nixpkgs": "nixpkgs_317",
-        "nixpkgs-windows": "nixpkgs-windows_287"
+        "nixpkgs-windows": "nixpkgs-windows_288"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16905,7 +18900,7 @@
     "logos-nix_318": {
       "inputs": {
         "nixpkgs": "nixpkgs_318",
-        "nixpkgs-windows": "nixpkgs-windows_288"
+        "nixpkgs-windows": "nixpkgs-windows_289"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16923,14 +18918,15 @@
     },
     "logos-nix_319": {
       "inputs": {
-        "nixpkgs": "nixpkgs_319"
+        "nixpkgs": "nixpkgs_319",
+        "nixpkgs-windows": "nixpkgs-windows_290"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -16961,7 +18957,7 @@
     "logos-nix_320": {
       "inputs": {
         "nixpkgs": "nixpkgs_320",
-        "nixpkgs-windows": "nixpkgs-windows_289"
+        "nixpkgs-windows": "nixpkgs-windows_291"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16980,7 +18976,7 @@
     "logos-nix_321": {
       "inputs": {
         "nixpkgs": "nixpkgs_321",
-        "nixpkgs-windows": "nixpkgs-windows_290"
+        "nixpkgs-windows": "nixpkgs-windows_292"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -16999,7 +18995,7 @@
     "logos-nix_322": {
       "inputs": {
         "nixpkgs": "nixpkgs_322",
-        "nixpkgs-windows": "nixpkgs-windows_291"
+        "nixpkgs-windows": "nixpkgs-windows_293"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17018,7 +19014,7 @@
     "logos-nix_323": {
       "inputs": {
         "nixpkgs": "nixpkgs_323",
-        "nixpkgs-windows": "nixpkgs-windows_292"
+        "nixpkgs-windows": "nixpkgs-windows_294"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17037,7 +19033,7 @@
     "logos-nix_324": {
       "inputs": {
         "nixpkgs": "nixpkgs_324",
-        "nixpkgs-windows": "nixpkgs-windows_293"
+        "nixpkgs-windows": "nixpkgs-windows_295"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17055,15 +19051,14 @@
     },
     "logos-nix_325": {
       "inputs": {
-        "nixpkgs": "nixpkgs_325",
-        "nixpkgs-windows": "nixpkgs-windows_294"
+        "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17074,15 +19069,14 @@
     },
     "logos-nix_326": {
       "inputs": {
-        "nixpkgs": "nixpkgs_326",
-        "nixpkgs-windows": "nixpkgs-windows_295"
+        "nixpkgs": "nixpkgs_326"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17169,14 +19163,15 @@
     },
     "logos-nix_330": {
       "inputs": {
-        "nixpkgs": "nixpkgs_330"
+        "nixpkgs": "nixpkgs_330",
+        "nixpkgs-windows": "nixpkgs-windows_299"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17187,14 +19182,15 @@
     },
     "logos-nix_331": {
       "inputs": {
-        "nixpkgs": "nixpkgs_331"
+        "nixpkgs": "nixpkgs_331",
+        "nixpkgs-windows": "nixpkgs-windows_300"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -17206,7 +19202,7 @@
     "logos-nix_332": {
       "inputs": {
         "nixpkgs": "nixpkgs_332",
-        "nixpkgs-windows": "nixpkgs-windows_299"
+        "nixpkgs-windows": "nixpkgs-windows_301"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -17224,15 +19220,14 @@
     },
     "logos-nix_333": {
       "inputs": {
-        "nixpkgs": "nixpkgs_333",
-        "nixpkgs-windows": "nixpkgs-windows_300"
+        "nixpkgs": "nixpkgs_333"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17243,15 +19238,14 @@
     },
     "logos-nix_334": {
       "inputs": {
-        "nixpkgs": "nixpkgs_334",
-        "nixpkgs-windows": "nixpkgs-windows_301"
+        "nixpkgs": "nixpkgs_334"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -17627,11 +19621,11 @@
         "nixpkgs-windows": "nixpkgs-windows_319"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -17646,11 +19640,11 @@
         "nixpkgs-windows": "nixpkgs-windows_320"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18079,15 +20073,14 @@
     },
     "logos-nix_374": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374",
-        "nixpkgs-windows": "nixpkgs-windows_341"
+        "nixpkgs": "nixpkgs_374"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18116,14 +20109,15 @@
     },
     "logos-nix_376": {
       "inputs": {
-        "nixpkgs": "nixpkgs_376"
+        "nixpkgs": "nixpkgs_376",
+        "nixpkgs-windows": "nixpkgs-windows_341"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18343,15 +20337,14 @@
     },
     "logos-nix_387": {
       "inputs": {
-        "nixpkgs": "nixpkgs_387",
-        "nixpkgs-windows": "nixpkgs-windows_352"
+        "nixpkgs": "nixpkgs_387"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18380,14 +20373,15 @@
     },
     "logos-nix_389": {
       "inputs": {
-        "nixpkgs": "nixpkgs_389"
+        "nixpkgs": "nixpkgs_389",
+        "nixpkgs-windows": "nixpkgs-windows_352"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18497,11 +20491,11 @@
         "nixpkgs-windows": "nixpkgs-windows_357"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -18516,25 +20510,6 @@
         "nixpkgs-windows": "nixpkgs-windows_358"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_396": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_396",
-        "nixpkgs-windows": "nixpkgs-windows_359"
-      },
-      "locked": {
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
@@ -18548,9 +20523,9 @@
         "type": "github"
       }
     },
-    "logos-nix_397": {
+    "logos-nix_396": {
       "inputs": {
-        "nixpkgs": "nixpkgs_397"
+        "nixpkgs": "nixpkgs_396"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -18558,6 +20533,25 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_397": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_397",
+        "nixpkgs-windows": "nixpkgs-windows_359"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18777,15 +20771,14 @@
     },
     "logos-nix_407": {
       "inputs": {
-        "nixpkgs": "nixpkgs_407",
-        "nixpkgs-windows": "nixpkgs-windows_369"
+        "nixpkgs": "nixpkgs_407"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -18814,14 +20807,15 @@
     },
     "logos-nix_409": {
       "inputs": {
-        "nixpkgs": "nixpkgs_409"
+        "nixpkgs": "nixpkgs_409",
+        "nixpkgs-windows": "nixpkgs-windows_369"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18965,14 +20959,15 @@
     },
     "logos-nix_416": {
       "inputs": {
-        "nixpkgs": "nixpkgs_416"
+        "nixpkgs": "nixpkgs_416",
+        "nixpkgs-windows": "nixpkgs-windows_376"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -18983,14 +20978,15 @@
     },
     "logos-nix_417": {
       "inputs": {
-        "nixpkgs": "nixpkgs_417"
+        "nixpkgs": "nixpkgs_417",
+        "nixpkgs-windows": "nixpkgs-windows_377"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19002,7 +20998,7 @@
     "logos-nix_418": {
       "inputs": {
         "nixpkgs": "nixpkgs_418",
-        "nixpkgs-windows": "nixpkgs-windows_376"
+        "nixpkgs-windows": "nixpkgs-windows_378"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19021,7 +21017,7 @@
     "logos-nix_419": {
       "inputs": {
         "nixpkgs": "nixpkgs_419",
-        "nixpkgs-windows": "nixpkgs-windows_377"
+        "nixpkgs-windows": "nixpkgs-windows_379"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19059,7 +21055,7 @@
     "logos-nix_420": {
       "inputs": {
         "nixpkgs": "nixpkgs_420",
-        "nixpkgs-windows": "nixpkgs-windows_378"
+        "nixpkgs-windows": "nixpkgs-windows_380"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19078,7 +21074,7 @@
     "logos-nix_421": {
       "inputs": {
         "nixpkgs": "nixpkgs_421",
-        "nixpkgs-windows": "nixpkgs-windows_379"
+        "nixpkgs-windows": "nixpkgs-windows_381"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19097,7 +21093,7 @@
     "logos-nix_422": {
       "inputs": {
         "nixpkgs": "nixpkgs_422",
-        "nixpkgs-windows": "nixpkgs-windows_380"
+        "nixpkgs-windows": "nixpkgs-windows_382"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19116,7 +21112,7 @@
     "logos-nix_423": {
       "inputs": {
         "nixpkgs": "nixpkgs_423",
-        "nixpkgs-windows": "nixpkgs-windows_381"
+        "nixpkgs-windows": "nixpkgs-windows_383"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19135,7 +21131,7 @@
     "logos-nix_424": {
       "inputs": {
         "nixpkgs": "nixpkgs_424",
-        "nixpkgs-windows": "nixpkgs-windows_382"
+        "nixpkgs-windows": "nixpkgs-windows_384"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19154,7 +21150,7 @@
     "logos-nix_425": {
       "inputs": {
         "nixpkgs": "nixpkgs_425",
-        "nixpkgs-windows": "nixpkgs-windows_383"
+        "nixpkgs-windows": "nixpkgs-windows_385"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19173,7 +21169,7 @@
     "logos-nix_426": {
       "inputs": {
         "nixpkgs": "nixpkgs_426",
-        "nixpkgs-windows": "nixpkgs-windows_384"
+        "nixpkgs-windows": "nixpkgs-windows_386"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19192,7 +21188,7 @@
     "logos-nix_427": {
       "inputs": {
         "nixpkgs": "nixpkgs_427",
-        "nixpkgs-windows": "nixpkgs-windows_385"
+        "nixpkgs-windows": "nixpkgs-windows_387"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19211,7 +21207,7 @@
     "logos-nix_428": {
       "inputs": {
         "nixpkgs": "nixpkgs_428",
-        "nixpkgs-windows": "nixpkgs-windows_386"
+        "nixpkgs-windows": "nixpkgs-windows_388"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19230,7 +21226,7 @@
     "logos-nix_429": {
       "inputs": {
         "nixpkgs": "nixpkgs_429",
-        "nixpkgs-windows": "nixpkgs-windows_387"
+        "nixpkgs-windows": "nixpkgs-windows_389"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19268,14 +21264,14 @@
     "logos-nix_430": {
       "inputs": {
         "nixpkgs": "nixpkgs_430",
-        "nixpkgs-windows": "nixpkgs-windows_388"
+        "nixpkgs-windows": "nixpkgs-windows_390"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -19287,7 +21283,7 @@
     "logos-nix_431": {
       "inputs": {
         "nixpkgs": "nixpkgs_431",
-        "nixpkgs-windows": "nixpkgs-windows_389"
+        "nixpkgs-windows": "nixpkgs-windows_391"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19306,7 +21302,7 @@
     "logos-nix_432": {
       "inputs": {
         "nixpkgs": "nixpkgs_432",
-        "nixpkgs-windows": "nixpkgs-windows_390"
+        "nixpkgs-windows": "nixpkgs-windows_392"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19325,7 +21321,7 @@
     "logos-nix_433": {
       "inputs": {
         "nixpkgs": "nixpkgs_433",
-        "nixpkgs-windows": "nixpkgs-windows_391"
+        "nixpkgs-windows": "nixpkgs-windows_393"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19344,7 +21340,7 @@
     "logos-nix_434": {
       "inputs": {
         "nixpkgs": "nixpkgs_434",
-        "nixpkgs-windows": "nixpkgs-windows_392"
+        "nixpkgs-windows": "nixpkgs-windows_394"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19363,14 +21359,14 @@
     "logos-nix_435": {
       "inputs": {
         "nixpkgs": "nixpkgs_435",
-        "nixpkgs-windows": "nixpkgs-windows_393"
+        "nixpkgs-windows": "nixpkgs-windows_395"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19382,7 +21378,7 @@
     "logos-nix_436": {
       "inputs": {
         "nixpkgs": "nixpkgs_436",
-        "nixpkgs-windows": "nixpkgs-windows_394"
+        "nixpkgs-windows": "nixpkgs-windows_396"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19401,7 +21397,7 @@
     "logos-nix_437": {
       "inputs": {
         "nixpkgs": "nixpkgs_437",
-        "nixpkgs-windows": "nixpkgs-windows_395"
+        "nixpkgs-windows": "nixpkgs-windows_397"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19420,7 +21416,7 @@
     "logos-nix_438": {
       "inputs": {
         "nixpkgs": "nixpkgs_438",
-        "nixpkgs-windows": "nixpkgs-windows_396"
+        "nixpkgs-windows": "nixpkgs-windows_398"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19439,7 +21435,7 @@
     "logos-nix_439": {
       "inputs": {
         "nixpkgs": "nixpkgs_439",
-        "nixpkgs-windows": "nixpkgs-windows_397"
+        "nixpkgs-windows": "nixpkgs-windows_399"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19477,7 +21473,7 @@
     "logos-nix_440": {
       "inputs": {
         "nixpkgs": "nixpkgs_440",
-        "nixpkgs-windows": "nixpkgs-windows_398"
+        "nixpkgs-windows": "nixpkgs-windows_400"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19496,7 +21492,7 @@
     "logos-nix_441": {
       "inputs": {
         "nixpkgs": "nixpkgs_441",
-        "nixpkgs-windows": "nixpkgs-windows_399"
+        "nixpkgs-windows": "nixpkgs-windows_401"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19515,7 +21511,7 @@
     "logos-nix_442": {
       "inputs": {
         "nixpkgs": "nixpkgs_442",
-        "nixpkgs-windows": "nixpkgs-windows_400"
+        "nixpkgs-windows": "nixpkgs-windows_402"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19534,7 +21530,7 @@
     "logos-nix_443": {
       "inputs": {
         "nixpkgs": "nixpkgs_443",
-        "nixpkgs-windows": "nixpkgs-windows_401"
+        "nixpkgs-windows": "nixpkgs-windows_403"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19553,7 +21549,7 @@
     "logos-nix_444": {
       "inputs": {
         "nixpkgs": "nixpkgs_444",
-        "nixpkgs-windows": "nixpkgs-windows_402"
+        "nixpkgs-windows": "nixpkgs-windows_404"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19572,7 +21568,7 @@
     "logos-nix_445": {
       "inputs": {
         "nixpkgs": "nixpkgs_445",
-        "nixpkgs-windows": "nixpkgs-windows_403"
+        "nixpkgs-windows": "nixpkgs-windows_405"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19591,7 +21587,7 @@
     "logos-nix_446": {
       "inputs": {
         "nixpkgs": "nixpkgs_446",
-        "nixpkgs-windows": "nixpkgs-windows_404"
+        "nixpkgs-windows": "nixpkgs-windows_406"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19610,7 +21606,7 @@
     "logos-nix_447": {
       "inputs": {
         "nixpkgs": "nixpkgs_447",
-        "nixpkgs-windows": "nixpkgs-windows_405"
+        "nixpkgs-windows": "nixpkgs-windows_407"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19629,7 +21625,7 @@
     "logos-nix_448": {
       "inputs": {
         "nixpkgs": "nixpkgs_448",
-        "nixpkgs-windows": "nixpkgs-windows_406"
+        "nixpkgs-windows": "nixpkgs-windows_408"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19648,7 +21644,7 @@
     "logos-nix_449": {
       "inputs": {
         "nixpkgs": "nixpkgs_449",
-        "nixpkgs-windows": "nixpkgs-windows_407"
+        "nixpkgs-windows": "nixpkgs-windows_409"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19686,7 +21682,7 @@
     "logos-nix_450": {
       "inputs": {
         "nixpkgs": "nixpkgs_450",
-        "nixpkgs-windows": "nixpkgs-windows_408"
+        "nixpkgs-windows": "nixpkgs-windows_410"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19705,7 +21701,7 @@
     "logos-nix_451": {
       "inputs": {
         "nixpkgs": "nixpkgs_451",
-        "nixpkgs-windows": "nixpkgs-windows_409"
+        "nixpkgs-windows": "nixpkgs-windows_411"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19723,15 +21719,14 @@
     },
     "logos-nix_452": {
       "inputs": {
-        "nixpkgs": "nixpkgs_452",
-        "nixpkgs-windows": "nixpkgs-windows_410"
+        "nixpkgs": "nixpkgs_452"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19742,15 +21737,14 @@
     },
     "logos-nix_453": {
       "inputs": {
-        "nixpkgs": "nixpkgs_453",
-        "nixpkgs-windows": "nixpkgs-windows_411"
+        "nixpkgs": "nixpkgs_453"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19818,14 +21812,15 @@
     },
     "logos-nix_457": {
       "inputs": {
-        "nixpkgs": "nixpkgs_457"
+        "nixpkgs": "nixpkgs_457",
+        "nixpkgs-windows": "nixpkgs-windows_415"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19836,14 +21831,15 @@
     },
     "logos-nix_458": {
       "inputs": {
-        "nixpkgs": "nixpkgs_458"
+        "nixpkgs": "nixpkgs_458",
+        "nixpkgs-windows": "nixpkgs-windows_416"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19855,7 +21851,7 @@
     "logos-nix_459": {
       "inputs": {
         "nixpkgs": "nixpkgs_459",
-        "nixpkgs-windows": "nixpkgs-windows_415"
+        "nixpkgs-windows": "nixpkgs-windows_417"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19893,7 +21889,7 @@
     "logos-nix_460": {
       "inputs": {
         "nixpkgs": "nixpkgs_460",
-        "nixpkgs-windows": "nixpkgs-windows_416"
+        "nixpkgs-windows": "nixpkgs-windows_418"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19912,7 +21908,7 @@
     "logos-nix_461": {
       "inputs": {
         "nixpkgs": "nixpkgs_461",
-        "nixpkgs-windows": "nixpkgs-windows_417"
+        "nixpkgs-windows": "nixpkgs-windows_419"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19931,7 +21927,7 @@
     "logos-nix_462": {
       "inputs": {
         "nixpkgs": "nixpkgs_462",
-        "nixpkgs-windows": "nixpkgs-windows_418"
+        "nixpkgs-windows": "nixpkgs-windows_420"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19950,7 +21946,7 @@
     "logos-nix_463": {
       "inputs": {
         "nixpkgs": "nixpkgs_463",
-        "nixpkgs-windows": "nixpkgs-windows_419"
+        "nixpkgs-windows": "nixpkgs-windows_421"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19969,7 +21965,7 @@
     "logos-nix_464": {
       "inputs": {
         "nixpkgs": "nixpkgs_464",
-        "nixpkgs-windows": "nixpkgs-windows_420"
+        "nixpkgs-windows": "nixpkgs-windows_422"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19987,15 +21983,14 @@
     },
     "logos-nix_465": {
       "inputs": {
-        "nixpkgs": "nixpkgs_465",
-        "nixpkgs-windows": "nixpkgs-windows_421"
+        "nixpkgs": "nixpkgs_465"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20006,15 +22001,14 @@
     },
     "logos-nix_466": {
       "inputs": {
-        "nixpkgs": "nixpkgs_466",
-        "nixpkgs-windows": "nixpkgs-windows_422"
+        "nixpkgs": "nixpkgs_466"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20101,43 +22095,7 @@
     },
     "logos-nix_470": {
       "inputs": {
-        "nixpkgs": "nixpkgs_470"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_471": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_471"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_472": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_472",
+        "nixpkgs": "nixpkgs_470",
         "nixpkgs-windows": "nixpkgs-windows_426"
       },
       "locked": {
@@ -20154,10 +22112,48 @@
         "type": "github"
       }
     },
+    "logos-nix_471": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_471",
+        "nixpkgs-windows": "nixpkgs-windows_427"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_472": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_472",
+        "nixpkgs-windows": "nixpkgs-windows_428"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_473": {
       "inputs": {
         "nixpkgs": "nixpkgs_473",
-        "nixpkgs-windows": "nixpkgs-windows_427"
+        "nixpkgs-windows": "nixpkgs-windows_429"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20175,15 +22171,14 @@
     },
     "logos-nix_474": {
       "inputs": {
-        "nixpkgs": "nixpkgs_474",
-        "nixpkgs-windows": "nixpkgs-windows_428"
+        "nixpkgs": "nixpkgs_474"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20195,7 +22190,7 @@
     "logos-nix_475": {
       "inputs": {
         "nixpkgs": "nixpkgs_475",
-        "nixpkgs-windows": "nixpkgs-windows_429"
+        "nixpkgs-windows": "nixpkgs-windows_430"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20214,7 +22209,7 @@
     "logos-nix_476": {
       "inputs": {
         "nixpkgs": "nixpkgs_476",
-        "nixpkgs-windows": "nixpkgs-windows_430"
+        "nixpkgs-windows": "nixpkgs-windows_431"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20233,14 +22228,14 @@
     "logos-nix_477": {
       "inputs": {
         "nixpkgs": "nixpkgs_477",
-        "nixpkgs-windows": "nixpkgs-windows_431"
+        "nixpkgs-windows": "nixpkgs-windows_432"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20252,7 +22247,7 @@
     "logos-nix_478": {
       "inputs": {
         "nixpkgs": "nixpkgs_478",
-        "nixpkgs-windows": "nixpkgs-windows_432"
+        "nixpkgs-windows": "nixpkgs-windows_433"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20270,14 +22265,15 @@
     },
     "logos-nix_479": {
       "inputs": {
-        "nixpkgs": "nixpkgs_479"
+        "nixpkgs": "nixpkgs_479",
+        "nixpkgs-windows": "nixpkgs-windows_434"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20308,7 +22304,7 @@
     "logos-nix_480": {
       "inputs": {
         "nixpkgs": "nixpkgs_480",
-        "nixpkgs-windows": "nixpkgs-windows_433"
+        "nixpkgs-windows": "nixpkgs-windows_435"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20327,7 +22323,7 @@
     "logos-nix_481": {
       "inputs": {
         "nixpkgs": "nixpkgs_481",
-        "nixpkgs-windows": "nixpkgs-windows_434"
+        "nixpkgs-windows": "nixpkgs-windows_436"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20346,7 +22342,7 @@
     "logos-nix_482": {
       "inputs": {
         "nixpkgs": "nixpkgs_482",
-        "nixpkgs-windows": "nixpkgs-windows_435"
+        "nixpkgs-windows": "nixpkgs-windows_437"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20365,7 +22361,7 @@
     "logos-nix_483": {
       "inputs": {
         "nixpkgs": "nixpkgs_483",
-        "nixpkgs-windows": "nixpkgs-windows_436"
+        "nixpkgs-windows": "nixpkgs-windows_438"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20384,7 +22380,7 @@
     "logos-nix_484": {
       "inputs": {
         "nixpkgs": "nixpkgs_484",
-        "nixpkgs-windows": "nixpkgs-windows_437"
+        "nixpkgs-windows": "nixpkgs-windows_439"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20402,15 +22398,14 @@
     },
     "logos-nix_485": {
       "inputs": {
-        "nixpkgs": "nixpkgs_485",
-        "nixpkgs-windows": "nixpkgs-windows_438"
+        "nixpkgs": "nixpkgs_485"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20421,15 +22416,14 @@
     },
     "logos-nix_486": {
       "inputs": {
-        "nixpkgs": "nixpkgs_486",
-        "nixpkgs-windows": "nixpkgs-windows_439"
+        "nixpkgs": "nixpkgs_486"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20516,14 +22510,15 @@
     },
     "logos-nix_490": {
       "inputs": {
-        "nixpkgs": "nixpkgs_490"
+        "nixpkgs": "nixpkgs_490",
+        "nixpkgs-windows": "nixpkgs-windows_443"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20534,14 +22529,15 @@
     },
     "logos-nix_491": {
       "inputs": {
-        "nixpkgs": "nixpkgs_491"
+        "nixpkgs": "nixpkgs_491",
+        "nixpkgs-windows": "nixpkgs-windows_444"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20553,7 +22549,7 @@
     "logos-nix_492": {
       "inputs": {
         "nixpkgs": "nixpkgs_492",
-        "nixpkgs-windows": "nixpkgs-windows_443"
+        "nixpkgs-windows": "nixpkgs-windows_445"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20571,15 +22567,14 @@
     },
     "logos-nix_493": {
       "inputs": {
-        "nixpkgs": "nixpkgs_493",
-        "nixpkgs-windows": "nixpkgs-windows_444"
+        "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -20590,15 +22585,14 @@
     },
     "logos-nix_494": {
       "inputs": {
-        "nixpkgs": "nixpkgs_494",
-        "nixpkgs-windows": "nixpkgs-windows_445"
+        "nixpkgs": "nixpkgs_494"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20666,14 +22660,15 @@
     },
     "logos-nix_498": {
       "inputs": {
-        "nixpkgs": "nixpkgs_498"
+        "nixpkgs": "nixpkgs_498",
+        "nixpkgs-windows": "nixpkgs-windows_449"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20684,14 +22679,15 @@
     },
     "logos-nix_499": {
       "inputs": {
-        "nixpkgs": "nixpkgs_499"
+        "nixpkgs": "nixpkgs_499",
+        "nixpkgs-windows": "nixpkgs-windows_450"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20741,7 +22737,7 @@
     "logos-nix_500": {
       "inputs": {
         "nixpkgs": "nixpkgs_500",
-        "nixpkgs-windows": "nixpkgs-windows_449"
+        "nixpkgs-windows": "nixpkgs-windows_451"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20760,7 +22756,7 @@
     "logos-nix_501": {
       "inputs": {
         "nixpkgs": "nixpkgs_501",
-        "nixpkgs-windows": "nixpkgs-windows_450"
+        "nixpkgs-windows": "nixpkgs-windows_452"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20779,7 +22775,7 @@
     "logos-nix_502": {
       "inputs": {
         "nixpkgs": "nixpkgs_502",
-        "nixpkgs-windows": "nixpkgs-windows_451"
+        "nixpkgs-windows": "nixpkgs-windows_453"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20798,7 +22794,7 @@
     "logos-nix_503": {
       "inputs": {
         "nixpkgs": "nixpkgs_503",
-        "nixpkgs-windows": "nixpkgs-windows_452"
+        "nixpkgs-windows": "nixpkgs-windows_454"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20816,14 +22812,15 @@
     },
     "logos-nix_504": {
       "inputs": {
-        "nixpkgs": "nixpkgs_504"
+        "nixpkgs": "nixpkgs_504",
+        "nixpkgs-windows": "nixpkgs-windows_455"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20835,7 +22832,7 @@
     "logos-nix_505": {
       "inputs": {
         "nixpkgs": "nixpkgs_505",
-        "nixpkgs-windows": "nixpkgs-windows_453"
+        "nixpkgs-windows": "nixpkgs-windows_456"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20854,7 +22851,7 @@
     "logos-nix_506": {
       "inputs": {
         "nixpkgs": "nixpkgs_506",
-        "nixpkgs-windows": "nixpkgs-windows_454"
+        "nixpkgs-windows": "nixpkgs-windows_457"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20873,7 +22870,7 @@
     "logos-nix_507": {
       "inputs": {
         "nixpkgs": "nixpkgs_507",
-        "nixpkgs-windows": "nixpkgs-windows_455"
+        "nixpkgs-windows": "nixpkgs-windows_458"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20892,7 +22889,7 @@
     "logos-nix_508": {
       "inputs": {
         "nixpkgs": "nixpkgs_508",
-        "nixpkgs-windows": "nixpkgs-windows_456"
+        "nixpkgs-windows": "nixpkgs-windows_459"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20910,14 +22907,15 @@
     },
     "logos-nix_509": {
       "inputs": {
-        "nixpkgs": "nixpkgs_509"
+        "nixpkgs": "nixpkgs_509",
+        "nixpkgs-windows": "nixpkgs-windows_460"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20947,14 +22945,15 @@
     },
     "logos-nix_510": {
       "inputs": {
-        "nixpkgs": "nixpkgs_510"
+        "nixpkgs": "nixpkgs_510",
+        "nixpkgs-windows": "nixpkgs-windows_461"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20966,7 +22965,7 @@
     "logos-nix_511": {
       "inputs": {
         "nixpkgs": "nixpkgs_511",
-        "nixpkgs-windows": "nixpkgs-windows_457"
+        "nixpkgs-windows": "nixpkgs-windows_462"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20985,14 +22984,14 @@
     "logos-nix_512": {
       "inputs": {
         "nixpkgs": "nixpkgs_512",
-        "nixpkgs-windows": "nixpkgs-windows_458"
+        "nixpkgs-windows": "nixpkgs-windows_463"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21004,7 +23003,7 @@
     "logos-nix_513": {
       "inputs": {
         "nixpkgs": "nixpkgs_513",
-        "nixpkgs-windows": "nixpkgs-windows_459"
+        "nixpkgs-windows": "nixpkgs-windows_464"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21023,7 +23022,7 @@
     "logos-nix_514": {
       "inputs": {
         "nixpkgs": "nixpkgs_514",
-        "nixpkgs-windows": "nixpkgs-windows_460"
+        "nixpkgs-windows": "nixpkgs-windows_465"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21041,14 +23040,15 @@
     },
     "logos-nix_515": {
       "inputs": {
-        "nixpkgs": "nixpkgs_515"
+        "nixpkgs": "nixpkgs_515",
+        "nixpkgs-windows": "nixpkgs-windows_466"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21059,14 +23059,15 @@
     },
     "logos-nix_516": {
       "inputs": {
-        "nixpkgs": "nixpkgs_516"
+        "nixpkgs": "nixpkgs_516",
+        "nixpkgs-windows": "nixpkgs-windows_467"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21078,7 +23079,7 @@
     "logos-nix_517": {
       "inputs": {
         "nixpkgs": "nixpkgs_517",
-        "nixpkgs-windows": "nixpkgs-windows_461"
+        "nixpkgs-windows": "nixpkgs-windows_468"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21097,7 +23098,7 @@
     "logos-nix_518": {
       "inputs": {
         "nixpkgs": "nixpkgs_518",
-        "nixpkgs-windows": "nixpkgs-windows_462"
+        "nixpkgs-windows": "nixpkgs-windows_469"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21116,7 +23117,7 @@
     "logos-nix_519": {
       "inputs": {
         "nixpkgs": "nixpkgs_519",
-        "nixpkgs-windows": "nixpkgs-windows_463"
+        "nixpkgs-windows": "nixpkgs-windows_470"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21153,7 +23154,7 @@
     "logos-nix_520": {
       "inputs": {
         "nixpkgs": "nixpkgs_520",
-        "nixpkgs-windows": "nixpkgs-windows_464"
+        "nixpkgs-windows": "nixpkgs-windows_471"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21171,14 +23172,167 @@
     },
     "logos-nix_521": {
       "inputs": {
-        "nixpkgs": "nixpkgs_521"
+        "nixpkgs": "nixpkgs_521",
+        "nixpkgs-windows": "nixpkgs-windows_472"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_522": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_522",
+        "nixpkgs-windows": "nixpkgs-windows_473"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_523": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_523",
+        "nixpkgs-windows": "nixpkgs-windows_474"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_524": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_524",
+        "nixpkgs-windows": "nixpkgs-windows_475"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_525": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_525",
+        "nixpkgs-windows": "nixpkgs-windows_476"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_526": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_526",
+        "nixpkgs-windows": "nixpkgs-windows_477"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_527": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_527",
+        "nixpkgs-windows": "nixpkgs-windows_478"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_528": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_528",
+        "nixpkgs-windows": "nixpkgs-windows_479"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_529": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_529",
+        "nixpkgs-windows": "nixpkgs-windows_480"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21205,10 +23359,386 @@
         "type": "github"
       }
     },
+    "logos-nix_530": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_530",
+        "nixpkgs-windows": "nixpkgs-windows_481"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_531": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_531",
+        "nixpkgs-windows": "nixpkgs-windows_482"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_532": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_532",
+        "nixpkgs-windows": "nixpkgs-windows_483"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_533": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_533",
+        "nixpkgs-windows": "nixpkgs-windows_484"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_534": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_534"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_535": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_535"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_536": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_536",
+        "nixpkgs-windows": "nixpkgs-windows_485"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_537": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_537",
+        "nixpkgs-windows": "nixpkgs-windows_486"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_538": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_538",
+        "nixpkgs-windows": "nixpkgs-windows_487"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_539": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_539",
+        "nixpkgs-windows": "nixpkgs-windows_488"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_54": {
       "inputs": {
         "nixpkgs": "nixpkgs_54",
         "nixpkgs-windows": "nixpkgs-windows_50"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_540": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_540",
+        "nixpkgs-windows": "nixpkgs-windows_489"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_541": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_541",
+        "nixpkgs-windows": "nixpkgs-windows_490"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_542": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_542",
+        "nixpkgs-windows": "nixpkgs-windows_491"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_543": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_543",
+        "nixpkgs-windows": "nixpkgs-windows_492"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_544": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_544",
+        "nixpkgs-windows": "nixpkgs-windows_493"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_545": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_545",
+        "nixpkgs-windows": "nixpkgs-windows_494"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_546": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_546",
+        "nixpkgs-windows": "nixpkgs-windows_495"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_547": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_547"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_548": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_548"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_549": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_549",
+        "nixpkgs-windows": "nixpkgs-windows_496"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21243,10 +23773,387 @@
         "type": "github"
       }
     },
+    "logos-nix_550": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_550",
+        "nixpkgs-windows": "nixpkgs-windows_497"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_551": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_551",
+        "nixpkgs-windows": "nixpkgs-windows_498"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_552": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_552",
+        "nixpkgs-windows": "nixpkgs-windows_499"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_553": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_553",
+        "nixpkgs-windows": "nixpkgs-windows_500"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_554": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_554",
+        "nixpkgs-windows": "nixpkgs-windows_501"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_555": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_555",
+        "nixpkgs-windows": "nixpkgs-windows_502"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_556": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_556"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_557": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_557",
+        "nixpkgs-windows": "nixpkgs-windows_503"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_558": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_558",
+        "nixpkgs-windows": "nixpkgs-windows_504"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_559": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_559",
+        "nixpkgs-windows": "nixpkgs-windows_505"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_56": {
       "inputs": {
         "nixpkgs": "nixpkgs_56",
         "nixpkgs-windows": "nixpkgs-windows_52"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_560": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_560",
+        "nixpkgs-windows": "nixpkgs-windows_506"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_561": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_561",
+        "nixpkgs-windows": "nixpkgs-windows_507"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_562": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_562",
+        "nixpkgs-windows": "nixpkgs-windows_508"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_563": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_563",
+        "nixpkgs-windows": "nixpkgs-windows_509"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_564": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_564",
+        "nixpkgs-windows": "nixpkgs-windows_510"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_565": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_565",
+        "nixpkgs-windows": "nixpkgs-windows_511"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_566": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_566",
+        "nixpkgs-windows": "nixpkgs-windows_512"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_567": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_567"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_568": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_568"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_569": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_569",
+        "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21281,10 +24188,385 @@
         "type": "github"
       }
     },
+    "logos-nix_570": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_570",
+        "nixpkgs-windows": "nixpkgs-windows_514"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_571": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_571",
+        "nixpkgs-windows": "nixpkgs-windows_515"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_572": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_572",
+        "nixpkgs-windows": "nixpkgs-windows_516"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_573": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_573",
+        "nixpkgs-windows": "nixpkgs-windows_517"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_574": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_574",
+        "nixpkgs-windows": "nixpkgs-windows_518"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_575": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_575"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_576": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_576"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_577": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_577",
+        "nixpkgs-windows": "nixpkgs-windows_519"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_578": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_578",
+        "nixpkgs-windows": "nixpkgs-windows_520"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_579": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_579",
+        "nixpkgs-windows": "nixpkgs-windows_521"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_58": {
       "inputs": {
         "nixpkgs": "nixpkgs_58",
         "nixpkgs-windows": "nixpkgs-windows_54"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_580": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_580",
+        "nixpkgs-windows": "nixpkgs-windows_522"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_581": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_581"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_582": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_582",
+        "nixpkgs-windows": "nixpkgs-windows_523"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_583": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_583",
+        "nixpkgs-windows": "nixpkgs-windows_524"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_584": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_584",
+        "nixpkgs-windows": "nixpkgs-windows_525"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_585": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_585",
+        "nixpkgs-windows": "nixpkgs-windows_526"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_586": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_586"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_587": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_587"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_588": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_588",
+        "nixpkgs-windows": "nixpkgs-windows_527"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_589": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_589",
+        "nixpkgs-windows": "nixpkgs-windows_528"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21311,6 +24593,174 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_590": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_590",
+        "nixpkgs-windows": "nixpkgs-windows_529"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_591": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_591",
+        "nixpkgs-windows": "nixpkgs-windows_530"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_592": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_592"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_593": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_593"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_594": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_594",
+        "nixpkgs-windows": "nixpkgs-windows_531"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_595": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_595",
+        "nixpkgs-windows": "nixpkgs-windows_532"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_596": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_596",
+        "nixpkgs-windows": "nixpkgs-windows_533"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_597": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_597",
+        "nixpkgs-windows": "nixpkgs-windows_534"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_598": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_598"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -21912,11 +25362,11 @@
         "nixpkgs-windows": "nixpkgs-windows_82"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22181,10 +25631,10 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_167",
-        "logos-package": "logos-package_16",
-        "nix-bundle-appimage": "nix-bundle-appimage_12",
-        "nix-bundle-dir": "nix-bundle-dir_27",
+        "logos-nix": "logos-nix_244",
+        "logos-package": "logos-package_23",
+        "nix-bundle-appimage": "nix-bundle-appimage_17",
+        "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -22208,7 +25658,7 @@
     },
     "logos-package-downloader-module": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_3",
+        "logos-module-builder": "logos-module-builder_5",
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
@@ -22227,10 +25677,10 @@
     },
     "logos-package-downloader_2": {
       "inputs": {
-        "logos-nix": "logos-nix_414",
-        "logos-package": "logos-package_41",
-        "nix-bundle-appimage": "nix-bundle-appimage_30",
-        "nix-bundle-dir": "nix-bundle-dir_69",
+        "logos-nix": "logos-nix_491",
+        "logos-package": "logos-package_48",
+        "nix-bundle-appimage": "nix-bundle-appimage_35",
+        "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -22284,8 +25734,8 @@
     },
     "logos-package-manager-module": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_5",
-        "logos-package-manager": "logos-package-manager_11"
+        "logos-module-builder": "logos-module-builder_7",
+        "logos-package-manager": "logos-package-manager_14"
       },
       "locked": {
         "lastModified": 1787692588,
@@ -22303,8 +25753,8 @@
     },
     "logos-package-manager-ui": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_7",
-        "logos-package": "logos-package_33",
+        "logos-module-builder": "logos-module-builder_9",
+        "logos-package": "logos-package_40",
         "package_downloader": "package_downloader",
         "package_manager": "package_manager"
       },
@@ -22324,41 +25774,11 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_246",
-        "logos-package": "logos-package_23",
+        "logos-nix": "logos-nix_249",
+        "logos-package": "logos-package_24",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
-        "nix-bundle-dir": "nix-bundle-dir_40",
+        "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468071,
-        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "rev": "3ad200d485c2d4510e41681231291a4899def181",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package-manager",
-        "type": "github"
-      }
-    },
-    "logos-package-manager_11": {
-      "inputs": {
-        "logos-nix": "logos-nix_254",
-        "logos-package": "logos-package_25",
-        "nix-bundle-appimage": "nix-bundle-appimage_19",
-        "nix-bundle-dir": "nix-bundle-dir_43",
-        "nixpkgs": [
-          "logos-package-manager-module",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -22378,14 +25798,14 @@
         "type": "github"
       }
     },
-    "logos-package-manager_12": {
+    "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
-        "logos-package": "logos-package_27",
-        "nix-bundle-appimage": "nix-bundle-appimage_22",
-        "nix-bundle-dir": "nix-bundle-dir_48",
+        "logos-nix": "logos-nix_290",
+        "logos-package": "logos-package_26",
+        "nix-bundle-appimage": "nix-bundle-appimage_21",
+        "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22411,14 +25831,14 @@
         "type": "github"
       }
     },
-    "logos-package-manager_13": {
+    "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_308",
-        "logos-package": "logos-package_29",
-        "nix-bundle-appimage": "nix-bundle-appimage_23",
-        "nix-bundle-dir": "nix-bundle-dir_51",
+        "logos-nix": "logos-nix_303",
+        "logos-package": "logos-package_28",
+        "nix-bundle-appimage": "nix-bundle-appimage_22",
+        "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22441,14 +25861,14 @@
         "type": "github"
       }
     },
-    "logos-package-manager_14": {
+    "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
-        "logos-package": "logos-package_31",
-        "nix-bundle-appimage": "nix-bundle-appimage_24",
-        "nix-bundle-dir": "nix-bundle-dir_54",
+        "logos-nix": "logos-nix_323",
+        "logos-package": "logos-package_30",
+        "nix-bundle-appimage": "nix-bundle-appimage_23",
+        "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -22470,15 +25890,41 @@
         "type": "github"
       }
     },
+    "logos-package-manager_14": {
+      "inputs": {
+        "logos-nix": "logos-nix_331",
+        "logos-package": "logos-package_32",
+        "nix-bundle-appimage": "nix-bundle-appimage_24",
+        "nix-bundle-dir": "nix-bundle-dir_55",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787428523,
+        "narHash": "sha256-WV30+aqn7MOnz9neSY1ni8AggRPROHsc3rrocx32/1U=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "7c5aad9ae59961a0e28b13ca37b2d18baf4f0e9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
-        "logos-package": "logos-package_35",
+        "logos-nix": "logos-nix_372",
+        "logos-package": "logos-package_34",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22506,13 +25952,12 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
-        "logos-package": "logos-package_37",
+        "logos-nix": "logos-nix_385",
+        "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_63",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22537,13 +25982,12 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
-        "logos-package": "logos-package_39",
+        "logos-nix": "logos-nix_405",
+        "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -22567,13 +26011,13 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
-        "logos-package": "logos-package_43",
-        "nix-bundle-appimage": "nix-bundle-appimage_33",
-        "nix-bundle-dir": "nix-bundle-dir_74",
+        "logos-nix": "logos-nix_450",
+        "logos-package": "logos-package_42",
+        "nix-bundle-appimage": "nix-bundle-appimage_32",
+        "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22601,13 +26045,13 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_468",
-        "logos-package": "logos-package_45",
-        "nix-bundle-appimage": "nix-bundle-appimage_34",
-        "nix-bundle-dir": "nix-bundle-dir_77",
+        "logos-nix": "logos-nix_463",
+        "logos-package": "logos-package_44",
+        "nix-bundle-appimage": "nix-bundle-appimage_33",
+        "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22662,10 +26106,105 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_488",
-        "logos-package": "logos-package_47",
-        "nix-bundle-appimage": "nix-bundle-appimage_35",
-        "nix-bundle-dir": "nix-bundle-dir_80",
+        "logos-nix": "logos-nix_483",
+        "logos-package": "logos-package_46",
+        "nix-bundle-appimage": "nix-bundle-appimage_34",
+        "nix-bundle-dir": "nix-bundle-dir_78",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_21": {
+      "inputs": {
+        "logos-nix": "logos-nix_532",
+        "logos-package": "logos-package_50",
+        "nix-bundle-appimage": "nix-bundle-appimage_38",
+        "nix-bundle-dir": "nix-bundle-dir_86",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_22": {
+      "inputs": {
+        "logos-nix": "logos-nix_545",
+        "logos-package": "logos-package_52",
+        "nix-bundle-appimage": "nix-bundle-appimage_39",
+        "nix-bundle-dir": "nix-bundle-dir_89",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package-manager",
+        "type": "github"
+      }
+    },
+    "logos-package-manager_23": {
+      "inputs": {
+        "logos-nix": "logos-nix_565",
+        "logos-package": "logos-package_54",
+        "nix-bundle-appimage": "nix-bundle-appimage_40",
+        "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22690,12 +26229,12 @@
         "type": "github"
       }
     },
-    "logos-package-manager_21": {
+    "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
-        "logos-package": "logos-package_49",
-        "nix-bundle-appimage": "nix-bundle-appimage_36",
-        "nix-bundle-dir": "nix-bundle-dir_83",
+        "logos-nix": "logos-nix_573",
+        "logos-package": "logos-package_56",
+        "nix-bundle-appimage": "nix-bundle-appimage_41",
+        "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -22718,12 +26257,12 @@
         "type": "github"
       }
     },
-    "logos-package-manager_22": {
+    "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_513",
-        "logos-package": "logos-package_50",
-        "nix-bundle-appimage": "nix-bundle-appimage_38",
-        "nix-bundle-dir": "nix-bundle-dir_87",
+        "logos-nix": "logos-nix_590",
+        "logos-package": "logos-package_57",
+        "nix-bundle-appimage": "nix-bundle-appimage_43",
+        "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -22774,12 +26313,12 @@
     },
     "logos-package-manager_4": {
       "inputs": {
-        "logos-nix": "logos-nix_126",
-        "logos-package": "logos-package_10",
+        "logos-nix": "logos-nix_124",
+        "logos-package": "logos-package_9",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22807,12 +26346,12 @@
     },
     "logos-package-manager_5": {
       "inputs": {
-        "logos-nix": "logos-nix_139",
-        "logos-package": "logos-package_12",
+        "logos-nix": "logos-nix_137",
+        "logos-package": "logos-package_11",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -22837,12 +26376,12 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_159",
-        "logos-package": "logos-package_14",
+        "logos-nix": "logos-nix_157",
+        "logos-package": "logos-package_13",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -22866,22 +26405,29 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_203",
         "logos-package": "logos-package_17",
-        "nix-bundle-appimage": "nix-bundle-appimage_13",
-        "nix-bundle-dir": "nix-bundle-dir_29",
+        "nix-bundle-appimage": "nix-bundle-appimage_14",
+        "nix-bundle-dir": "nix-bundle-dir_30",
         "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787428523,
-        "narHash": "sha256-WV30+aqn7MOnz9neSY1ni8AggRPROHsc3rrocx32/1U=",
+        "lastModified": 1786468071,
+        "narHash": "sha256-BVL8zJRPzaZbG72KkD4eZZewcxx3n1ZVgxWGjV8cQGU=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "7c5aad9ae59961a0e28b13ca37b2d18baf4f0e9d",
+        "rev": "3ad200d485c2d4510e41681231291a4899def181",
         "type": "github"
       },
       "original": {
@@ -22892,18 +26438,15 @@
     },
     "logos-package-manager_8": {
       "inputs": {
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_216",
         "logos-package": "logos-package_19",
-        "nix-bundle-appimage": "nix-bundle-appimage_16",
-        "nix-bundle-dir": "nix-bundle-dir_34",
+        "nix-bundle-appimage": "nix-bundle-appimage_15",
+        "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -22925,15 +26468,14 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_236",
         "logos-package": "logos-package_21",
-        "nix-bundle-appimage": "nix-bundle-appimage_17",
-        "nix-bundle-dir": "nix-bundle-dir_37",
+        "nix-bundle-appimage": "nix-bundle-appimage_16",
+        "nix-bundle-dir": "nix-bundle-dir_36",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-nix",
           "nixpkgs"
@@ -22955,16 +26497,16 @@
     },
     "logos-package_10": {
       "inputs": {
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_130",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -22986,16 +26528,13 @@
     },
     "logos-package_11": {
       "inputs": {
-        "logos-nix": "logos-nix_132",
+        "logos-nix": "logos-nix_138",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23017,13 +26556,11 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_154",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23045,35 +26582,9 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_156",
+        "logos-nix": "logos-nix_158",
         "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_14": {
-      "inputs": {
-        "logos-nix": "logos-nix_160",
-        "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -23096,11 +26607,11 @@
         "type": "github"
       }
     },
-    "logos-package_15": {
+    "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_165",
+        "logos-nix": "logos-nix_163",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -23123,12 +26634,40 @@
         "type": "github"
       }
     },
+    "logos-package_15": {
+      "inputs": {
+        "logos-nix": "logos-nix_166",
+        "nixpkgs": [
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786629110,
+        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_200",
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23150,8 +26689,15 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_173",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -23174,14 +26720,15 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_209",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23204,15 +26751,12 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_217",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -23262,15 +26806,10 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": "logos-nix_233",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23293,12 +26832,11 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_237",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
           "logos-nix",
@@ -23321,10 +26859,11 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_242",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
@@ -23347,12 +26886,10 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_245",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23374,12 +26911,9 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_252",
+        "logos-nix": "logos-nix_250",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23401,10 +26935,15 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_255",
+        "logos-nix": "logos-nix_287",
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23426,15 +26965,16 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_292",
+        "logos-nix": "logos-nix_291",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23458,38 +26998,7 @@
       "inputs": {
         "logos-nix": "logos-nix_296",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_28": {
-      "inputs": {
-        "logos-nix": "logos-nix_301",
-        "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -23516,15 +27025,41 @@
         "type": "github"
       }
     },
-    "logos-package_29": {
+    "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_304",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_29": {
+      "inputs": {
+        "logos-nix": "logos-nix_320",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23573,11 +27108,12 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23601,10 +27137,10 @@
       "inputs": {
         "logos-nix": "logos-nix_329",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23626,12 +27162,10 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_332",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager-module",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23653,20 +27187,26 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
+        "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786629110,
-        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
         "type": "github"
       },
       "original": {
@@ -23677,16 +27217,16 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23708,17 +27248,16 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_378",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23740,17 +27279,13 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_379",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23772,39 +27307,9 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_387",
+        "logos-nix": "logos-nix_402",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_403",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-package",
@@ -23826,15 +27331,41 @@
         "type": "github"
       }
     },
-    "logos-package_39": {
+    "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
+        "logos-nix": "logos-nix_406",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_411",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23883,24 +27414,20 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_413",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "lastModified": 1786629110,
+        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
         "type": "github"
       },
       "original": {
@@ -23911,11 +27438,16 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_447",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
-          "logos-package-downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23937,16 +27469,17 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_451",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -23971,14 +27504,14 @@
         "logos-nix": "logos-nix_456",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24000,42 +27533,10 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_464",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_45": {
-      "inputs": {
-        "logos-nix": "logos-nix_469",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24059,14 +27560,42 @@
         "type": "github"
       }
     },
-    "logos-package_46": {
+    "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_485",
+        "logos-nix": "logos-nix_480",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_484",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24091,35 +27620,7 @@
         "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_494",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -24142,13 +27643,44 @@
         "type": "github"
       }
     },
+    "logos-package_48": {
+      "inputs": {
+        "logos-nix": "logos-nix_492",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-package-downloader",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_529",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
-          "logos-package-manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24198,8 +27730,15 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_533",
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
           "logos-package",
@@ -24223,7 +27762,202 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_538",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_546",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_53": {
+      "inputs": {
+        "logos-nix": "logos-nix_562",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_54": {
+      "inputs": {
+        "logos-nix": "logos-nix_566",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_55": {
+      "inputs": {
+        "logos-nix": "logos-nix_571",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_56": {
+      "inputs": {
+        "logos-nix": "logos-nix_574",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_591",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -24301,19 +28035,26 @@
     },
     "logos-package_8": {
       "inputs": {
-        "logos-nix": "logos-nix_89",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786629110,
-        "narHash": "sha256-DqaRPmXGBdqQvYaTbSugPx9QEcZu2dVNWYfYLm2QmFE=",
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "01b1f337896509565dfcf9ab37945dbcf3097130",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
         "type": "github"
       },
       "original": {
@@ -24324,15 +28065,16 @@
     },
     "logos-package_9": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_125",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -24388,7 +28130,83 @@
       "inputs": {
         "logos-lidl": "logos-lidl_115",
         "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_424",
+        "logos-nix": "logos-nix_419",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787268499,
+        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-core_11": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_121",
+        "logos-module": "logos-module_88",
+        "logos-nix": "logos-nix_436",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-core_12": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_138",
+        "logos-module": "logos-module_99",
+        "logos-nix": "logos-nix_501",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -24418,11 +28236,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-core_11": {
+    "logos-plugin-core_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_121",
-        "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_441",
+        "logos-lidl": "logos-lidl_144",
+        "logos-module": "logos-module_104",
+        "logos-nix": "logos-nix_518",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -24464,14 +28282,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_23",
         "logos-module": "logos-module_19",
-        "logos-nix": "logos-nix_95",
+        "logos-nix": "logos-nix_93",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -24496,9 +28314,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_29",
         "logos-module": "logos-module_24",
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_110",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24507,7 +28325,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24536,14 +28354,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_46",
         "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_182",
+        "logos-nix": "logos-nix_172",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -24568,9 +28386,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_52",
         "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_189",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24579,7 +28397,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24608,14 +28426,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_69",
         "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_264",
+        "logos-nix": "logos-nix_259",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -24640,9 +28458,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_75",
         "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_276",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24651,7 +28469,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24680,16 +28498,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_92",
         "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_341",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-nix",
@@ -24697,11 +28513,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -24714,10 +28530,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_98",
         "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_358",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24727,7 +28542,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24828,14 +28642,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_24",
         "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_97",
+        "logos-nix": "logos-nix_95",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -24843,11 +28657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787435195,
-        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {
@@ -24859,26 +28673,26 @@
     "logos-plugin-qt_12": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
         "logos-module": "logos-module_21",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -24904,9 +28718,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_30",
         "logos-module": "logos-module_25",
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_112",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24915,7 +28729,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24943,7 +28757,7 @@
     "logos-plugin-qt_14": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24954,7 +28768,7 @@
         ],
         "logos-module": "logos-module_26",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24964,7 +28778,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -24974,7 +28788,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25005,7 +28819,7 @@
         "logos-lidl": "logos-lidl_33",
         "logos-module": "logos-module_27",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25015,7 +28829,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25025,7 +28839,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25054,7 +28868,7 @@
         "logos-lidl": "logos-lidl_36",
         "logos-module": "logos-module_28",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25064,7 +28878,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25074,7 +28888,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25103,21 +28917,21 @@
         "logos-lidl": "logos-lidl_38",
         "logos-module": "logos-module_30",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25143,19 +28957,19 @@
         "logos-lidl": "logos-lidl_40",
         "logos-module": "logos-module_31",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -25180,19 +28994,19 @@
         "logos-lidl": "logos-lidl_41",
         "logos-module": "logos-module_32",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -25261,19 +29075,19 @@
         "logos-lidl": "logos-lidl_44",
         "logos-module": "logos-module_33",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -25297,14 +29111,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_47",
         "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_184",
+        "logos-nix": "logos-nix_174",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -25312,11 +29126,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -25328,26 +29142,26 @@
     "logos-plugin-qt_22": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
         "logos-module": "logos-module_37",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -25373,9 +29187,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_53",
         "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_191",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25384,7 +29198,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25412,7 +29226,7 @@
     "logos-plugin-qt_24": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25423,7 +29237,7 @@
         ],
         "logos-module": "logos-module_42",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25433,7 +29247,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25443,7 +29257,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25474,7 +29288,7 @@
         "logos-lidl": "logos-lidl_56",
         "logos-module": "logos-module_43",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25484,7 +29298,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25494,7 +29308,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25523,7 +29337,7 @@
         "logos-lidl": "logos-lidl_59",
         "logos-module": "logos-module_44",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25533,7 +29347,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25543,7 +29357,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25572,21 +29386,21 @@
         "logos-lidl": "logos-lidl_61",
         "logos-module": "logos-module_46",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25612,19 +29426,19 @@
         "logos-lidl": "logos-lidl_63",
         "logos-module": "logos-module_47",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -25649,19 +29463,19 @@
         "logos-lidl": "logos-lidl_64",
         "logos-module": "logos-module_48",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -25723,19 +29537,19 @@
         "logos-lidl": "logos-lidl_67",
         "logos-module": "logos-module_49",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -25759,14 +29573,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_70",
         "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_266",
+        "logos-nix": "logos-nix_261",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -25774,11 +29588,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787435195,
-        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -25790,26 +29604,26 @@
     "logos-plugin-qt_32": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
         "logos-module": "logos-module_53",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -25835,9 +29649,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_76",
         "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_278",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25846,7 +29660,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25874,7 +29688,7 @@
     "logos-plugin-qt_34": {
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25885,7 +29699,7 @@
         ],
         "logos-module": "logos-module_58",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25895,7 +29709,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25905,7 +29719,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25936,7 +29750,7 @@
         "logos-lidl": "logos-lidl_79",
         "logos-module": "logos-module_59",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25946,7 +29760,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25956,7 +29770,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25985,7 +29799,7 @@
         "logos-lidl": "logos-lidl_82",
         "logos-module": "logos-module_60",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -25995,7 +29809,7 @@
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26005,7 +29819,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26034,21 +29848,21 @@
         "logos-lidl": "logos-lidl_84",
         "logos-module": "logos-module_62",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26074,19 +29888,19 @@
         "logos-lidl": "logos-lidl_86",
         "logos-module": "logos-module_63",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -26111,19 +29925,19 @@
         "logos-lidl": "logos-lidl_87",
         "logos-module": "logos-module_64",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -26185,19 +29999,19 @@
         "logos-lidl": "logos-lidl_90",
         "logos-module": "logos-module_65",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -26221,16 +30035,14 @@
       "inputs": {
         "logos-lidl": "logos-lidl_93",
         "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_343",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -26238,11 +30050,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268499,
-        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "lastModified": 1787435195,
+        "narHash": "sha256-/tkYJNXt9vZX2GFlZQmct/VeI3dvSP2V7Mwm6BhResQ=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "rev": "c459e477876175d9cba219d50f2efa241fef650c",
         "type": "github"
       },
       "original": {
@@ -26255,7 +30067,6 @@
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
@@ -26263,21 +30074,18 @@
         "logos-module": "logos-module_69",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -26303,10 +30111,9 @@
       "inputs": {
         "logos-lidl": "logos-lidl_99",
         "logos-module": "logos-module_73",
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_360",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26316,7 +30123,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26345,7 +30151,6 @@
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26357,7 +30162,6 @@
         "logos-module": "logos-module_74",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26368,7 +30172,6 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26379,7 +30182,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26411,7 +30213,6 @@
         "logos-module": "logos-module_75",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26422,7 +30223,6 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26433,7 +30233,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26463,7 +30262,6 @@
         "logos-module": "logos-module_76",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26474,7 +30272,6 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26485,7 +30282,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26515,7 +30311,6 @@
         "logos-module": "logos-module_78",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26523,7 +30318,6 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26531,7 +30325,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26558,21 +30351,18 @@
         "logos-module": "logos-module_79",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -26598,21 +30388,18 @@
         "logos-module": "logos-module_80",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -26682,21 +30469,18 @@
         "logos-module": "logos-module_81",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -26720,16 +30504,16 @@
       "inputs": {
         "logos-lidl": "logos-lidl_116",
         "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_421",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -26754,7 +30538,7 @@
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
@@ -26762,21 +30546,21 @@
         "logos-module": "logos-module_85",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -26802,10 +30586,10 @@
       "inputs": {
         "logos-lidl": "logos-lidl_122",
         "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_438",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26815,7 +30599,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26844,7 +30628,7 @@
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26856,7 +30640,7 @@
         "logos-module": "logos-module_90",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26867,7 +30651,7 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26878,7 +30662,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26910,7 +30694,7 @@
         "logos-module": "logos-module_91",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26921,7 +30705,7 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26932,7 +30716,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26962,7 +30746,7 @@
         "logos-module": "logos-module_92",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26973,7 +30757,7 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -26984,7 +30768,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27014,7 +30798,7 @@
         "logos-module": "logos-module_94",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27022,7 +30806,7 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27030,7 +30814,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27057,21 +30841,21 @@
         "logos-module": "logos-module_95",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -27097,21 +30881,21 @@
         "logos-module": "logos-module_96",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -27177,6 +30961,497 @@
         "logos-module": "logos-module_97",
         "logos-nix": [
           "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_61": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_139",
+        "logos-module": "logos-module_100",
+        "logos-nix": "logos-nix_503",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787268499,
+        "narHash": "sha256-uYMUAOqwuJhA6KE7KddbaQAJZl55T/K4tZMoF02ShhQ=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "55713b9c799af3c73e176b2a22001a9aa7eb8a71",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_62": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_101",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_63": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_145",
+        "logos-module": "logos-module_105",
+        "logos-nix": "logos-nix_520",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_64": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_106",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_65": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_148",
+        "logos-module": "logos-module_107",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_66": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_151",
+        "logos-module": "logos-module_108",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_67": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_153",
+        "logos-module": "logos-module_110",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_68": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_155",
+        "logos-module": "logos-module_111",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_69": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_156",
+        "logos-module": "logos-module_112",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_7": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_11",
+        "logos-nix": "logos-nix_59",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_70": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_159",
+        "logos-module": "logos-module_113",
+        "logos-nix": [
+          "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -27211,12 +31486,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_61": {
+    "logos-plugin-qt_71": {
       "inputs": {
-        "logos-lidl": "logos-lidl_137",
-        "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_502",
-        "logos-protocol": "logos-protocol_73",
+        "logos-lidl": "logos-lidl_160",
+        "logos-module": "logos-module_114",
+        "logos-nix": "logos-nix_579",
+        "logos-protocol": "logos-protocol_85",
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-nix",
@@ -27237,13 +31512,13 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_62": {
+    "logos-plugin-qt_72": {
       "inputs": {
         "logos-lidl": [
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_99",
+        "logos-module": "logos-module_115",
         "logos-nix": [
           "logos-qt-sdk",
           "logos-nix"
@@ -27273,10 +31548,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_63": {
+    "logos-plugin-qt_73": {
       "inputs": {
-        "logos-lidl": "logos-lidl_140",
-        "logos-module": "logos-module_100",
+        "logos-lidl": "logos-lidl_163",
+        "logos-module": "logos-module_116",
         "logos-nix": [
           "logos-view-module-runtime",
           "logos-nix"
@@ -27287,42 +31562,6 @@
         ],
         "nixpkgs": [
           "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_7": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_11",
-        "logos-nix": "logos-nix_59",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-plugin-qt",
-          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -27565,9 +31804,9 @@
     },
     "logos-protocol_15": {
       "inputs": {
-        "logos-nix": "logos-nix_98",
+        "logos-nix": "logos-nix_96",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -27575,11 +31814,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787430480,
-        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -27591,13 +31830,13 @@
     "logos-protocol_16": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-protocol",
@@ -27606,11 +31845,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -27622,14 +31861,14 @@
     "logos-protocol_17": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -27654,9 +31893,9 @@
     },
     "logos-protocol_18": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_113",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27684,7 +31923,7 @@
     "logos-protocol_19": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27694,7 +31933,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27752,7 +31991,7 @@
     "logos-protocol_20": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27763,7 +32002,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27793,7 +32032,7 @@
     "logos-protocol_21": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27803,7 +32042,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27829,9 +32068,9 @@
     },
     "logos-protocol_22": {
       "inputs": {
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_143",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -27857,13 +32096,13 @@
     "logos-protocol_23": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -27886,13 +32125,13 @@
     "logos-protocol_24": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -27915,14 +32154,14 @@
     "logos-protocol_25": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -27948,13 +32187,13 @@
     "logos-protocol_26": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -27976,9 +32215,9 @@
     },
     "logos-protocol_27": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_175",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -27986,11 +32225,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
         "type": "github"
       },
       "original": {
@@ -28002,13 +32241,13 @@
     "logos-protocol_28": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-protocol",
@@ -28017,11 +32256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -28033,14 +32272,14 @@
     "logos-protocol_29": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -28094,9 +32333,9 @@
     },
     "logos-protocol_30": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28124,7 +32363,7 @@
     "logos-protocol_31": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28134,7 +32373,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28161,7 +32400,7 @@
     "logos-protocol_32": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28172,7 +32411,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28202,7 +32441,7 @@
     "logos-protocol_33": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28212,7 +32451,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28238,9 +32477,9 @@
     },
     "logos-protocol_34": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_222",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28266,13 +32505,13 @@
     "logos-protocol_35": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -28295,13 +32534,13 @@
     "logos-protocol_36": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -28324,14 +32563,14 @@
     "logos-protocol_37": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -28357,13 +32596,13 @@
     "logos-protocol_38": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -28385,9 +32624,9 @@
     },
     "logos-protocol_39": {
       "inputs": {
-        "logos-nix": "logos-nix_267",
+        "logos-nix": "logos-nix_262",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -28395,11 +32634,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787430480,
-        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -28444,13 +32683,13 @@
     "logos-protocol_40": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-protocol",
@@ -28459,11 +32698,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -28475,14 +32714,14 @@
     "logos-protocol_41": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -28507,9 +32746,9 @@
     },
     "logos-protocol_42": {
       "inputs": {
-        "logos-nix": "logos-nix_284",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28537,7 +32776,7 @@
     "logos-protocol_43": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28547,7 +32786,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28574,7 +32813,7 @@
     "logos-protocol_44": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28585,7 +32824,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28615,7 +32854,7 @@
     "logos-protocol_45": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28625,7 +32864,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28651,9 +32890,9 @@
     },
     "logos-protocol_46": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_309",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28679,13 +32918,13 @@
     "logos-protocol_47": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -28708,13 +32947,13 @@
     "logos-protocol_48": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -28737,14 +32976,14 @@
     "logos-protocol_49": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -28799,13 +33038,13 @@
     "logos-protocol_50": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -28827,11 +33066,41 @@
     },
     "logos-protocol_51": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787430480,
+        "narHash": "sha256-TpbTH95fk8e1F5DGxTeX+5y1MilGoSfOp8/JIoU1PMI=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "6c24fcb13229cda6ebe70205b4ecf00dacd0ed1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_52": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -28851,11 +33120,10 @@
         "type": "github"
       }
     },
-    "logos-protocol_52": {
+    "logos-protocol_53": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -28863,40 +33131,9 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_53": {
-      "inputs": {
-        "logos-nix": "logos-nix_362",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -28918,9 +33155,37 @@
     },
     "logos-protocol_54": {
       "inputs": {
+        "logos-nix": "logos-nix_361",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_55": {
+      "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28931,7 +33196,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28955,11 +33219,10 @@
         "type": "github"
       }
     },
-    "logos-protocol_55": {
+    "logos-protocol_56": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28971,7 +33234,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -28998,11 +33260,10 @@
         "type": "github"
       }
     },
-    "logos-protocol_56": {
+    "logos-protocol_57": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29013,7 +33274,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29037,12 +33297,11 @@
         "type": "github"
       }
     },
-    "logos-protocol_57": {
+    "logos-protocol_58": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29065,18 +33324,16 @@
         "type": "github"
       }
     },
-    "logos-protocol_58": {
+    "logos-protocol_59": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "nixpkgs"
@@ -29088,37 +33345,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_59": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_downloader",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -29158,7 +33384,35 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_61": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -29166,7 +33420,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -29189,18 +33442,16 @@
         "type": "github"
       }
     },
-    "logos-protocol_61": {
+    "logos-protocol_62": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -29220,12 +33471,12 @@
         "type": "github"
       }
     },
-    "logos-protocol_62": {
+    "logos-protocol_63": {
       "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_422",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -29246,11 +33497,11 @@
         "type": "github"
       }
     },
-    "logos-protocol_63": {
+    "logos-protocol_64": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
@@ -29258,40 +33509,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_64": {
-      "inputs": {
-        "logos-nix": "logos-nix_444",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -29313,9 +33534,39 @@
     },
     "logos-protocol_65": {
       "inputs": {
+        "logos-nix": "logos-nix_439",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_66": {
+      "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29326,7 +33577,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29350,11 +33601,11 @@
         "type": "github"
       }
     },
-    "logos-protocol_66": {
+    "logos-protocol_67": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29366,7 +33617,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29393,11 +33644,11 @@
         "type": "github"
       }
     },
-    "logos-protocol_67": {
+    "logos-protocol_68": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29408,7 +33659,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29432,12 +33683,12 @@
         "type": "github"
       }
     },
-    "logos-protocol_68": {
+    "logos-protocol_69": {
       "inputs": {
-        "logos-nix": "logos-nix_474",
+        "logos-nix": "logos-nix_469",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -29452,37 +33703,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_69": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -29520,14 +33740,45 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_71": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -29547,11 +33798,11 @@
         "type": "github"
       }
     },
-    "logos-protocol_71": {
+    "logos-protocol_72": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -29559,7 +33810,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -29582,18 +33833,18 @@
         "type": "github"
       }
     },
-    "logos-protocol_72": {
+    "logos-protocol_73": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -29613,48 +33864,24 @@
         "type": "github"
       }
     },
-    "logos-protocol_73": {
-      "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_74": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_504",
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -29666,22 +33893,30 @@
     "logos-protocol_75": {
       "inputs": {
         "logos-nix": [
-          "logos-qt-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-qt-sdk",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -29692,12 +33927,95 @@
     },
     "logos-protocol_76": {
       "inputs": {
+        "logos-nix": "logos-nix_521",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_77": {
+      "inputs": {
         "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_78": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-protocol",
@@ -29719,23 +34037,37 @@
         "type": "github"
       }
     },
-    "logos-protocol_77": {
+    "logos-protocol_79": {
       "inputs": {
         "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -29779,6 +34111,293 @@
         "type": "github"
       }
     },
+    "logos-protocol_80": {
+      "inputs": {
+        "logos-nix": "logos-nix_551",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275122,
+        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_81": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_82": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_83": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_84": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_85": {
+      "inputs": {
+        "logos-nix": [
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_86": {
+      "inputs": {
+        "logos-nix": "logos-nix_580",
+        "nixpkgs": [
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_87": {
+      "inputs": {
+        "logos-nix": [
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_88": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_89": {
+      "inputs": {
+        "logos-nix": [
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_9": {
       "inputs": {
         "logos-nix": [
@@ -29812,9 +34431,9 @@
     },
     "logos-qt-mcp": {
       "inputs": {
-        "logos-nix": "logos-nix_150",
+        "logos-nix": "logos-nix_148",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -29838,9 +34457,9 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -29864,9 +34483,9 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_319",
+        "logos-nix": "logos-nix_314",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-qt-mcp",
@@ -29890,7 +34509,33 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
+        "logos-nix": "logos-nix_396",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-qt-mcp",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782152420,
+        "narHash": "sha256-dNZsL+qE+NFCHlpgUzlhbmXu13goEwgdJGbEbw5uOEM=",
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "rev": "1fea509485a48ab185fafae8dc21bdbcc808a07e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-mcp",
+        "type": "github"
+      }
+    },
+    "logos-qt-mcp_5": {
+      "inputs": {
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -29915,9 +34560,9 @@
         "type": "github"
       }
     },
-    "logos-qt-mcp_5": {
+    "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -29942,9 +34587,9 @@
         "type": "github"
       }
     },
-    "logos-qt-mcp_6": {
+    "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_581",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -30005,23 +34650,23 @@
     "logos-qt-sdk_10": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_39",
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_144",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30047,32 +34692,32 @@
     "logos-qt-sdk_11": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_42",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30095,20 +34740,20 @@
     "logos-qt-sdk_12": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_48",
-        "logos-nix": "logos-nix_186",
+        "logos-nix": "logos-nix_176",
         "logos-plugin-qt": "logos-plugin-qt_22",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -30116,11 +34761,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787538017,
-        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
+        "lastModified": 1787442773,
+        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
+        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
         "type": "github"
       },
       "original": {
@@ -30132,7 +34777,7 @@
     "logos-qt-sdk_13": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30141,10 +34786,10 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_54",
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_193",
         "logos-plugin-qt": "logos-plugin-qt_24",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30153,7 +34798,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30181,7 +34826,7 @@
     "logos-qt-sdk_14": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30192,7 +34837,7 @@
         ],
         "logos-lidl": "logos-lidl_57",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30202,7 +34847,7 @@
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30212,7 +34857,7 @@
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30222,7 +34867,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30249,23 +34894,23 @@
     "logos-qt-sdk_15": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_62",
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_223",
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30291,32 +34936,32 @@
     "logos-qt-sdk_16": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_65",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30339,20 +34984,20 @@
     "logos-qt-sdk_17": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_71",
-        "logos-nix": "logos-nix_268",
+        "logos-nix": "logos-nix_263",
         "logos-plugin-qt": "logos-plugin-qt_32",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -30360,11 +35005,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787442773,
-        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -30376,7 +35021,7 @@
     "logos-qt-sdk_18": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30385,10 +35030,10 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_77",
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_280",
         "logos-plugin-qt": "logos-plugin-qt_34",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30397,7 +35042,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30425,7 +35070,7 @@
     "logos-qt-sdk_19": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30436,7 +35081,7 @@
         ],
         "logos-lidl": "logos-lidl_80",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30446,7 +35091,7 @@
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30456,7 +35101,7 @@
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30466,7 +35111,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30541,23 +35186,23 @@
     "logos-qt-sdk_20": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_85",
-        "logos-nix": "logos-nix_315",
+        "logos-nix": "logos-nix_310",
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30583,32 +35228,32 @@
     "logos-qt-sdk_21": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_88",
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30632,22 +35277,19 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_94",
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_345",
         "logos-plugin-qt": "logos-plugin-qt_42",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -30655,11 +35297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787268585,
-        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
+        "lastModified": 1787442773,
+        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
+        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
         "type": "github"
       },
       "original": {
@@ -30672,7 +35314,6 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30681,11 +35322,10 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_100",
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_362",
         "logos-plugin-qt": "logos-plugin-qt_44",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30695,7 +35335,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30724,7 +35363,6 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30736,7 +35374,6 @@
         "logos-lidl": "logos-lidl_103",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30747,7 +35384,6 @@
         ],
         "logos-plugin-qt": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30758,7 +35394,6 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30769,7 +35404,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30797,17 +35431,15 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_108",
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_392",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30815,7 +35447,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30842,7 +35473,6 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
@@ -30850,28 +35480,24 @@
         "logos-lidl": "logos-lidl_111",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-plugin-qt": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -30895,22 +35521,22 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_117",
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_423",
         "logos-plugin-qt": "logos-plugin-qt_52",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -30935,7 +35561,7 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30944,11 +35570,11 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_123",
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_440",
         "logos-plugin-qt": "logos-plugin-qt_54",
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30958,7 +35584,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30987,7 +35613,7 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -30999,7 +35625,7 @@
         "logos-lidl": "logos-lidl_126",
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31010,7 +35636,7 @@
         ],
         "logos-plugin-qt": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31021,7 +35647,7 @@
         ],
         "logos-protocol": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31032,7 +35658,7 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31097,14 +35723,277 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_131",
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_470",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786469121,
+        "narHash": "sha256-8sM8d98dquIUOcu9YRlAnpRZ5zcTqWCZii5AyhCwi1k=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "c6be61d0ba3f1c06c1a5ff7ad6d42f3eda254877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_31": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_134",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_32": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_140",
+        "logos-nix": "logos-nix_505",
+        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787268585,
+        "narHash": "sha256-yDh1GpHNWAo7JlGvR83paJhFTCNLjDnLtxRxNl/1RzE=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "4a1104cabb5647ef8524809c7021104e050cb529",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_33": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_146",
+        "logos-nix": "logos-nix_522",
+        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_34": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_149",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_35": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_154",
+        "logos-nix": "logos-nix_552",
         "logos-protocol": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31138,7 +36027,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_31": {
+    "logos-qt-sdk_36": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -31147,7 +36036,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_134",
+        "logos-lidl": "logos-lidl_157",
         "logos-nix": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31191,13 +36080,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_32": {
+    "logos-qt-sdk_37": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
-        "logos-lidl": "logos-lidl_138",
-        "logos-nix": "logos-nix_505",
-        "logos-plugin-qt": "logos-plugin-qt_62",
-        "logos-protocol": "logos-protocol_75",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-lidl": "logos-lidl_161",
+        "logos-nix": "logos-nix_582",
+        "logos-plugin-qt": "logos-plugin-qt_72",
+        "logos-protocol": "logos-protocol_87",
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-nix",
@@ -31328,20 +36217,20 @@
     "logos-qt-sdk_7": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_25",
-        "logos-nix": "logos-nix_99",
+        "logos-nix": "logos-nix_97",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -31349,11 +36238,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787442773,
-        "narHash": "sha256-XBztDKox0BmrTnIVVWji8Jhgh1dVKqAEqXj1dUlWIOE=",
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "4ab78a1a42f0db1ff97cc5d8a3fb9b41753e16c9",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -31365,7 +36254,7 @@
     "logos-qt-sdk_8": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31374,10 +36263,10 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_31",
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_114",
         "logos-plugin-qt": "logos-plugin-qt_14",
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31386,7 +36275,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31414,7 +36303,7 @@
     "logos-qt-sdk_9": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31425,7 +36314,7 @@
         ],
         "logos-lidl": "logos-lidl_34",
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31435,7 +36324,7 @@
           "logos-nix"
         ],
         "logos-plugin-qt": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31445,7 +36334,7 @@
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31455,7 +36344,7 @@
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31525,6 +36414,106 @@
         "logos-lidl": "logos-lidl_101",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-module-builder": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787192832,
+        "narHash": "sha256-OOKWEtVLRZ0an2mMLGb/V1bCwVnW/vJkzNqln5KQvN0=",
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "rev": "a3d0d719e396bb5a8805527eb88702bcb400d2e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "type": "github"
+      }
+    },
+    "logos-rust-sdk_11": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_118",
+        "logos-logoscore-cli": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-module-builder": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787312984,
+        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-rust-sdk",
+        "type": "github"
+      }
+    },
+    "logos-rust-sdk_12": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_124",
+        "logos-logoscore-cli": [
+          "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
@@ -31580,9 +36569,9 @@
         "type": "github"
       }
     },
-    "logos-rust-sdk_11": {
+    "logos-rust-sdk_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_118",
+        "logos-lidl": "logos-lidl_141",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31624,9 +36613,9 @@
         "type": "github"
       }
     },
-    "logos-rust-sdk_12": {
+    "logos-rust-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_124",
+        "logos-lidl": "logos-lidl_147",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "package_manager",
@@ -31732,23 +36721,23 @@
       "inputs": {
         "logos-lidl": "logos-lidl_26",
         "logos-logoscore-cli": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_16",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -31756,11 +36745,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787432825,
-        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
+        "lastModified": 1787605292,
+        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
+        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
         "type": "github"
       },
       "original": {
@@ -31773,7 +36762,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_32",
         "logos-logoscore-cli": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31782,7 +36771,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31791,7 +36780,7 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31800,7 +36789,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31829,23 +36818,23 @@
       "inputs": {
         "logos-lidl": "logos-lidl_49",
         "logos-logoscore-cli": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_28",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -31853,11 +36842,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605292,
-        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -31870,7 +36859,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_55",
         "logos-logoscore-cli": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31879,7 +36868,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31888,7 +36877,7 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31897,7 +36886,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31926,23 +36915,23 @@
       "inputs": {
         "logos-lidl": "logos-lidl_72",
         "logos-logoscore-cli": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_40",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -31950,11 +36939,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787432825,
-        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
+        "lastModified": 1787605292,
+        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
+        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
         "type": "github"
       },
       "original": {
@@ -31967,7 +36956,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_78",
         "logos-logoscore-cli": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31976,7 +36965,7 @@
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31985,7 +36974,7 @@
           "logos-cpp-sdk"
         ],
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -31994,7 +36983,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32024,25 +37013,22 @@
         "logos-lidl": "logos-lidl_95",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-module-builder": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_52",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix",
@@ -32050,11 +37036,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787312984,
-        "narHash": "sha256-5tUekequUlrzhG7C005bm20zALXpLPw2K2SYl2eZL1I=",
+        "lastModified": 1787432825,
+        "narHash": "sha256-ewGa76Pym9ZQjtFP7Kwxfks9ys23AVd3Mx5GdzLQ2Dw=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "49dbb0768a9a18cfaf264cc3ecfa55cca2630157",
+        "rev": "2b88750085193aa4e2771e26e825a990a6caf91a",
         "type": "github"
       },
       "original": {
@@ -32067,22 +37053,22 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_11",
         "logos-design-system": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_148",
+        "logos-nix": "logos-nix_146",
         "logos-plugin-qt": "logos-plugin-qt_18",
         "logos-protocol": "logos-protocol_23",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -32107,22 +37093,22 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_17",
         "logos-design-system": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_3",
-        "logos-nix": "logos-nix_235",
+        "logos-nix": "logos-nix_225",
         "logos-plugin-qt": "logos-plugin-qt_28",
         "logos-protocol": "logos-protocol_35",
         "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -32147,22 +37133,22 @@
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-design-system": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
-        "logos-nix": "logos-nix_317",
+        "logos-nix": "logos-nix_312",
         "logos-plugin-qt": "logos-plugin-qt_38",
         "logos-protocol": "logos-protocol_47",
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-nix",
@@ -32188,15 +37174,55 @@
         "logos-cpp-sdk": "logos-cpp-sdk_29",
         "logos-design-system": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_394",
         "logos-plugin-qt": "logos-plugin-qt_48",
-        "logos-protocol": "logos-protocol_58",
+        "logos-protocol": "logos-protocol_59",
         "logos-qt-mcp": "logos-qt-mcp_4",
+        "logos-view-module-runtime": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787361051,
+        "narHash": "sha256-q3RlsjdM3wIgnZVQg17xC9/1AgW2Jla/QmN3RsIU8wY=",
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "rev": "9c0aabef5b68cf5ab88d1bab6b375e23a4f9d2a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-standalone-app",
+        "type": "github"
+      }
+    },
+    "logos-standalone-app_5": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-design-system": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system"
+        ],
+        "logos-liblogos": "logos-liblogos_6",
+        "logos-nix": "logos-nix_472",
+        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-protocol": "logos-protocol_70",
+        "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -32226,20 +37252,20 @@
         "type": "github"
       }
     },
-    "logos-standalone-app_5": {
+    "logos-standalone-app_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-design-system": [
           "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-design-system"
         ],
-        "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_477",
-        "logos-plugin-qt": "logos-plugin-qt_58",
-        "logos-protocol": "logos-protocol_69",
-        "logos-qt-mcp": "logos-qt-mcp_5",
+        "logos-liblogos": "logos-liblogos_7",
+        "logos-nix": "logos-nix_554",
+        "logos-plugin-qt": "logos-plugin-qt_68",
+        "logos-protocol": "logos-protocol_81",
+        "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32306,17 +37332,15 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_397",
         "logos-plugin-qt": "logos-plugin-qt_49",
-        "logos-protocol": "logos-protocol_59",
+        "logos-protocol": "logos-protocol_60",
         "logos-qt-sdk": "logos-qt-sdk_26",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -32341,7 +37365,7 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32349,13 +37373,13 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_442",
         "logos-plugin-qt": "logos-plugin-qt_55",
-        "logos-protocol": "logos-protocol_65",
+        "logos-protocol": "logos-protocol_66",
         "logos-qt-sdk": "logos-qt-sdk_29",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32384,14 +37408,92 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_475",
+        "logos-plugin-qt": "logos-plugin-qt_59",
+        "logos-protocol": "logos-protocol_71",
+        "logos-qt-sdk": "logos-qt-sdk_31",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787175653,
+        "narHash": "sha256-LWTrfyl7RTAeG51kxUy4rHKzDJ8CtyUgISYK5hLJFMw=",
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "rev": "5f75c9418b7c842f1750bfde31accf3d0cba283d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "type": "github"
+      }
+    },
+    "logos-test-framework_13": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_524",
+        "logos-plugin-qt": "logos-plugin-qt_65",
+        "logos-protocol": "logos-protocol_77",
+        "logos-qt-sdk": "logos-qt-sdk_34",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787175653,
+        "narHash": "sha256-LWTrfyl7RTAeG51kxUy4rHKzDJ8CtyUgISYK5hLJFMw=",
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "rev": "5f75c9418b7c842f1750bfde31accf3d0cba283d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-test-framework",
+        "type": "github"
+      }
+    },
+    "logos-test-framework_14": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_480",
-        "logos-plugin-qt": "logos-plugin-qt_59",
-        "logos-protocol": "logos-protocol_70",
-        "logos-qt-sdk": "logos-qt-sdk_31",
+        "logos-nix": "logos-nix_557",
+        "logos-plugin-qt": "logos-plugin-qt_69",
+        "logos-protocol": "logos-protocol_82",
+        "logos-qt-sdk": "logos-qt-sdk_36",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32463,7 +37565,7 @@
     "logos-test-framework_3": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32471,12 +37573,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_116",
         "logos-plugin-qt": "logos-plugin-qt_15",
         "logos-protocol": "logos-protocol_19",
         "logos-qt-sdk": "logos-qt-sdk_9",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32504,16 +37606,16 @@
     "logos-test-framework_4": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_151",
+        "logos-nix": "logos-nix_149",
         "logos-plugin-qt": "logos-plugin-qt_19",
         "logos-protocol": "logos-protocol_24",
         "logos-qt-sdk": "logos-qt-sdk_11",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -32537,7 +37639,7 @@
     "logos-test-framework_5": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32545,12 +37647,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_195",
         "logos-plugin-qt": "logos-plugin-qt_25",
         "logos-protocol": "logos-protocol_31",
         "logos-qt-sdk": "logos-qt-sdk_14",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32578,16 +37680,16 @@
     "logos-test-framework_6": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_238",
+        "logos-nix": "logos-nix_228",
         "logos-plugin-qt": "logos-plugin-qt_29",
         "logos-protocol": "logos-protocol_36",
         "logos-qt-sdk": "logos-qt-sdk_16",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -32611,7 +37713,7 @@
     "logos-test-framework_7": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32619,12 +37721,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_282",
         "logos-plugin-qt": "logos-plugin-qt_35",
         "logos-protocol": "logos-protocol_43",
         "logos-qt-sdk": "logos-qt-sdk_19",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32652,16 +37754,16 @@
     "logos-test-framework_8": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_315",
         "logos-plugin-qt": "logos-plugin-qt_39",
         "logos-protocol": "logos-protocol_48",
         "logos-qt-sdk": "logos-qt-sdk_21",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix",
@@ -32686,7 +37788,6 @@
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32694,13 +37795,12 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_364",
         "logos-plugin-qt": "logos-plugin-qt_45",
-        "logos-protocol": "logos-protocol_54",
+        "logos-protocol": "logos-protocol_55",
         "logos-qt-sdk": "logos-qt-sdk_24",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32785,12 +37885,11 @@
     "logos-view-module-runtime_10": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_399",
         "logos-plugin-qt": "logos-plugin-qt_50",
-        "logos-protocol": "logos-protocol_61",
+        "logos-protocol": "logos-protocol_62",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -32814,12 +37913,12 @@
     "logos-view-module-runtime_11": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_37",
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_444",
         "logos-plugin-qt": "logos-plugin-qt_56",
-        "logos-protocol": "logos-protocol_67",
+        "logos-protocol": "logos-protocol_68",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32847,9 +37946,71 @@
     "logos-view-module-runtime_12": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_477",
         "logos-plugin-qt": "logos-plugin-qt_60",
-        "logos-protocol": "logos-protocol_72",
+        "logos-protocol": "logos-protocol_73",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787356738,
+        "narHash": "sha256-icN5SY1+l3xcup/9cvWnden6JW7n/mdDYm3bYHkcAO4=",
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "rev": "7cbc5a6ed3ba5ccffd584c25b966dbf67868d841",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "type": "github"
+      }
+    },
+    "logos-view-module-runtime_13": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-nix": "logos-nix_526",
+        "logos-plugin-qt": "logos-plugin-qt_66",
+        "logos-protocol": "logos-protocol_79",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787172850,
+        "narHash": "sha256-p5MReDNu3sSosuGYzEeD+wVP4dYUL2KKHA6dtCBsTN8=",
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "rev": "b9a6778fff2f5714ddb556647ab961f4689a9937",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module-runtime",
+        "type": "github"
+      }
+    },
+    "logos-view-module-runtime_14": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-nix": "logos-nix_559",
+        "logos-plugin-qt": "logos-plugin-qt_70",
+        "logos-protocol": "logos-protocol_84",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -32873,12 +38034,12 @@
         "type": "github"
       }
     },
-    "logos-view-module-runtime_13": {
+    "logos-view-module-runtime_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
-        "logos-nix": "logos-nix_507",
-        "logos-plugin-qt": "logos-plugin-qt_63",
-        "logos-protocol": "logos-protocol_77",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-nix": "logos-nix_584",
+        "logos-plugin-qt": "logos-plugin-qt_73",
+        "logos-protocol": "logos-protocol_89",
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-nix",
@@ -32931,11 +38092,11 @@
     "logos-view-module-runtime_3": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_13",
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_118",
         "logos-plugin-qt": "logos-plugin-qt_16",
         "logos-protocol": "logos-protocol_21",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -32963,11 +38124,11 @@
     "logos-view-module-runtime_4": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_15",
-        "logos-nix": "logos-nix_153",
+        "logos-nix": "logos-nix_151",
         "logos-plugin-qt": "logos-plugin-qt_20",
         "logos-protocol": "logos-protocol_26",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -32991,11 +38152,11 @@
     "logos-view-module-runtime_5": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_19",
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_197",
         "logos-plugin-qt": "logos-plugin-qt_26",
         "logos-protocol": "logos-protocol_33",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33023,11 +38184,11 @@
     "logos-view-module-runtime_6": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_21",
-        "logos-nix": "logos-nix_240",
+        "logos-nix": "logos-nix_230",
         "logos-plugin-qt": "logos-plugin-qt_30",
         "logos-protocol": "logos-protocol_38",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -33051,11 +38212,11 @@
     "logos-view-module-runtime_7": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_25",
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_284",
         "logos-plugin-qt": "logos-plugin-qt_36",
         "logos-protocol": "logos-protocol_45",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33083,11 +38244,11 @@
     "logos-view-module-runtime_8": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_27",
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_317",
         "logos-plugin-qt": "logos-plugin-qt_40",
         "logos-protocol": "logos-protocol_50",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix",
@@ -33111,12 +38272,11 @@
     "logos-view-module-runtime_9": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_366",
         "logos-plugin-qt": "logos-plugin-qt_46",
-        "logos-protocol": "logos-protocol_56",
+        "logos-protocol": "logos-protocol_57",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33145,6 +38305,74 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787441236,
+        "narHash": "sha256-dDbws6OlaOw5YTCHQfVLXqF+ssD6Fs3vCrLqOthEYOI=",
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "rev": "d6c8885494524504cc5ea9dcfdad54a98ed26ea4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "type": "github"
+      }
+    },
+    "logos-view-module_11": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787164758,
+        "narHash": "sha256-RFu9RTD4RVbwoKJN01qmt00eqF8ZwKHm3gcbYc95HyE=",
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "rev": "1f95a75f836a7601bde3b488dc2e773c4ebb9068",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-view-module",
+        "type": "github"
+      }
+    },
+    "logos-view-module_12": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
           "package_downloader",
           "logos-module-builder",
           "logos-nix"
@@ -33172,7 +38400,7 @@
         "type": "github"
       }
     },
-    "logos-view-module_11": {
+    "logos-view-module_13": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -33211,7 +38439,7 @@
         "type": "github"
       }
     },
-    "logos-view-module_12": {
+    "logos-view-module_14": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -33276,7 +38504,7 @@
     "logos-view-module_3": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33285,7 +38513,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33313,12 +38541,12 @@
     "logos-view-module_4": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -33342,7 +38570,7 @@
     "logos-view-module_5": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33351,7 +38579,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33379,12 +38607,12 @@
     "logos-view-module_6": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -33408,7 +38636,7 @@
     "logos-view-module_7": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33417,7 +38645,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33445,12 +38673,12 @@
     "logos-view-module_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module",
           "logos-nix",
@@ -33475,7 +38703,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33485,7 +38712,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33547,10 +38773,10 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_139",
         "nix-bundle-dir": "nix-bundle-dir_20",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -33576,10 +38802,10 @@
     },
     "nix-bundle-appimage_11": {
       "inputs": {
-        "logos-nix": "logos-nix_161",
+        "logos-nix": "logos-nix_159",
         "nix-bundle-dir": "nix-bundle-dir_23",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -33604,13 +38830,22 @@
     },
     "nix-bundle-appimage_12": {
       "inputs": {
-        "logos-nix": "logos-nix_169",
-        "nix-bundle-dir": "nix-bundle-dir_26",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -33630,9 +38865,63 @@
     },
     "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_174",
-        "nix-bundle-dir": "nix-bundle-dir_28",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_14": {
+      "inputs": {
+        "logos-nix": "logos-nix_205",
+        "nix-bundle-dir": "nix-bundle-dir_29",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -33653,80 +38942,27 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_14": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
+        "logos-nix": "logos-nix_218",
+        "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -33737,14 +38973,10 @@
     },
     "nix-bundle-appimage_16": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
-        "nix-bundle-dir": "nix-bundle-dir_33",
+        "logos-nix": "logos-nix_238",
+        "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -33769,25 +39001,22 @@
     },
     "nix-bundle-appimage_17": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
-        "nix-bundle-dir": "nix-bundle-dir_36",
+        "logos-nix": "logos-nix_246",
+        "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
           "nix-bundle-appimage",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -33798,12 +39027,9 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_248",
-        "nix-bundle-dir": "nix-bundle-dir_39",
+        "logos-nix": "logos-nix_251",
+        "nix-bundle-dir": "nix-bundle-dir_40",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -33826,22 +39052,31 @@
     },
     "nix-bundle-appimage_19": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
-        "nix-bundle-dir": "nix-bundle-dir_42",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -33881,19 +39116,31 @@
     "nix-bundle-appimage_20": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -33915,43 +39162,28 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
+        "logos-nix": "logos-nix_292",
+        "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -33962,16 +39194,13 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_297",
-        "nix-bundle-dir": "nix-bundle-dir_47",
+        "logos-nix": "logos-nix_305",
+        "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -33994,13 +39223,12 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_310",
-        "nix-bundle-dir": "nix-bundle-dir_50",
+        "logos-nix": "logos-nix_325",
+        "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -34023,12 +39251,10 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
-        "nix-bundle-dir": "nix-bundle-dir_53",
+        "logos-nix": "logos-nix_333",
+        "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-package-manager-module",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -34053,21 +39279,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -34091,7 +39314,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34102,7 +39324,6 @@
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34113,7 +39334,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34139,11 +39359,10 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_374",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34172,11 +39391,10 @@
     },
     "nix-bundle-appimage_28": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_387",
         "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34202,11 +39420,10 @@
     },
     "nix-bundle-appimage_29": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_407",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -34260,8 +39477,188 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_416",
-        "nix-bundle-dir": "nix-bundle-dir_68",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_31": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_32": {
+      "inputs": {
+        "logos-nix": "logos-nix_452",
+        "nix-bundle-dir": "nix-bundle-dir_71",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_33": {
+      "inputs": {
+        "logos-nix": "logos-nix_465",
+        "nix-bundle-dir": "nix-bundle-dir_74",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_34": {
+      "inputs": {
+        "logos-nix": "logos-nix_485",
+        "nix-bundle-dir": "nix-bundle-dir_77",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_35": {
+      "inputs": {
+        "logos-nix": "logos-nix_493",
+        "nix-bundle-dir": "nix-bundle-dir_80",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -34285,205 +39682,36 @@
         "type": "github"
       }
     },
-    "nix-bundle-appimage_31": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_32": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nix-bundle-dir": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nix-bundle-dir"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776974156,
-        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_33": {
-      "inputs": {
-        "logos-nix": "logos-nix_457",
-        "nix-bundle-dir": "nix-bundle-dir_73",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_34": {
-      "inputs": {
-        "logos-nix": "logos-nix_470",
-        "nix-bundle-dir": "nix-bundle-dir_76",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
-    "nix-bundle-appimage_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_490",
-        "nix-bundle-dir": "nix-bundle-dir_79",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-appimage",
-        "type": "github"
-      }
-    },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
-        "nix-bundle-dir": "nix-bundle-dir_82",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1774455478,
-        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -34494,20 +39722,46 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
-        "nix-bundle-dir": "nix-bundle-dir_84",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
         "nixpkgs": [
-          "nix-bundle-appimage",
-          "logos-nix",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785798386,
-        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
+        "lastModified": 1776974156,
+        "narHash": "sha256-VzzOBZEIuPWaqDf8YgmVW/VbA3POFwLU5qAruMFw/JA=",
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
-        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
+        "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
         "type": "github"
       },
       "original": {
@@ -34518,10 +39772,47 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
-        "nix-bundle-dir": "nix-bundle-dir_86",
+        "logos-nix": "logos-nix_534",
+        "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_547",
+        "nix-bundle-dir": "nix-bundle-dir_88",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "logos-nix",
@@ -34572,6 +39863,112 @@
         "owner": "logos-co",
         "repo": "nix-bundle-appimage",
         "rev": "8fcc56b5afcc313ca917cf3487be082ae2f0184c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_40": {
+      "inputs": {
+        "logos-nix": "logos-nix_567",
+        "nix-bundle-dir": "nix-bundle-dir_91",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_41": {
+      "inputs": {
+        "logos-nix": "logos-nix_575",
+        "nix-bundle-dir": "nix-bundle-dir_94",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_42": {
+      "inputs": {
+        "logos-nix": "logos-nix_586",
+        "nix-bundle-dir": "nix-bundle-dir_96",
+        "nixpkgs": [
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785798386,
+        "narHash": "sha256-TYle4kdzZE3VgOuhHyE7qncyvjI7KEV7wCmL+KTm7/M=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "04a3cf89f8ba3dc20f08a8e2b6c337a672bceda7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "type": "github"
+      }
+    },
+    "nix-bundle-appimage_43": {
+      "inputs": {
+        "logos-nix": "logos-nix_592",
+        "nix-bundle-dir": "nix-bundle-dir_98",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1774455478,
+        "narHash": "sha256-S8IMfdDc+2Wwri0krLDsIUwSqmwanmvHAJWHOFo8ykk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-appimage",
+        "rev": "2428125a4a1b34ad9119efa97edb98676283e3da",
         "type": "github"
       },
       "original": {
@@ -34638,19 +40035,19 @@
     "nix-bundle-appimage_7": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -34673,7 +40070,7 @@
     "nix-bundle-appimage_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34683,7 +40080,7 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34693,7 +40090,7 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34719,10 +40116,10 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_126",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34787,6 +40184,31 @@
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_100": {
+      "inputs": {
+        "logos-nix": "logos-nix_597",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -34886,13 +40308,13 @@
     "nix-bundle-dir_14": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -34915,7 +40337,7 @@
     "nix-bundle-dir_15": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34925,7 +40347,7 @@
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34951,9 +40373,9 @@
     },
     "nix-bundle-dir_16": {
       "inputs": {
-        "logos-nix": "logos-nix_124",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -34981,9 +40403,9 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_129",
+        "logos-nix": "logos-nix_127",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35011,9 +40433,9 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_128",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35042,9 +40464,9 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_133",
+        "logos-nix": "logos-nix_131",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35099,9 +40521,9 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_142",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35126,9 +40548,9 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_141",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -35154,9 +40576,9 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_155",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -35180,9 +40602,9 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_162",
+        "logos-nix": "logos-nix_160",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -35206,9 +40628,9 @@
     },
     "nix-bundle-dir_24": {
       "inputs": {
-        "logos-nix": "logos-nix_163",
+        "logos-nix": "logos-nix_161",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -35233,9 +40655,9 @@
     },
     "nix-bundle-dir_25": {
       "inputs": {
-        "logos-nix": "logos-nix_166",
+        "logos-nix": "logos-nix_164",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -35260,20 +40682,25 @@
     },
     "nix-bundle-dir_26": {
       "inputs": {
-        "logos-nix": "logos-nix_170",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -35284,12 +40711,24 @@
     },
     "nix-bundle-dir_27": {
       "inputs": {
-        "logos-nix": "logos-nix_171",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -35309,32 +40748,15 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_175",
+        "logos-nix": "logos-nix_201",
         "nixpkgs": [
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_29": {
-      "inputs": {
-        "logos-nix": "logos-nix_176",
-        "nixpkgs": [
-          "logos-package-manager",
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35346,6 +40768,36 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_29": {
+      "inputs": {
+        "logos-nix": "logos-nix_206",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -35382,16 +40834,18 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_207",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-design-system",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -35411,51 +40865,15 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_210",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_32": {
-      "inputs": {
-        "logos-nix": "logos-nix_211",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
@@ -35476,17 +40894,14 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_33": {
+    "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_219",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -35506,18 +40921,41 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_34": {
+    "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_220",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_34": {
+      "inputs": {
+        "logos-nix": "logos-nix_234",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35539,43 +40977,11 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_220",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_36": {
-      "inputs": {
-        "logos-nix": "logos-nix_229",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -35595,15 +41001,41 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_36": {
+      "inputs": {
+        "logos-nix": "logos-nix_240",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_37": {
       "inputs": {
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_243",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35625,11 +41057,34 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_244",
+        "logos-nix": "logos-nix_247",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-package-downloader-module",
+          "logos-package-downloader",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_248",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-package-downloader",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35641,32 +41096,6 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_39": {
-      "inputs": {
-        "logos-nix": "logos-nix_249",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -35704,23 +41133,19 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
+        "logos-nix": "logos-nix_252",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -35733,10 +41158,7 @@
       "inputs": {
         "logos-nix": "logos-nix_253",
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35758,20 +41180,25 @@
     },
     "nix-bundle-dir_42": {
       "inputs": {
-        "logos-nix": "logos-nix_257",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-appimage",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -35782,12 +41209,24 @@
     },
     "nix-bundle-dir_43": {
       "inputs": {
-        "logos-nix": "logos-nix_258",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -35807,16 +41246,17 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_288",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-design-system",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -35836,33 +41276,26 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_293",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -35873,15 +41306,16 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-        "logos-nix": "logos-nix_293",
+        "logos-nix": "logos-nix_294",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35903,46 +41337,16 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_298",
+        "logos-nix": "logos-nix_297",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_299",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -35962,18 +41366,42 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_49": {
+    "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_306",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_307",
+        "nixpkgs": [
+          "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36022,40 +41450,11 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_321",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_51": {
-      "inputs": {
-        "logos-nix": "logos-nix_312",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36075,13 +41474,40 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_52": {
+    "nix-bundle-dir_51": {
       "inputs": {
         "logos-nix": "logos-nix_326",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_52": {
+      "inputs": {
+        "logos-nix": "logos-nix_327",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36103,38 +41529,12 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_54": {
-      "inputs": {
-        "logos-nix": "logos-nix_332",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36154,14 +41554,36 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_54": {
+      "inputs": {
+        "logos-nix": "logos-nix_334",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_55": {
       "inputs": {
         "logos-nix": "logos-nix_335",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager-module",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36185,14 +41607,12 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -36216,7 +41636,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36227,7 +41646,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36253,10 +41671,9 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_370",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36284,10 +41701,9 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_376",
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36340,10 +41756,9 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36372,10 +41787,9 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_379",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36404,10 +41818,9 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36432,10 +41845,9 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_389",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -36461,10 +41873,9 @@
     },
     "nix-bundle-dir_64": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_403",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -36488,10 +41899,9 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_408",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -36515,10 +41925,9 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -36543,10 +41952,9 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_412",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -36571,21 +41979,27 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_417",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
-          "logos-package-downloader",
-          "nix-bundle-appimage",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1776974030,
-        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -36596,13 +42010,26 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_418",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
-          "logos-package-downloader",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -36653,18 +42080,18 @@
     },
     "nix-bundle-dir_70": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_448",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
-          "logos-design-system",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -36684,35 +42111,27 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_453",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-design-system",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -36723,16 +42142,17 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36754,48 +42174,17 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_74": {
-      "inputs": {
-        "logos-nix": "logos-nix_459",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36815,19 +42204,44 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_75": {
+    "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_462",
+        "logos-nix": "logos-nix_466",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_75": {
+      "inputs": {
+        "logos-nix": "logos-nix_467",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -36849,67 +42263,10 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_471",
+        "logos-nix": "logos-nix_481",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_472",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_78": {
-      "inputs": {
-        "logos-nix": "logos-nix_486",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "nix-bundle-dir",
@@ -36931,12 +42288,12 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_79": {
+    "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
+        "logos-nix": "logos-nix_486",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -36950,6 +42307,62 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_487",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_79": {
+      "inputs": {
+        "logos-nix": "logos-nix_490",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -36987,24 +42400,21 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "package_downloader",
+          "logos-package-downloader",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1776974030,
+        "narHash": "sha256-lQ/tc/owFa7Yjh8MXe0Fn2GodQXVGmpOZwe5gBEcENA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "4937262f55cf8be942263255dd0801e3e3878bc9",
         "type": "github"
       },
       "original": {
@@ -37018,10 +42428,8 @@
         "logos-nix": "logos-nix_495",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "package_downloader",
+          "logos-package-downloader",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -37043,10 +42451,117 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_83": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_84": {
+      "inputs": {
+        "logos-nix": "logos-nix_530",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_85": {
+      "inputs": {
+        "logos-nix": "logos-nix_535",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-appimage",
           "nixpkgs"
@@ -37066,12 +42581,18 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_83": {
+    "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
@@ -37092,81 +42613,19 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_84": {
-      "inputs": {
-        "logos-nix": "logos-nix_510",
-        "nixpkgs": [
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_85": {
-      "inputs": {
-        "logos-nix": "logos-nix_511",
-        "nixpkgs": [
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786576773,
-        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_516",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_517",
+        "logos-nix": "logos-nix_539",
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "logos-package-manager",
+          "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -37188,10 +42647,42 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_548",
         "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_549",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -37238,6 +42729,261 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_90": {
+      "inputs": {
+        "logos-nix": "logos-nix_563",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_568",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_92": {
+      "inputs": {
+        "logos-nix": "logos-nix_569",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_93": {
+      "inputs": {
+        "logos-nix": "logos-nix_572",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_94": {
+      "inputs": {
+        "logos-nix": "logos-nix_576",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_95": {
+      "inputs": {
+        "logos-nix": "logos-nix_577",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_96": {
+      "inputs": {
+        "logos-nix": "logos-nix_587",
+        "nixpkgs": [
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_97": {
+      "inputs": {
+        "logos-nix": "logos-nix_588",
+        "nixpkgs": [
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_593",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_594",
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-lgx": {
       "inputs": {
         "logos-nix": "logos-nix_16",
@@ -37267,11 +43013,11 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_218",
-        "logos-package": "logos-package_20",
-        "nix-bundle-dir": "nix-bundle-dir_35",
+        "logos-nix": "logos-nix_208",
+        "logos-package": "logos-package_18",
+        "nix-bundle-dir": "nix-bundle-dir_31",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37299,11 +43045,11 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
-        "logos-package": "logos-package_22",
-        "nix-bundle-dir": "nix-bundle-dir_38",
+        "logos-nix": "logos-nix_232",
+        "logos-package": "logos-package_20",
+        "nix-bundle-dir": "nix-bundle-dir_34",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -37326,11 +43072,11 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_251",
-        "logos-package": "logos-package_24",
-        "nix-bundle-dir": "nix-bundle-dir_41",
+        "logos-nix": "logos-nix_241",
+        "logos-package": "logos-package_22",
+        "nix-bundle-dir": "nix-bundle-dir_37",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37354,11 +43100,11 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
-        "logos-package": "logos-package_26",
-        "nix-bundle-dir": "nix-bundle-dir_46",
+        "logos-nix": "logos-nix_286",
+        "logos-package": "logos-package_25",
+        "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37385,11 +43131,11 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
-        "logos-package": "logos-package_28",
-        "nix-bundle-dir": "nix-bundle-dir_49",
+        "logos-nix": "logos-nix_295",
+        "logos-package": "logos-package_27",
+        "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37417,11 +43163,11 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
-        "logos-package": "logos-package_30",
-        "nix-bundle-dir": "nix-bundle-dir_52",
+        "logos-nix": "logos-nix_319",
+        "logos-package": "logos-package_29",
+        "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -37444,11 +43190,11 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
-        "logos-package": "logos-package_32",
-        "nix-bundle-dir": "nix-bundle-dir_55",
+        "logos-nix": "logos-nix_328",
+        "logos-package": "logos-package_31",
+        "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37472,12 +43218,11 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
-        "logos-package": "logos-package_34",
+        "logos-nix": "logos-nix_368",
+        "logos-package": "logos-package_33",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37504,12 +43249,11 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_378",
-        "logos-package": "logos-package_36",
+        "logos-nix": "logos-nix_377",
+        "logos-package": "logos-package_35",
         "nix-bundle-dir": "nix-bundle-dir_61",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37537,12 +43281,11 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
-        "logos-package": "logos-package_38",
+        "logos-nix": "logos-nix_401",
+        "logos-package": "logos-package_37",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -37593,12 +43336,11 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_411",
-        "logos-package": "logos-package_40",
+        "logos-nix": "logos-nix_410",
+        "logos-package": "logos-package_39",
         "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37622,12 +43364,12 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
-        "logos-package": "logos-package_42",
-        "nix-bundle-dir": "nix-bundle-dir_72",
+        "logos-nix": "logos-nix_446",
+        "logos-package": "logos-package_41",
+        "nix-bundle-dir": "nix-bundle-dir_70",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37654,12 +43396,12 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
-        "logos-package": "logos-package_44",
-        "nix-bundle-dir": "nix-bundle-dir_75",
+        "logos-nix": "logos-nix_455",
+        "logos-package": "logos-package_43",
+        "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_manager",
+          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37687,9 +43429,131 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_484",
-        "logos-package": "logos-package_46",
-        "nix-bundle-dir": "nix-bundle-dir_78",
+        "logos-nix": "logos-nix_479",
+        "logos-package": "logos-package_45",
+        "nix-bundle-dir": "nix-bundle-dir_76",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_24": {
+      "inputs": {
+        "logos-nix": "logos-nix_488",
+        "logos-package": "logos-package_47",
+        "nix-bundle-dir": "nix-bundle-dir_79",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_25": {
+      "inputs": {
+        "logos-nix": "logos-nix_528",
+        "logos-package": "logos-package_49",
+        "nix-bundle-dir": "nix-bundle-dir_84",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_26": {
+      "inputs": {
+        "logos-nix": "logos-nix_537",
+        "logos-package": "logos-package_51",
+        "nix-bundle-dir": "nix-bundle-dir_87",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_manager",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_27": {
+      "inputs": {
+        "logos-nix": "logos-nix_561",
+        "logos-package": "logos-package_53",
+        "nix-bundle-dir": "nix-bundle-dir_90",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37713,11 +43577,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-lgx_24": {
+    "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
-        "logos-package": "logos-package_48",
-        "nix-bundle-dir": "nix-bundle-dir_81",
+        "logos-nix": "logos-nix_570",
+        "logos-package": "logos-package_55",
+        "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -37742,11 +43606,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-lgx_25": {
+    "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_518",
-        "logos-package": "logos-package_51",
-        "nix-bundle-dir": "nix-bundle-dir_88",
+        "logos-nix": "logos-nix_595",
+        "logos-package": "logos-package_58",
+        "nix-bundle-dir": "nix-bundle-dir_100",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37827,11 +43691,11 @@
     },
     "nix-bundle-lgx_5": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
-        "logos-package": "logos-package_9",
+        "logos-nix": "logos-nix_120",
+        "logos-package": "logos-package_8",
         "nix-bundle-dir": "nix-bundle-dir_16",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37858,11 +43722,11 @@
     },
     "nix-bundle-lgx_6": {
       "inputs": {
-        "logos-nix": "logos-nix_131",
-        "logos-package": "logos-package_11",
+        "logos-nix": "logos-nix_129",
+        "logos-package": "logos-package_10",
         "nix-bundle-dir": "nix-bundle-dir_19",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -37890,11 +43754,11 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_155",
-        "logos-package": "logos-package_13",
+        "logos-nix": "logos-nix_153",
+        "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_22",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -37917,11 +43781,11 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_164",
-        "logos-package": "logos-package_15",
+        "logos-nix": "logos-nix_162",
+        "logos-package": "logos-package_14",
         "nix-bundle-dir": "nix-bundle-dir_25",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37945,11 +43809,11 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_209",
-        "logos-package": "logos-package_18",
-        "nix-bundle-dir": "nix-bundle-dir_32",
+        "logos-nix": "logos-nix_199",
+        "logos-package": "logos-package_16",
+        "nix-bundle-dir": "nix-bundle-dir_28",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38003,9 +43867,68 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_404",
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_20",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468957,
+        "narHash": "sha256-4RHdcjR9s6sJATHyPWz1zr+9Il2IIbkUown37jtrNAk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "rev": "e1947b07a88548cfff605bf335e0342c2e98bbaf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "type": "github"
+      }
+    },
+    "nix-bundle-logos-module-install_11": {
+      "inputs": {
+        "logos-nix": "logos-nix_449",
+        "logos-package-manager": "logos-package-manager_18",
+        "nix-bundle-lgx": "nix-bundle-lgx_22",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468957,
+        "narHash": "sha256-4RHdcjR9s6sJATHyPWz1zr+9Il2IIbkUown37jtrNAk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "rev": "e1947b07a88548cfff605bf335e0342c2e98bbaf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-logos-module-install",
+        "type": "github"
+      }
+    },
+    "nix-bundle-logos-module-install_12": {
+      "inputs": {
+        "logos-nix": "logos-nix_482",
+        "logos-package-manager": "logos-package-manager_20",
+        "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -38029,11 +43952,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_11": {
+    "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
-        "logos-package-manager": "logos-package-manager_18",
-        "nix-bundle-lgx": "nix-bundle-lgx_22",
+        "logos-nix": "logos-nix_531",
+        "logos-package-manager": "logos-package-manager_21",
+        "nix-bundle-lgx": "nix-bundle-lgx_26",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -38061,11 +43984,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_12": {
+    "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_487",
-        "logos-package-manager": "logos-package-manager_20",
-        "nix-bundle-lgx": "nix-bundle-lgx_24",
+        "logos-nix": "logos-nix_564",
+        "logos-package-manager": "logos-package-manager_23",
+        "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -38089,11 +44012,11 @@
         "type": "github"
       }
     },
-    "nix-bundle-logos-module-install_13": {
+    "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
-        "logos-package-manager": "logos-package-manager_22",
-        "nix-bundle-lgx": "nix-bundle-lgx_25",
+        "logos-nix": "logos-nix_589",
+        "logos-package-manager": "logos-package-manager_25",
+        "nix-bundle-lgx": "nix-bundle-lgx_29",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -38144,11 +44067,11 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_125",
+        "logos-nix": "logos-nix_123",
         "logos-package-manager": "logos-package-manager_4",
         "nix-bundle-lgx": "nix-bundle-lgx_6",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38175,11 +44098,11 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_158",
+        "logos-nix": "logos-nix_156",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_8",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -38202,11 +44125,11 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_212",
-        "logos-package-manager": "logos-package-manager_8",
+        "logos-nix": "logos-nix_202",
+        "logos-package-manager": "logos-package-manager_7",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38233,11 +44156,11 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
-        "logos-package-manager": "logos-package-manager_10",
+        "logos-nix": "logos-nix_235",
+        "logos-package-manager": "logos-package-manager_9",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -38260,11 +44183,11 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_294",
-        "logos-package-manager": "logos-package-manager_12",
+        "logos-nix": "logos-nix_289",
+        "logos-package-manager": "logos-package-manager_11",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38291,11 +44214,11 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
-        "logos-package-manager": "logos-package-manager_14",
+        "logos-nix": "logos-nix_322",
+        "logos-package-manager": "logos-package-manager_13",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -38318,12 +44241,11 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_371",
         "logos-package-manager": "logos-package-manager_15",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38387,21 +44309,18 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -38425,7 +44344,6 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38436,7 +44354,6 @@
         ],
         "nix-bundle-dir": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38447,7 +44364,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38475,6 +44391,94 @@
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781728271,
+        "narHash": "sha256-LHdzXrQPJCEVLC9cntURu8O9qSPPrePoVBzZd0UFGN0=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "rev": "d6b0cc518e599ab7a52258bf3e1f8123c8a01d31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "type": "github"
+      }
+    },
+    "nix-bundle-macos-app_13": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nix-bundle-dir": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nix-bundle-dir"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781728271,
+        "narHash": "sha256-LHdzXrQPJCEVLC9cntURu8O9qSPPrePoVBzZd0UFGN0=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "rev": "d6b0cc518e599ab7a52258bf3e1f8123c8a01d31",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-macos-app",
+        "type": "github"
+      }
+    },
+    "nix-bundle-macos-app_14": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
           "package_manager",
           "logos-module-builder",
           "logos-design-system",
@@ -38509,7 +44513,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-macos-app_13": {
+    "nix-bundle-macos-app_15": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -38559,9 +44563,9 @@
         "type": "github"
       }
     },
-    "nix-bundle-macos-app_14": {
+    "nix-bundle-macos-app_16": {
       "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_598",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -38653,19 +44657,19 @@
     "nix-bundle-macos-app_4": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -38688,7 +44692,7 @@
     "nix-bundle-macos-app_5": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38698,7 +44702,7 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38708,7 +44712,7 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38735,19 +44739,19 @@
     "nix-bundle-macos-app_6": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -38770,7 +44774,7 @@
     "nix-bundle-macos-app_7": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38780,7 +44784,7 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38790,7 +44794,7 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38817,19 +44821,19 @@
     "nix-bundle-macos-app_8": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -38852,7 +44856,7 @@
     "nix-bundle-macos-app_9": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38862,7 +44866,7 @@
           "logos-nix"
         ],
         "nix-bundle-dir": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -38872,7 +44876,7 @@
           "nix-bundle-dir"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -45408,7 +51412,247 @@
         "type": "github"
       }
     },
+    "nixpkgs-windows_465": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_466": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_467": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_468": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_469": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
     "nixpkgs-windows_47": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_470": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_471": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_472": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_473": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_474": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_475": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_476": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_477": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_478": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_479": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -45440,7 +51684,327 @@
         "type": "github"
       }
     },
+    "nixpkgs-windows_480": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_481": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_482": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_483": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_484": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_485": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_486": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_487": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_488": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_489": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
     "nixpkgs-windows_49": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_490": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_491": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_492": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_493": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_494": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_495": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_496": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_497": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_498": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_499": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -45488,7 +52052,327 @@
         "type": "github"
       }
     },
+    "nixpkgs-windows_500": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_501": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_502": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_503": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_504": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_505": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_506": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_507": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_508": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_509": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
     "nixpkgs-windows_51": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_510": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_511": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_512": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_513": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_514": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_515": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_516": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_517": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_518": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_519": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -45520,7 +52404,247 @@
         "type": "github"
       }
     },
+    "nixpkgs-windows_520": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_521": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_522": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_523": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_524": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_525": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_526": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_527": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_528": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_529": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
     "nixpkgs-windows_53": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_530": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_531": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_532": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_533": {
+      "locked": {
+        "lastModified": 1782723713,
+        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "type": "github"
+      }
+    },
+    "nixpkgs-windows_534": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -53840,7 +60964,295 @@
         "type": "github"
       }
     },
+    "nixpkgs_522": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_523": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_524": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_525": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_526": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_527": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_528": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_529": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_53": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_530": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_531": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_532": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_533": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_534": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_535": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_536": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_537": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_538": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_539": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -53872,7 +61284,327 @@
         "type": "github"
       }
     },
+    "nixpkgs_540": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_541": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_542": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_543": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_544": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_545": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_546": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_547": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_548": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_549": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_55": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_550": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_551": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_552": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_553": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_554": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_555": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_556": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_557": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_558": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_559": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -53904,7 +61636,327 @@
         "type": "github"
       }
     },
+    "nixpkgs_560": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_561": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_562": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_563": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_564": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_565": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_566": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_567": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_568": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_569": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_57": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_570": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_571": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_572": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_573": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_574": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_575": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_576": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_577": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_578": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_579": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -53936,7 +61988,311 @@
         "type": "github"
       }
     },
+    "nixpkgs_580": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_581": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_582": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_583": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_584": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_585": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_586": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_587": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_588": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_589": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_59": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_590": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_591": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_592": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_593": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_594": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_595": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_596": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_597": {
+      "locked": {
+        "lastModified": 1759036355,
+        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_598": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -54658,7 +63014,7 @@
     },
     "package_downloader": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_9",
+        "logos-module-builder": "logos-module-builder_11",
         "logos-package-downloader": "logos-package-downloader_2"
       },
       "locked": {
@@ -54677,8 +63033,8 @@
     },
     "package_manager": {
       "inputs": {
-        "logos-module-builder": "logos-module-builder_11",
-        "logos-package-manager": "logos-package-manager_21"
+        "logos-module-builder": "logos-module-builder_13",
+        "logos-package-manager": "logos-package-manager_24"
       },
       "locked": {
         "lastModified": 1787434680,
@@ -54720,9 +63076,9 @@
     },
     "process-stats_2": {
       "inputs": {
-        "logos-nix": "logos-nix_147",
+        "logos-nix": "logos-nix_145",
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -54747,9 +63103,9 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_224",
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -54774,9 +63130,9 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_311",
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -54801,7 +63157,34 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_393",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "process-stats",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452357,
+        "narHash": "sha256-rjKseurJfMtHLNnsgRcVu1Qc5Q5UgWYxjpf7DCJTreY=",
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "rev": "3e58e1c94b45803a15b29b29a112427efb2764ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "process-stats",
+        "type": "github"
+      }
+    },
+    "process-stats_6": {
+      "inputs": {
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_downloader",
@@ -54827,9 +63210,9 @@
         "type": "github"
       }
     },
-    "process-stats_6": {
+    "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_476",
+        "logos-nix": "logos-nix_553",
         "nixpkgs": [
           "logos-package-manager-ui",
           "package_manager",
@@ -54863,21 +63246,22 @@
         "logos-liblogos": "logos-liblogos",
         "logos-module": "logos-module_15",
         "logos-module-loader-qt": "logos-module-loader-qt",
-        "logos-nix": "logos-nix_88",
-        "logos-package": "logos-package_8",
+        "logos-modules-state-module": "logos-modules-state-module",
+        "logos-nix": "logos-nix_165",
+        "logos-package": "logos-package_15",
         "logos-package-downloader-module": "logos-package-downloader-module",
-        "logos-package-manager": "logos-package-manager_7",
+        "logos-package-manager": "logos-package-manager_10",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-        "logos-plugin-qt": "logos-plugin-qt_61",
-        "logos-protocol": "logos-protocol_74",
-        "logos-qt-mcp": "logos-qt-mcp_6",
-        "logos-qt-sdk": "logos-qt-sdk_32",
-        "logos-view-module-runtime": "logos-view-module-runtime_13",
-        "nix-bundle-appimage": "nix-bundle-appimage_37",
-        "nix-bundle-dir": "nix-bundle-dir_85",
-        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_13",
-        "nix-bundle-macos-app": "nix-bundle-macos-app_14",
+        "logos-plugin-qt": "logos-plugin-qt_71",
+        "logos-protocol": "logos-protocol_86",
+        "logos-qt-mcp": "logos-qt-mcp_7",
+        "logos-qt-sdk": "logos-qt-sdk_37",
+        "logos-view-module-runtime": "logos-view-module-runtime_15",
+        "nix-bundle-appimage": "nix-bundle-appimage_42",
+        "nix-bundle-dir": "nix-bundle-dir_97",
+        "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
+        "nix-bundle-macos-app": "nix-bundle-macos-app_16",
         "nixpkgs": [
           "logos-nix",
           "nixpkgs"
@@ -54910,7 +63294,6 @@
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -54930,6 +63313,56 @@
       }
     },
     "rust-overlay_11": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784870759,
+        "narHash": "sha256-ZaS89rj5u6pygXKDRfCzPMGm7isJxLsSeIAR5EaSyu8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "471286a5fadc690e2408ad854eb32325f5e74da7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_12": {
+      "inputs": {
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "package_downloader",
+          "logos-module-builder",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784870759,
+        "narHash": "sha256-ZaS89rj5u6pygXKDRfCzPMGm7isJxLsSeIAR5EaSyu8=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "471286a5fadc690e2408ad854eb32325f5e74da7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "rust-overlay_13": {
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54956,7 +63389,7 @@
         "type": "github"
       }
     },
-    "rust-overlay_12": {
+    "rust-overlay_14": {
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -55005,7 +63438,7 @@
     "rust-overlay_3": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -55031,7 +63464,7 @@
     "rust-overlay_4": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -55053,7 +63486,7 @@
     "rust-overlay_5": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -55079,7 +63512,7 @@
     "rust-overlay_6": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -55101,7 +63534,7 @@
     "rust-overlay_7": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -55127,7 +63560,7 @@
     "rust-overlay_8": {
       "inputs": {
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "logos-package-manager-module",
           "logos-module-builder",
           "nixpkgs"
         ]
@@ -55150,7 +63583,6 @@
       "inputs": {
         "nixpkgs": [
           "logos-package-manager-ui",
-          "package_downloader",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     logos-package-manager-module.url = "github:logos-co/logos-package-manager-module";
     logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
+    logos-modules-state-module.url = "github:logos-co/logos-modules-state-module";
     logos-package.url = "github:logos-co/logos-package";
     logos-package-manager-ui.url = "github:logos-co/logos-package-manager-ui";
     logos-design-system.url = "github:logos-co/logos-design-system";
@@ -36,7 +37,7 @@
     extra-trusted-public-keys = [ "public:l4HrXgL4nw246+LBh2SOJyhz64BoGegOYLheT/iIAPU=" ];
   };
 
-  outputs = { self, nixpkgs, logos-nix, logos-cpp-sdk, logos-protocol, logos-plugin-qt, logos-qt-sdk, logos-module, logos-module-loader-qt, logos-liblogos, logos-package-manager, logos-package-manager-module, logos-package-downloader-module, logos-capability-module, logos-package, logos-package-manager-ui, logos-design-system, logos-view-module-runtime, logos-qt-mcp, nix-bundle-logos-module-install, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app }:
+  outputs = { self, nixpkgs, logos-nix, logos-cpp-sdk, logos-protocol, logos-plugin-qt, logos-qt-sdk, logos-module, logos-module-loader-qt, logos-liblogos, logos-package-manager, logos-package-manager-module, logos-package-downloader-module, logos-capability-module, logos-modules-state-module, logos-package, logos-package-manager-ui, logos-design-system, logos-view-module-runtime, logos-qt-mcp, nix-bundle-logos-module-install, nix-bundle-dir, nix-bundle-appimage, nix-bundle-macos-app }:
     let
       systems = [ "aarch64-darwin" "x86_64-darwin" "aarch64-linux" "x86_64-linux" ];
       # Build info (version + commit hashes) baked into the app binary so
@@ -63,6 +64,7 @@
           { name = "logos-package-manager-module"; commit = revOf logos-package-manager-module; }
           { name = "logos-package-downloader-module"; commit = revOf logos-package-downloader-module; }
           { name = "logos-capability-module"; commit = revOf logos-capability-module; }
+          { name = "logos-modules-state-module"; commit = revOf logos-modules-state-module; }
           { name = "logos-package"; commit = revOf logos-package; }
           { name = "logos-package-manager-ui"; commit = revOf logos-package-manager-ui; }
           { name = "logos-design-system"; commit = revOf logos-design-system; }
@@ -112,6 +114,7 @@
         logosLiblogosPortable = logos-liblogos.packages.${system}.portable;
         logosPackageManagerModuleLibPortable = logos-package-manager-module.packages.${system}.lib-portable;
         logosCapabilityModule = logos-capability-module.packages.${system}.default;
+        logosModulesStateModule = logos-modules-state-module.packages.${system}.default;
         logosPackageLib = logos-package.packages.${system}.lib;
         # Headers-only output (include/ with logos/semver.hpp + semver/, no
         # library). The app's AppsModel includes the shared semver comparator;
@@ -150,7 +153,7 @@
       });
     in
     {
-      packages = forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
+      packages = forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
         let
           # Common configuration
           common = import ./nix/default.nix {
@@ -183,12 +186,18 @@
             logosPackageManagerModuleLib
             logosPackageDownloaderModuleLib
             logosCapabilityModule
+            # The module lifecycle registry. liblogos feeds it load/unload/crash
+            # as sequenced facts, which is what lets a consumer stop polling --
+            # PackageCoordinator's settle-timer inference is what this replaces.
+            # Optional by construction: absent, the feed never arms.
+            logosModulesStateModule
             packageManagerUIPlugin
           ];
           installedDistributed = map installPortable [
             logosPackageManagerModuleLibPortable
             logosPackageDownloaderModuleLib
             logosCapabilityModule
+            logosModulesStateModule
             packageManagerUIPlugin
           ];
 


### PR DESCRIPTION
Added to `installedDev` and `installedDistributed`, so the GUI ships the same module surface as the CLI — the property logos-logoscore-cli's flake comment claims, and which would otherwise have quietly stopped being true.

This is the module that replaces the polling. `PackageCoordinator` infers module lifecycle from package-install events plus a settle timer because there was nothing else to infer it from; `modules_state` is that something else.

**Bundling does not change `PackageCoordinator`** — that is a later change. It makes the data available to make it.

Optional by construction: absent, liblogos' feed never arms and costs nothing.

## Depends on

logos-co/logos-liblogos#193 for the auto-load. Without it the module ships and sits in `modules/` unloaded.