### PR TITLE
Fix/MCP UI app manager automation object names

### DIFF
--- a/src/Basecamp/AppManager/AppManagerView.qml
+++ b/src/Basecamp/AppManager/AppManagerView.qml
@@ -207,7 +207,7 @@ Rectangle {
                     // AND there are no local-only installed rows to fall back on.
                     // If either exists, we render the grid instead.
                     EmptyView {
-                        objectName: "appManager.emptyView"
+                        objectName: "appManager.noReposView"
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         visible: root.repositories.length === 0
@@ -303,6 +303,7 @@ Rectangle {
 
     // Global loading overlay — matches Package Manager UI's Reload feedback.
     LoadingOverlay {
+        objectName: "appManager.loadingOverlay"
         anchors.fill: parent
         visible: root.loading
     }

--- a/src/Basecamp/AppManager/AppManagerView.qml
+++ b/src/Basecamp/AppManager/AppManagerView.qml
@@ -294,6 +294,23 @@ Rectangle {
                                 onAppManageRequested: (name, url) => root.manageAppRequested(name, url)
                                 onAppUninstallRequested: (name, url) => root.uninstallAppRequested(name, url)
                             }
+
+                            // Empty-search state — every section above hides
+                            // itself when the search matches nothing, so fill
+                            // the viewport with feedback instead of a blank
+                            // panel. Search-only: an empty search keeps the
+                            // no-repos EmptyView / category filtering as-is.
+                            EmptyView {
+                                objectName: "appManager.emptyView"
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: gridScroll.height
+                                visible: d.searchText.length > 0
+                                         && root.appsProxy !== null
+                                         && root.appsProxy.visibleCount === 0
+
+                                title: qsTr("No apps match your search.")
+                                subtitle: qsTr("Try a different search term.")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Add the missing automation objectNames to the App Manager QML views.

## Test plan

- [x] `nix build .#app` succeeds
- [x] `nix build .#smoke-test -L` passes
- [x] `nix build .#integration-test -L` passes (if UI-visible)
- [x] Doctests pass (`nix build .#doctests -L` if touched)

## Checklist

- [x] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [x] No unrelated changes bundled in
- [x] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [x] Uncommitted binaries, screenshots, or `.DS_Store` files removed