### PR TITLE
Fix/MCP UI app manager empty search feedback

### DIFF
--- a/src/Basecamp/AppManager/AppManagerView.qml
+++ b/src/Basecamp/AppManager/AppManagerView.qml
@@ -294,6 +294,23 @@ Rectangle {
                                 onAppManageRequested: (name, url) => root.manageAppRequested(name, url)
                                 onAppUninstallRequested: (name, url) => root.uninstallAppRequested(name, url)
                             }
+
+                            // Empty-search state — every section above hides
+                            // itself when the search matches nothing, so fill
+                            // the viewport with feedback instead of a blank
+                            // panel. Search-only: an empty search keeps the
+                            // no-repos EmptyView / category filtering as-is.
+                            EmptyView {
+                                objectName: "appManager.emptyView"
+                                Layout.fillWidth: true
+                                Layout.preferredHeight: gridScroll.height
+                                visible: d.searchText.length > 0
+                                         && root.appsProxy !== null
+                                         && root.appsProxy.visibleCount === 0
+
+                                title: qsTr("No apps match your search.")
+                                subtitle: qsTr("Try a different search term.")
+                            }
                         }
                     }
                 }


### PR DESCRIPTION


## Summary

Add show an empty-search message in the App Manager when a non-empty search matches no apps.

## Test plan

- [x] `nix build .#app` succeeds
- [x] `nix build .#smoke-test -L` passes
- [x] `nix build .#integration-test -L` passes (if UI-visible)
- [x] Doctests pass (`nix build .#doctests -L` if touched)

## Checklist

- [x] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [x] No unrelated changes bundled in
- [x] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [x] Uncommitted binaries, screenshots, or `.DS_Store` files removed