### PR TITLE
feat: provide routing when an intent caller calls a request that rout…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,7 @@ Load-bearing invariants, all covered by tests:
 - **The requester's `requestId` never leaves its side.** The broker mints a separate `dispatchId`. A response is accepted only if the id is pending, the phase is `Dispatched`, **and** the responding endpoint is pointer-identical to the recorded provider — pointer, not name, so a reloaded app cannot inherit in-flight requests. A failed guard drops silently.
 - **`unavailable` merges "nothing installed" with "denied"**, floored at 400 ms, so an app cannot enumerate what you have installed. The install suggestion answers the requester immediately and never completes its request, for the same reason.
 - **One dialog at a time.** A second request queues rather than repointing a chooser under the user's cursor — that would be a consent swap.
+- **Only a provider's own answer moves the user.** Answering returns them to the requester; the other five `finish()` paths (deadlines, endpoint death, abandon, refusals) never navigate, because nothing on screen would explain it. `"handoff": true` on a `provides` entry opts out entirely — the request existed to take the user somewhere and leave them there. It governs navigation only; when the provider answers (on arrival, or when the user marks the action done) is independent.
 
 Where things are: dialogs in `src/Basecamp/Shell/Intent*Dialog.qml`, wiring in `Shell/OverlayDialogs.qml`, fixtures in `tests/fixtures/intents/`. Full design and known limitations: `docs/app-to-app-intents.md`.
 

--- a/app/IntentBroker.cpp
+++ b/app/IntentBroker.cpp
@@ -15,6 +15,9 @@ constexpr int kSweepIntervalMs = 250;
 // then vanished, long enough that a real person reading a dialog never hits it.
 // Reported as `cancelled`: from the requester's side that is what it looks like.
 constexpr int kChooserBackstopMs = 10 * 60 * 1000;
+// Auto-return timings.
+constexpr qint64 kReturnBreakerWindowMs   = 3 * 1000;
+constexpr int    kReturnBreakerLimit      = 5;
 
 QString mintDispatchId()
 {
@@ -52,6 +55,16 @@ void IntentBroker::setTimeouts(int activationMs, int responseMs, int errorFloorM
     m_activationTimeoutMs = activationMs;
     m_responseTimeoutMs = responseMs;
     m_errorFloorMs = errorFloorMs;
+}
+
+void IntentBroker::setReturnDwellFloorMs(int ms)
+{
+    m_returnDwellFloorMs = ms;
+}
+
+void IntentBroker::setReturnBreakerCooldownMs(int ms)
+{
+    m_returnBreakerCooldownMs = ms;
 }
 
 int IntentBroker::pendingCount() const
@@ -181,7 +194,8 @@ void IntentBroker::startRequest(const QString& dispatchId)
     // it is a fact about the caller's own manifest and leaks nothing about what
     // else is installed.
     if (requesterName.isEmpty() || !m_registry->declaresUse(requesterName, intent)) {
-        finish(dispatchId, false, QVariant(), logos::intent::errNotDeclared());
+        finish(dispatchId, false, QVariant(), logos::intent::errNotDeclared(),
+               CompletionPath::Rejected);
         return;
     }
 
@@ -361,8 +375,11 @@ void IntentBroker::cancelChooser(const QString& dispatchId)
     if (it == m_pending.end() || it->phase != Phase::AwaitingChoice)
         return;
 
-    // Indistinguishable from a provider-side cancel, deliberately.
-    finish(dispatchId, false, QVariant(), logos::intent::errCancelled());
+    // Indistinguishable from a provider-side cancel, deliberately. Rejected,
+    // not ProviderResponse: no dispatch happened, so the user never left the
+    // requester and there is nothing to return from.
+    finish(dispatchId, false, QVariant(), logos::intent::errCancelled(),
+           CompletionPath::Rejected);
 }
 
 void IntentBroker::chooseProvider(const QString& dispatchId, const QString& providerName)
@@ -531,11 +548,22 @@ void IntentBroker::dispatchTo(const QString& dispatchId)
     it->phase = Phase::Dispatched;
     it->phaseSinceMs = nowMs();
 
+    // SNAPSHOT, not a lookup at completion. rebuild() clears and refills the
+    // registry whenever plugins change, so reading this on the way out could
+    // answer differently from the declaration that was in force when the user
+    // was sent here — the navigation contract would change under a request in
+    // flight. Same reason `provider` above is a pointer taken now.
+    it->isHandoff = m_registry
+                 && m_registry->isHandoff(it->providerName, it->intent);
+
     // Not for the shell: it has no widget to raise, and its handler does its
     // own navigating (the repositories intent lands the user on Settings).
     // Calling presentApp here would either no-op or fight that.
-    if (m_presenter && !isShellProvider(it->providerName))
+    if (m_presenter && !isShellProvider(it->providerName)) {
         m_presenter->presentApp(it->providerName);
+        it->didNavigate = true;
+        it->navigatedAtMs = nowMs();
+    }
 
     const int receivers = provider->deliverRequest(dispatchId, it->intent,
                                                    it->params, it->requesterName);
@@ -577,18 +605,20 @@ bool IntentBroker::submitResponse(IntentEndpoint* from, const QString& dispatchI
         qWarning().noquote()
             << "IntentBroker: provider" << it->providerName
             << "answered" << it->intent << "with a non-canonical payload — dropped";
-        finish(dispatchId, false, QVariant(), logos::intent::errFailed());
+        finish(dispatchId, false, QVariant(), logos::intent::errFailed(),
+               CompletionPath::ProviderResponse);
         return false;
     }
 
     // A provider may only report cancelled / timeout / failed / bad_request.
     // Free text and the two broker-only codes are coerced here, at the boundary.
     const QString normalized = logos::intent::normalizeError(ok, error);
-    finish(dispatchId, ok, data, normalized);
+    finish(dispatchId, ok, data, normalized, CompletionPath::ProviderResponse);
     return true;
 }
 
-void IntentBroker::failWithFloor(const QString& dispatchId, const QString& errorCode)
+void IntentBroker::failWithFloor(const QString& dispatchId, const QString& errorCode,
+                                 CompletionPath path)
 {
     auto it = m_pending.find(dispatchId);
     if (it == m_pending.end())
@@ -597,20 +627,22 @@ void IntentBroker::failWithFloor(const QString& dispatchId, const QString& error
     const qint64 elapsed = nowMs() - it->acceptedAtMs;
     const qint64 remaining = static_cast<qint64>(m_errorFloorMs) - elapsed;
     if (remaining <= 0) {
-        finish(dispatchId, false, QVariant(), errorCode);
+        finish(dispatchId, false, QVariant(), errorCode, path);
         return;
     }
 
     // Hold it. A caller that gets "no" instantly has learned that nothing is
     // installed without ever being allowed to ask what is.
-    QTimer::singleShot(static_cast<int>(remaining), this, [this, dispatchId, errorCode]() {
+    QTimer::singleShot(static_cast<int>(remaining), this,
+                       [this, dispatchId, errorCode, path]() {
         if (m_pending.contains(dispatchId))
-            finish(dispatchId, false, QVariant(), errorCode);
+            finish(dispatchId, false, QVariant(), errorCode, path);
     });
 }
 
 void IntentBroker::finish(const QString& dispatchId, bool ok,
-                          const QVariant& data, const QString& error)
+                          const QVariant& data, const QString& error,
+                          CompletionPath path)
 {
     auto it = m_pending.find(dispatchId);
     if (it == m_pending.end())
@@ -638,6 +670,11 @@ void IntentBroker::finish(const QString& dispatchId, bool ok,
         }
     }
 
+    // Before delivering: the result landing in the requester's callback may
+    // change what it draws, and it should be drawing into a view the user is
+    // on their way back to rather than one behind them.
+    maybeReturnToRequester(request, path);
+
     deliver(request, logos::intent::makeEnvelope(ok, data, error));
 
     // The dialog may have just come free. Anything queued behind it gets its
@@ -646,6 +683,115 @@ void IntentBroker::finish(const QString& dispatchId, bool ok,
 
     if (m_pending.isEmpty())
         m_sweepTimer->stop();
+}
+
+// The return trip. Dispatching already moved the user to the provider; this is
+// the same move backwards, and the asymmetry — willing to take someone
+// somewhere, unwilling to bring them back — was the actual bug.
+//
+// Every guard here exists to keep the motion EXPLAINABLE. A shell that moves
+// for a reason the user can see reads as consequence; one that moves otherwise
+// reads as a fault.
+void IntentBroker::maybeReturnToRequester(const PendingRequest& request,
+                                          CompletionPath path)
+{
+    if (!m_presenter)
+        return;
+
+    // A tripped breaker re-arms once things have been quiet. Whatever the loop
+    // was, it is long over by then, and leaving the feature dead for the rest
+    // of a session because of one burst punishes the user for the shell's
+    // mistake.
+    if (m_returnsDisabled) {
+        if (nowMs() - m_returnsDisabledAtMs < m_returnBreakerCooldownMs)
+            return;
+        m_returnsDisabled = false;
+        m_returnTimestamps.clear();
+    }
+
+    // Only a provider answering. The other five paths — deadlines, an endpoint
+    // dying, an abandon, a rejection — happen for reasons that never reach the
+    // screen. Four of them never navigated either, so they are already no-ops;
+    // this keeps that explicit rather than incidental.
+    if (path != CompletionPath::ProviderResponse)
+        return;
+
+    // Nothing to return from.
+    if (!request.didNavigate)
+        return;
+
+    // A destination, not a transaction. Its `ok` meant "I have taken you
+    // there" — bouncing the user out is the opposite of what was asked for.
+    if (request.isHandoff)
+        return;
+
+    // Already moved on. Their current business outranks a request they left.
+    if (!m_presenter->isAppFrontmost(request.providerName))
+        return;
+
+    // Self-dispatch: an app servicing its own capability is internal
+    // navigation, and provider == requester makes this a no-op anyway.
+    if (request.providerName == request.requesterName)
+        return;
+
+    if (!m_presenter->isAppLoaded(request.requesterName))
+        return;
+
+    // Never out from under a dialog. Close to unreachable — the user answered
+    // by clicking in the provider, which a modal shell overlay would have
+    // blocked — but a background-triggered gate can raise one at any moment,
+    // and if it does we decline rather than retry: the sidebar is the fallback.
+    if (m_presenter->anyDialogOpen())
+        return;
+
+    // A provider that answers before the user could plausibly have acted turns
+    // the round trip into a flicker. Hold the floor so it reads as motion.
+    // Not a semantic test — `handoff` above is the semantic test; this is only
+    // about what the eye can follow.
+    const qint64 dwell = nowMs() - request.navigatedAtMs;
+    if (dwell < m_returnDwellFloorMs) {
+        const QString requesterName = request.requesterName;
+        const QString providerName = request.providerName;
+        QTimer::singleShot(static_cast<int>(m_returnDwellFloorMs - dwell), this,
+                           [this, requesterName, providerName]() {
+            // Re-check on the way out: the user has had the floor's worth of
+            // time to go somewhere else, and going somewhere else means they
+            // are no longer owed a ride home.
+            if (!m_presenter || m_returnsDisabled) return;
+            if (!m_presenter->isAppFrontmost(providerName)) return;
+            if (!m_presenter->isAppLoaded(requesterName)) return;
+            if (m_presenter->anyDialogOpen()) return;
+            m_presenter->presentApp(requesterName);
+        });
+        noteReturn();
+        return;
+    }
+
+    m_presenter->presentApp(request.requesterName);
+    noteReturn();
+}
+
+// Circuit breaker. Nested requests legitimately produce a couple of returns in
+// a row; a stream of them is a shell navigating on its own, and no guard above
+// can rule that out because nothing detects intent cycles and a provider may
+// submit while handling one.
+void IntentBroker::noteReturn()
+{
+    const qint64 now = nowMs();
+    m_returnTimestamps.append(now);
+    while (!m_returnTimestamps.isEmpty()
+           && now - m_returnTimestamps.first() > kReturnBreakerWindowMs)
+        m_returnTimestamps.removeFirst();
+
+    if (!m_returnsDisabled && m_returnTimestamps.size() > kReturnBreakerLimit) {
+        m_returnsDisabled = true;
+        m_returnsDisabledAtMs = now;
+        qWarning() << "IntentBroker:" << m_returnTimestamps.size()
+                   << "auto-returns within" << kReturnBreakerWindowMs
+                   << "ms — pausing auto-return for"
+                   << (m_returnBreakerCooldownMs / 1000)
+                   << "s. Apps can still be reached from the sidebar.";
+    }
 }
 
 void IntentBroker::deliver(const PendingRequest& request, const QVariantMap& envelope)
@@ -673,7 +819,8 @@ void IntentBroker::abandon(IntentEndpoint* from, const QStringList& requestIds)
             continue;
 
         it->requester = nullptr;
-        finish(dispatchId, false, QVariant(), logos::intent::errCancelled());
+        finish(dispatchId, false, QVariant(), logos::intent::errCancelled(),
+               CompletionPath::Abandoned);
     }
     if (m_pending.isEmpty())
         m_sweepTimer->stop();
@@ -699,14 +846,16 @@ void IntentBroker::endpointDestroyed(IntentEndpoint* endpoint)
             // surface, so a later provider response is simply dropped as an
             // unknown id.
             it->requester = nullptr;
-            finish(dispatchId, false, QVariant(), logos::intent::errCancelled());
+            finish(dispatchId, false, QVariant(), logos::intent::errCancelled(),
+                   CompletionPath::EndpointGone);
             continue;
         }
 
         if (it->provider == endpoint) {
             // "unavailable", not "failed": distinguishing "was reached and
             // died" from "was never there" leaks install state.
-            failWithFloor(dispatchId, logos::intent::errUnavailable());
+            failWithFloor(dispatchId, logos::intent::errUnavailable(),
+                          CompletionPath::EndpointGone);
         }
     }
 
@@ -732,13 +881,15 @@ void IntentBroker::sweep()
             // is 30 s before any QML compile, and some apps add their own
             // readiness gate on top.
             if (inPhase > m_activationTimeoutMs)
-                failWithFloor(dispatchId, logos::intent::errUnavailable());
+                failWithFloor(dispatchId, logos::intent::errUnavailable(),
+                              CompletionPath::Deadline);
             break;
 
         case Phase::Dispatched:
             if (inPhase > (it->providerHadHandler ? kChooserBackstopMs
                                                   : m_responseTimeoutMs))
-                finish(dispatchId, false, QVariant(), logos::intent::errTimeout());
+                finish(dispatchId, false, QVariant(), logos::intent::errTimeout(),
+                       CompletionPath::Deadline);
             break;
 
         case Phase::AwaitingChoice:
@@ -748,14 +899,16 @@ void IntentBroker::sweep()
             // mounted and then went away (view torn down, shell reloaded),
             // leaving a request nobody will ever answer.
             if (inPhase > kChooserBackstopMs)
-                failWithFloor(dispatchId, logos::intent::errCancelled());
+                failWithFloor(dispatchId, logos::intent::errCancelled(),
+                              CompletionPath::Deadline);
             break;
 
         case Phase::Accepted:
             // Queued dispatch runs on the next event-loop turn; if a request is
             // still here after the activation budget, something ate the post.
             if (inPhase > m_activationTimeoutMs)
-                failWithFloor(dispatchId, logos::intent::errUnavailable());
+                failWithFloor(dispatchId, logos::intent::errUnavailable(),
+                              CompletionPath::Deadline);
             break;
         }
     }

--- a/app/IntentBroker.h
+++ b/app/IntentBroker.h
@@ -41,6 +41,8 @@ public:
     virtual bool isAppLoaded(const QString& appName) const = 0;
     virtual void ensureAppLoaded(const QString& appName) = 0;
     virtual void presentApp(const QString& appName) = 0;
+    virtual bool isAppFrontmost(const QString& appName) const = 0;
+    virtual bool anyDialogOpen() const = 0;
 };
 
 // A seam rather than a signal because the broker must know whether a chooser is
@@ -124,6 +126,24 @@ public:
     // activation to prove the mute-provider case.
     void setTimeouts(int activationMs, int responseMs, int errorFloorMs);
 
+    // The two auto-return timings, overridable for the same reason as the
+    // deadlines above — a test should not pay wall-clock to watch either.
+    //
+    // Both are held apart from setTimeouts deliberately: a deadline decides
+    // whether a request SUCCEEDS, while these two only shape navigation. A
+    // wrong value here is a worse experience, never a wrong answer.
+    //
+    //   dwell floor (400 ms) — how long the user must have been on the
+    //     provider before a return is allowed. Legibility only: below it the
+    //     round trip is a flicker the eye reads as a glitch. `handoff` is the
+    //     semantic test; this is not.
+    //   breaker cooldown (30 s) — how long auto-return stays paused once the
+    //     runaway breaker trips. Tests drop it to milliseconds to prove it
+    //     re-arms at all, which is the half that matters: a permanent
+    //     disable was the original bug.
+    void setReturnDwellFloorMs(int ms);
+    void setReturnBreakerCooldownMs(int ms);
+
     int pendingCount() const;
 
 signals:
@@ -144,6 +164,19 @@ private:
         Dispatched
     };
 
+    // HOW a request ended, not just that it did. finish() is reached six ways
+    // and only one of them is something the user did: a provider answering.
+    // The rest — deadlines, an endpoint dying, a bridge dropping its callbacks,
+    // a payload refused — happen for reasons that never appear on screen, and
+    // navigating on those would move the shell with nothing to explain it.
+    enum class CompletionPath {
+        ProviderResponse,   // the provider answered; the user acted
+        Deadline,           // sweep() gave up
+        EndpointGone,       // provider or requester destroyed
+        Abandoned,          // the bridge dropped its callbacks
+        Rejected            // refused before or during dispatch
+    };
+
     struct PendingRequest {
         QString dispatchId;
         QString requestId;                 // the requester's own id
@@ -161,6 +194,9 @@ private:
         QVariantList choiceProviders;     // chooser payload
         qint64 acceptedAtMs = 0;
         qint64 phaseSinceMs = 0;
+        bool didNavigate = false;
+        qint64 navigatedAtMs = 0;
+        bool isHandoff = false;
     };
 
     void startRequest(const QString& dispatchId);
@@ -169,9 +205,13 @@ private:
     QString specViolation(const QString& providerName, const QString& intent,
                           const QVariantMap& params) const;
     void finish(const QString& dispatchId, bool ok, const QVariant& data,
-                const QString& error);
-    void failWithFloor(const QString& dispatchId, const QString& errorCode);
+                const QString& error, CompletionPath path);
+    void failWithFloor(const QString& dispatchId, const QString& errorCode,
+                       CompletionPath path = CompletionPath::Rejected);
     void deliver(const PendingRequest& request, const QVariantMap& envelope);
+    void maybeReturnToRequester(const PendingRequest& request,
+                                CompletionPath path);
+    void noteReturn();
     bool aChoiceIsOnScreen() const;
     void presentPendingChoice(const QString& dispatchId);
     void drainChoiceQueue();
@@ -194,6 +234,19 @@ private:
     QHash<QString, IntentEndpoint*> m_endpointsByName;
     QHash<QString, QStringList> m_activationQueue;
 
+    // Auto-return circuit breaker. Nothing in the broker detects intent cycles
+    // and a provider may submit while handling one, so nested requests can
+    // legitimately produce several returns in a row. A handful is a flow; a
+    // stream is a shell moving on its own, and the user must be able to get
+    // out of it.
+    QList<qint64> m_returnTimestamps;
+    bool m_returnsDisabled = false;
+    qint64 m_returnsDisabledAtMs = 0;
+    qint64 m_returnBreakerCooldownMs = kReturnBreakerCooldownMsDefault;
+    int m_returnDwellFloorMs = kReturnDwellFloorMsDefault;
+
+    static constexpr int    kReturnDwellFloorMsDefault      = 400;
+    static constexpr qint64 kReturnBreakerCooldownMsDefault = 30 * 1000;
     int m_activationTimeoutMs = 45000;
     int m_responseTimeoutMs = 20000;
     int m_errorFloorMs = 400;

--- a/app/IntentRegistry.cpp
+++ b/app/IntentRegistry.cpp
@@ -118,6 +118,7 @@ void IntentRegistry::reset()
     m_provides.clear();
     m_uses.clear();
     m_paramsSpec.clear();
+    m_handoff.clear();
     m_entries.clear();
     m_diagnostics.clear();
 }
@@ -133,6 +134,11 @@ void IntentRegistry::rebuild(const QMap<QString, QVariantMap>& plugins,
                                                   : m_uses.value(shell);
     const ProviderEntry shellEntry = shell.isEmpty() ? ProviderEntry()
                                                      : m_entries.value(shell);
+    QStringList shellHandoff;
+    for (const QString& intent : shellIntents) {
+        if (m_handoff.contains(shell + QLatin1Char('/') + intent))
+            shellHandoff.append(intent);
+    }
 
     // Clear and refill. Never incremental: a half-updated index is worse than
     // a slightly stale one, and every caller re-resolves on every request.
@@ -144,6 +150,8 @@ void IntentRegistry::rebuild(const QMap<QString, QVariantMap>& plugins,
         m_provides.insert(shell, shellIntents);
         if (!shellUses.isEmpty()) m_uses.insert(shell, shellUses);
         m_entries.insert(shell, shellEntry);
+        for (const QString& intent : shellHandoff)
+            m_handoff.insert(shell + QLatin1Char('/') + intent);
     }
 
     for (auto it = plugins.cbegin(); it != plugins.cend(); ++it)
@@ -218,6 +226,24 @@ void IntentRegistry::ingestRecord(const QString& moduleName,
         }
         if (!specs.isEmpty())
             m_paramsSpec.insert(moduleName + QLatin1Char('/') + intent, specs);
+
+        // Refused rather than coerced. `"handoff": "true"` is a string, and
+        // QVariant::toBool() would read it as true — silently giving a
+        // transactional intent the opposite navigation from the one its author
+        // wrote down. A diagnostic and the default is the honest answer.
+        const QVariant handoff = entry.value(QStringLiteral("handoff"));
+        if (handoff.isValid()) {
+            if (handoff.typeId() == QMetaType::Bool) {
+                if (handoff.toBool())
+                    m_handoff.insert(moduleName + QLatin1Char('/') + intent);
+            } else {
+                m_diagnostics.append(
+                    QStringLiteral("%1: '%2' declares handoff as %3, not a boolean "
+                                   "— ignored, treated as false")
+                        .arg(moduleName, intent,
+                             QString::fromUtf8(handoff.typeName())));
+            }
+        }
     }
     const QStringList uses = parseIntentArray(onDisk.value(QStringLiteral("uses")),
                                               moduleName, QStringLiteral("uses"),
@@ -299,6 +325,12 @@ QVariantList IntentRegistry::paramsSpecFor(const QString& moduleName,
     return m_paramsSpec.value(moduleName + QLatin1Char('/') + intent);
 }
 
+bool IntentRegistry::isHandoff(const QString& moduleName,
+                               const QString& intent) const
+{
+    return m_handoff.contains(moduleName + QLatin1Char('/') + intent);
+}
+
 bool IntentRegistry::isShellProvider(const QString& moduleName) const
 {
     return !m_shellModuleName.isEmpty() && moduleName == m_shellModuleName;
@@ -331,6 +363,7 @@ void IntentRegistry::registerShellUses(const QString& shellModuleName,
 
 void IntentRegistry::registerShellProvider(const QString& shellModuleName,
                                            const QStringList& intents,
+                                           const QStringList& handoffIntents,
                                            const QString& displayName,
                                            const QString& iconSource)
 {
@@ -347,6 +380,17 @@ void IntentRegistry::registerShellProvider(const QString& shellModuleName,
             continue;
         }
         accepted.append(intent);
+    }
+
+    // Only over intents that survived the grammar check: a hand-off flag on a
+    // name the registry refused would sit in the table describing nothing.
+    for (const QString& intent : handoffIntents) {
+        if (accepted.contains(intent))
+            m_handoff.insert(shellModuleName + QLatin1Char('/') + intent);
+        else
+            m_diagnostics.append(
+                QStringLiteral("shell: handoff declared for '%1', which is not a "
+                               "registered shell provider intent — ignored").arg(intent));
     }
 
     m_provides.insert(shellModuleName, accepted);

--- a/app/IntentRegistry.h
+++ b/app/IntentRegistry.h
@@ -2,6 +2,7 @@
 
 #include <QMap>
 #include <QObject>
+#include <QSet>
 #include <QString>
 #include <QStringList>
 #include <QVariantMap>
@@ -74,8 +75,14 @@ public:
 
     // The same for `provides`, and the only legitimate source of a "logos.*"
     // name — any disk record claiming one is refused.
+    // `handoffIntents` is the subset of `intents` that leaves the user with the
+    // shell rather than returning them. Declared rather than inferred: the
+    // repositories intent does not auto-return today only because the broker
+    // skips presentApp for shell providers, which is the right behaviour by an
+    // unrelated route.
     void registerShellProvider(const QString& shellModuleName,
                                const QStringList& intents,
+                               const QStringList& handoffIntents,
                                const QString& displayName,
                                const QString& iconSource);
 
@@ -102,6 +109,18 @@ public:
     // Each entry: { name, type, required, description }.
     QVariantList paramsSpecFor(const QString& moduleName,
                                const QString& intent) const;
+
+    // Does servicing this intent END, or does it hand the user off?
+    //
+    // A transaction returns control: the user acts, the provider answers, and
+    // the shell takes them back where they came from. A hand-off does not —
+    // the request's whole purpose was to put them somewhere and leave them
+    // there, so its `ok` means "I have taken you there", not "we are done".
+    //
+    // Same (provider, intent) key as paramsSpecFor, and for the same reason
+    // given there: two providers of one intent may legitimately differ, and
+    // there is no per-intent schema to appeal to. Absent means false.
+    bool isHandoff(const QString& moduleName, const QString& intent) const;
 
     // ── Installable providers — a SEPARATE table, deliberately ──────────
     //
@@ -158,5 +177,8 @@ private:
 
     // (moduleName, intent) -> [{name,type,required,description}]
     QHash<QString, QVariantList> m_paramsSpec;
+
+    // "moduleName/intent" for every provider entry declaring "handoff": true.
+    QSet<QString> m_handoff;
     QStringList m_diagnostics;
 };

--- a/app/MainUIBackend.cpp
+++ b/app/MainUIBackend.cpp
@@ -89,7 +89,11 @@ MainUIBackend::MainUIBackend(LogosAPI* logosAPI, logos::qt::QtLogosCore* core, Q
     // ui_qml app's bridge as it loads, before its QML runs.
     m_uiPluginManager->setIntentAdapter(m_intentAdapter);
 
-    m_intentPresenter = new UIPluginPresenter(m_uiPluginManager, this);
+    m_intentPresenter = new UIPluginPresenter(
+        m_uiPluginManager,
+        [this]() { return m_currentActiveSectionIndex; },
+        this);
+    m_intentPresenter->setDialogProbe([this]() { return m_overlayActive; });
     m_intentBroker->setPresenter(m_intentPresenter);
     wireIntents();
 
@@ -321,6 +325,7 @@ void MainUIBackend::refreshUiModules()
 }
 void MainUIBackend::onAppLauncherClicked(const QString& n)    { m_uiPluginManager->onAppLauncherClicked(n); }
 void MainUIBackend::setCurrentVisibleApp(const QString& n)    { m_uiPluginManager->setCurrentVisibleApp(n); }
+void MainUIBackend::setOverlayActive(bool active)             { m_overlayActive = active; }
 
 // PackageCoordinator — package_manager IPC and package-lifecycle cascade.
 void MainUIBackend::wireIntents()
@@ -457,9 +462,17 @@ void MainUIBackend::wireIntents()
     m_intentRegistry->registerShellUses(
         QStringLiteral("main_ui"), {QStringLiteral("packages.show")});
 
+    // repositories.manage is a HAND-OFF: it puts the user on the Settings
+    // repositories page and leaves them there for as long as they like, so its
+    // `ok` means "I have taken you there", not "we are done". Declared rather
+    // than left to fall out of the broker skipping presentApp for shell
+    // providers — that gives the right answer by an unrelated route, and stops
+    // doing so the day a shell intent is transactional. The confirm intents are
+    // not hand-offs: they are dialogs that resolve.
     m_intentRegistry->registerShellProvider(
         QStringLiteral("main_ui"),
         QStringList{QStringLiteral("logos.repositories.manage")} + kPackageConfirmIntents,
+        QStringList{QStringLiteral("logos.repositories.manage")},
         QStringLiteral("Logos"),
         QStringLiteral("qrc:/qt/qml/Basecamp/Icons/assets/settings.svg"));
 

--- a/app/MainUIBackend.h
+++ b/app/MainUIBackend.h
@@ -259,6 +259,12 @@ public slots:
     void onAppLauncherClicked(const QString& appName);
     void setCurrentVisibleApp(const QString& pluginName);
 
+    // Pushed from OverlayDialogs.qml's anyDialogOpen binding. Read by the
+    // intent presenter, which declines to auto-return while a dialog owns the
+    // screen. Not a Q_PROPERTY: nothing binds to it, and a property would
+    // invite QML to start driving navigation policy.
+    Q_INVOKABLE void setOverlayActive(bool active);
+
     Q_INVOKABLE void refreshRepositories();
     Q_INVOKABLE void refreshAppCatalog();
     Q_INVOKABLE void addRepository(const QString& url);
@@ -404,6 +410,7 @@ private:
 
     // Navigation state — the only state this facade class holds.
     int m_currentActiveSectionIndex;
+    bool m_overlayActive = false;
 
     // Intents. Construction order in the ctor is what decides destruction
     // order — see the comment there.

--- a/app/UIPluginPresenter.cpp
+++ b/app/UIPluginPresenter.cpp
@@ -1,12 +1,20 @@
 #include "UIPluginPresenter.h"
 
+#include "ShellSections.h"
 #include "UIPluginManager.h"
 
 UIPluginPresenter::UIPluginPresenter(UIPluginManager* uiPluginManager,
+                                     SectionFn sectionProvider,
                                      QObject* parent)
     : QObject(parent)
     , m_uiPluginManager(uiPluginManager)
+    , m_sectionProvider(std::move(sectionProvider))
 {
+}
+
+void UIPluginPresenter::setDialogProbe(std::function<bool()> probe)
+{
+    m_dialogProbe = std::move(probe);
 }
 
 bool UIPluginPresenter::isAppLoaded(const QString& appName) const
@@ -24,6 +32,39 @@ void UIPluginPresenter::presentApp(const QString& appName)
 {
     if (!m_uiPluginManager) return;
     m_uiPluginManager->activateApp(appName);
+}
+
+// BEING THE CURRENT APP AND BEING ON SCREEN ARE DIFFERENT QUESTIONS.
+// currentVisibleApp is not cleared when the user switches to Settings — the
+// sidebar deliberately keeps highlighting the app they were last in — so the
+// name check alone would report a backgrounded app as frontmost and let a
+// request drag someone out of Settings.
+bool UIPluginPresenter::isAppFrontmost(const QString& appName) const
+{
+    if (!m_uiPluginManager || appName.isEmpty())
+        return false;
+    if (m_uiPluginManager->currentVisibleApp() != appName)
+        return false;
+
+    // No provider means we cannot tell which section is up. Answer false: the
+    // only thing this gates is a navigation, and declining to move is the safe
+    // direction.
+    if (!m_sectionProvider)
+        return false;
+
+    const int section = m_sectionProvider();
+
+    // package_manager_ui is hoisted into the content stack as its own section
+    // rather than docked, so "frontmost" means that section is selected.
+    if (appName == QLatin1String("package_manager_ui"))
+        return section == ShellSection::PackageManager;
+
+    return section == ShellSection::Workspace;
+}
+
+bool UIPluginPresenter::anyDialogOpen() const
+{
+    return m_dialogProbe ? m_dialogProbe() : false;
 }
 
 

--- a/app/UIPluginPresenter.h
+++ b/app/UIPluginPresenter.h
@@ -4,6 +4,8 @@
 #include <QPointer>
 #include <QString>
 
+#include <functional>
+
 #include "IntentBroker.h"
 
 class UIPluginManager;
@@ -24,14 +26,21 @@ class UIPluginManager;
 class UIPluginPresenter : public QObject, public IntentPresenter {
     Q_OBJECT
 public:
+    using SectionFn = std::function<int()>;
     explicit UIPluginPresenter(UIPluginManager* uiPluginManager,
+                               SectionFn sectionProvider = {},
                                QObject* parent = nullptr);
 
     // ── IntentPresenter ─────────────────────────────────────────────────
     bool isAppLoaded(const QString& appName) const override;
     void ensureAppLoaded(const QString& appName) override;
     void presentApp(const QString& appName) override;
+    bool isAppFrontmost(const QString& appName) const override;
+    bool anyDialogOpen() const override;
+    void setDialogProbe(std::function<bool()> probe);
 
 private:
     QPointer<UIPluginManager> m_uiPluginManager;
+    SectionFn                 m_sectionProvider;
+    std::function<bool()>     m_dialogProbe;
 };

--- a/docs/app-to-app-intents.md
+++ b/docs/app-to-app-intents.md
@@ -211,7 +211,7 @@ Three consequences worth settling before any of this is built. `uses` cannot gat
 
 **Consent that scales, starting with "always use this app".** This shipped once and was pulled before release: remembering a pick is only half a feature without a way to see and undo it, and a preference you cannot revoke from the UI is worse than one you never made. Landing it properly needs a settings screen listing every remembered choice with a revoke button; intents that can never be remembered, since "always allow" must not apply to signing a transaction — a property of the intent, so it belongs in the registry above; and a rule that a remembered pick is only ever a shortcut past the chooser, never a different call shape, so the whole thing stays removable. Beyond that: a read/mutate distinction, which the vocabulary currently cannot express, and scoped grants — "this app, this intent, up to this amount, for 24 hours" — the shape that reduces prompts without reducing safety.
 
-**Getting back to whoever asked.** Dispatching brings the provider forward; nothing brings the user back — and after installing a suggested package you must return to the original app and repeat the action yourself. `IntentPresenter` deliberately has no "put it back", because a shell that navigates on its own fights whoever is driving — but the current state is the opposite extreme, where you approve something in a wallet and are left there with no thread home. What is missing is *offered* return: an affordance naming the app that asked, present while a request is in flight and briefly after, surviving navigation within the provider. Shell navigation only — no error code, no manifest field, no change to the frozen surface.
+**Getting back to whoever asked — partly answered.** A provider answering now returns the user to the requester, on either outcome; see §8. What is still missing is the *install* case: after installing a suggested package you must find the original app and repeat the action yourself. Nothing dispatched, so there is nothing to return from, and reviving a request the user was already told was `unavailable` would mean an app's action firing without them asking twice.
 
 **`cardinality: "all"` needs rethinking before it is built.** It is reserved in the grammar, but broadcast conflicts with the rest of the design in two ways: it tells providers the user never chose that a request happened, leaking the requester's activity to bystanders; and returning N results tells the caller how many providers exist, which is precisely the enumeration oracle that merging `unavailable` and flooring the timing exist to prevent. It needs a different consent shape — the user picking a *set* — and probably must not report a count. It is not simply pending implementation.
 
@@ -231,3 +231,43 @@ Three consequences worth settling before any of this is built. `uses` cannot gat
 | Dialogs | `logos-basecamp/src/Basecamp/Shell/Intent*Dialog.qml` |
 | App-author guide | `logos-tutorial/guide-intents-for-app-developers.md` |
 | Full reference | `logos-tutorial/logos-developer-guide.md` §8.5 |
+
+---
+
+## 8. Returning to the caller
+
+Dispatching moves the user to the provider. Not moving them back was an asymmetry, not a policy: the shell was willing to take someone somewhere and unwilling to bring them home.
+
+When a provider **answers** — `ok` either way; a cancel is the outcome that most wants a ride home — the shell returns the user to the requester. Navigation only: the result reaches the requester's callback exactly as before, and nothing about the frozen surface in `LogosIntent.h` changes.
+
+**Only that path navigates.** `finish()` is reached six ways and only `submitResponse` is something the user did. The `sweep` deadlines, the 400 ms `failWithFloor`, `endpointDestroyed`, `abandon` and refused payloads all happen for reasons that never reach the screen — four of them never navigated in the first place, and the two that did would otherwise move the shell minutes later with nothing on it to explain why. The path is recorded as `CompletionPath` and carried into `finish()` for exactly this reason.
+
+Five further guards, each keeping the motion explainable rather than merely safe:
+
+| Guard | Prevents |
+|---|---|
+| `didNavigate` | "returning" from a request that displaced nobody — a shell provider, or anything that failed before dispatch |
+| `isHandoff` | bouncing the user out of a destination they were sent to |
+| `isAppFrontmost(provider)` | dragging back a user who already moved on |
+| `isAppLoaded(requester)` | navigating to an app that unloaded meanwhile; a return must never become a load |
+| `anyDialogOpen()` | navigating out from under a shell dialog |
+
+A **400 ms dwell floor** holds the return so a fast provider produces visible motion rather than a flicker; it is a legibility bound, not a semantic one — `handoff` is the semantic test. A **circuit breaker** (3 returns in 10 s) disables auto-return for the session: nothing detects intent cycles and a provider may submit while handling one, so the user must never be trapped in a shell moving on its own.
+
+**Hand-offs.** Not every intent is a transaction. Some exist to take the user somewhere and leave them: a page, a note, something they will watch on its own timescale. Their `ok` means "I have taken you there", not "we are done", and returning would undo the request. The provider declares it on the `provides` entry beside `params`:
+
+```json
+{ "intent": "some.intent", "handoff": true }
+```
+
+Absent means `false`. Per *(provider, intent)*, like `params` and for the same reason: two apps may implement one capability differently and there is no per-intent schema to appeal to. A non-boolean is refused into `diagnostics()` rather than coerced — `"handoff": "true"` would otherwise read as true and silently invert an author's intent. Two providers may disagree; the chosen one's declaration is the one that applies.
+
+**`handoff` governs navigation only.** When a provider answers is a separate, independent decision: on arrival when there is no completion to wait for, or when the user marks the action done — at which point the caller learns it really happened and the user still is not sent back. The one constraint is the deadline a provider that accepted already lives under: **10 minutes** before the backstop reports `timeout`. Ample for a button press, not for work waiting on a network or a chain, where the provider should answer once the work is *started* and let the caller read the outcome from its own data source.
+
+`logos.repositories.manage` is declared a hand-off in code, through `registerShellProvider`. It happens not to auto-return anyway — the broker never presents a shell provider, so `didNavigate` is false — but that is the right behaviour by an unrelated route, and it would stop holding the day a shell intent is transactional.
+
+**Not carried into the manifest.** `handoff` stays in the installed `metadata.json`, exactly like `params`, and `bundle.sh` copies intent names alone. A second copy in the signed manifest would be a bundle-time snapshot nothing reads and that can drift from the file actually enforced.
+
+**Why no return affordance.** An earlier draft had a floating "← Back to Chat" chip for every case auto-return declines. Dropped: every loaded app has a permanent sidebar icon, and plugin widgets are confined to the content stack, so a provider's own popup cannot cover the way back. The chip would have been a second escape hatch layered on one that cannot be blocked — at the cost of a component, a grace timer, bridge plumbing, and a placement constraint (`OverlayDialogs` must stay hidden when idle or it steals the Linux drag-and-drop pixmap). **That makes "app content cannot cover the sidebar" load-bearing**, and it is the kind of thing a later full-bleed workspace would quietly break.
+
+Known limits: wander off before the provider answers and there is no automatic return; the install-offer flow has none, as above; and a return lands you on the app, not on where you were inside it — in-app position survives only because nothing here unloads anything.

--- a/docs/project.md
+++ b/docs/project.md
@@ -445,7 +445,7 @@ An app requests a capability by name; the shell decides who services it. Basecam
 | `app/IntentBridgeAdapter`, `app/ShellIntent*` | Bind each UI plugin's `LogosQmlBridge` to the broker; re-emit prompts as QML signals. |
 | `src/Basecamp/Shell/Intent*Dialog.qml` | The chooser and the install suggestion. |
 
-Flow: `logos.request` → bridge → broker → registry resolves → user chooses → provider raised and handed the request → result routed back to the requester alone.
+Flow: `logos.request` → bridge → broker → registry resolves → user chooses → provider raised and handed the request → result routed back to the requester alone → user returned to the requester, unless the provider declared the intent a hand-off (`"handoff": true`) or the request ended some way the user cannot see the cause of.
 
 The requester's own `requestId` never leaves its side; the broker mints a separate `dispatchId` and gives only that to the provider. A response is accepted only when the id is pending, the phase is `Dispatched`, and the responding endpoint is pointer-identical to the recorded provider.
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -251,6 +251,7 @@ A UI App can request a *capability* without naming, linking against, or discover
 - Suggest an installable package when nothing on disk can service a request, while telling the requester only that nothing was available
 - Refuse a payload the chosen provider declared unusable, before it reaches that provider
 - Bring the chosen app to the foreground and deliver the request to it; return exactly one result to the requester
+- Return the user to the requester once the provider answers, on either outcome — unless the provider declared the intent a hand-off, meaning the request existed to take the user somewhere and leave them there. Never move the user for an outcome they cannot see the cause of: a timeout, a teardown, a refusal
 
 Requirements that constrain the above, rather than describing it:
 

--- a/doctests/basecamp-intents.test.yaml
+++ b/doctests/basecamp-intents.test.yaml
@@ -122,6 +122,7 @@ sections:
           - "intent_requester_demo"
           - "intent_provider_a"
           - "intent_provider_b"
+          - "intent_provider_manual"
 
   - title: "Refusal, the chooser, and isolation"
     step: true
@@ -222,6 +223,74 @@ sections:
               property: "lastHandled"
               value: ""
               text: "The unchosen provider is not merely ignored — it is never told. The broker mints a separate dispatch id for the provider it picked, so the requester's own id never leaves its side and no other app sees the request at all."
+
+            - name: "Ask for something a provider answers on a button press"
+              action: click_object
+              find_by: "objectName"
+              find_value: "btnManual"
+              text: "`test.manual` goes to a fixture that holds the request open until someone clicks. The two providers above answer on a timer, which proves routing but says nothing about *when* the user acts — and the return trip is defined by that moment."
+
+            - name: "Choose the manual provider"
+              action: click_object
+              find_by: "objectName"
+              find_value: "intentProvider_intent_provider_manual"
+
+            - name: "It holds the request rather than answering"
+              action: expect_property
+              find_by: "objectName"
+              find_value: "providerRootManual"
+              property: "lastHandled"
+              value: "waiting"
+              timeout: 45000
+              text: "The shell has moved the user here and is waiting. Note the ordering the next step depends on: dispatch presents the provider *before* delivering to it, so arriving is not evidence the handler has run — which is why this gate exists rather than clicking straight away."
+
+            - name: "Answer it"
+              action: click_object
+              find_by: "objectName"
+              find_value: "btnComplete"
+
+            - name: "The user is back with whoever asked"
+              action: expect_property
+              find_by: "objectName"
+              find_value: "requesterRoot"
+              property: "lastResult"
+              value: "ok:intent_provider_manual"
+              timeout: 45000
+              text: "Answering returns the user to the requester — the same move dispatch made, run backwards. Navigation only: the result still arrives exactly as before, which is what this property shows. A cancel returns them too; the outcome that most wants a way home is the one where the user changed their mind."
+
+            - name: "Ask for a hand-off instead"
+              action: click_object
+              find_by: "objectName"
+              find_value: "btnHandoff"
+              text: "`test.handoff` is serviced by the SAME app, holds the request open the same way, and answers with the same `ok:true` on the same button. The only difference is `\"handoff\": true` in its `metadata.json`."
+
+            - name: "Choose the manual provider again"
+              action: click_object
+              find_by: "objectName"
+              find_value: "intentProvider_intent_provider_manual"
+
+            - name: "It holds this one open too"
+              action: expect_property
+              find_by: "objectName"
+              find_value: "providerRootManual"
+              property: "lastHandled"
+              value: "waiting"
+              timeout: 45000
+              text: "WHEN a provider answers and WHETHER the shell then moves the user are independent. The first is the provider's business — answer on arrival, or wait for the user, as here. The second is all `handoff` controls."
+
+            - name: "Complete it the same way"
+              action: click_object
+              find_by: "objectName"
+              find_value: "btnComplete"
+
+            - name: "Answered, and the user stays"
+              action: expect_property
+              find_by: "objectName"
+              find_value: "providerRootManual"
+              property: "lastHandled"
+              value: "handed-off"
+              timeout: 45000
+              text: "Identical completion to the transaction above, opposite navigation. A hand-off's `ok` means \"the thing you sent me here for is done\", not \"send me back\" — the request existed to put the user here, so returning would undo it. From here the sidebar is the way back, chosen by the user rather than by the shell."
 
   - title: "What this proves"
     text: |

--- a/src/Basecamp/Shell/OverlayDialogs.qml
+++ b/src/Basecamp/Shell/OverlayDialogs.qml
@@ -46,7 +46,10 @@ Item {
 
     signal overlayActiveChanged(bool active)
 
-    onAnyDialogOpenChanged: root.overlayActiveChanged(anyDialogOpen)
+    onAnyDialogOpenChanged: {
+        root.overlayActiveChanged(anyDialogOpen)
+        backend.setOverlayActive(anyDialogOpen)
+    }
 
     QtObject {
         id: _dialogDeps

--- a/tests/fixtures/intents/intent_provider_a/Main.qml
+++ b/tests/fixtures/intents/intent_provider_a/Main.qml
@@ -8,10 +8,15 @@ import QtQuick
 // cannot be co-installed.
 //
 // It answers on a TIMER, not synchronously. A synchronous answer completes the
-// whole round trip inside one event-loop turn, so the broker's back-edge
-// returns the user to the requester before the provider has been painted —
-// making a correctly working system look like the chooser did nothing. A real
-// provider shows UI and responds after the user acts; this models that.
+// whole round trip inside one event-loop turn, so the user is returned to the
+// requester before the provider has been painted — making a correctly working
+// system look like the chooser did nothing. A real provider shows UI and
+// responds after the user acts; this models that.
+//
+// The shell now holds auto-return to a dwell floor for exactly this reason, so
+// the timer is no longer load-bearing for that. It stays because "answers after
+// the user acts" is what a provider does. To drive the return trip by hand, use
+// intent_provider_manual, which holds the request open until a button press.
 Rectangle {
     id: root
     // Unique per provider so a doctest can address each one directly with

--- a/tests/fixtures/intents/intent_provider_manual/Main.qml
+++ b/tests/fixtures/intents/intent_provider_manual/Main.qml
@@ -1,0 +1,165 @@
+import QtQuick
+
+// Intent test fixture — the manual provider.
+//
+// The other two fixtures answer on a timer, which is enough to prove routing
+// but hides the thing auto-return is actually about: WHEN the user acts. This
+// one holds the request open until a button is pressed, so the return trip can
+// be watched by hand rather than inferred from a property flipping.
+//
+// It provides one intent of each shape, and the pair is the point:
+//
+//   test.manual  — a transaction. You press a button when the work is done,
+//                  it answers, and the shell brings you back to the requester.
+//   test.handoff — the same, declaring "handoff": true. Identical button,
+//                  identical `ok:true` — and the shell leaves you here.
+//
+// BOTH hold the request open until you press something. When a provider
+// answers and whether the shell then moves you are independent: the first is
+// the provider's business, the second is all `handoff` controls. Answering on
+// arrival is reasonable for an intent with no completion at all (the shell's
+// own repositories page works that way), but it is not what the flag means,
+// and modelling it that way here hid the distinction behind two dead buttons.
+Rectangle {
+    id: root
+    objectName: "providerRootManual"
+    color: "#1e1e1e"
+
+    property string providerName: "intent_provider_manual"
+
+    // "waiting" while a request is open, then one of "handled" / "handed-off"
+    // / "cancelled". The UI test reads this to know the request arrived before
+    // pressing anything, and which shape completed.
+    property string lastHandled: ""
+    property string pendingRequestId: ""
+    property bool   pendingIsHandoff: false
+
+    // Who asked. HOST-ATTESTED — the shell fills this from the module name it
+    // loaded the requester under, not from anything in the payload, so it is
+    // the one identity here a caller cannot forge. Kept after the request ends
+    // so the completed states can still name it.
+    property string lastRequester: ""
+    property string pendingIntent: ""
+
+    function answer(ok, error) {
+        if (root.pendingRequestId === "") return;
+        root.lastHandled = !ok ? "cancelled"
+                               : (root.pendingIsHandoff ? "handed-off" : "handled");
+        logos.respond(root.pendingRequestId,
+                      ok,
+                      ok ? ({ provider: "intent_provider_manual" }) : ({}),
+                      error);
+        root.pendingRequestId = "";
+        root.pendingIsHandoff = false;
+    }
+
+    // The buttons are dead unless a request is actually open, so a stray click
+    // cannot manufacture a response for a dispatch that never happened.
+    readonly property bool awaitingAnswer: root.pendingRequestId !== ""
+
+    readonly property string statusLine: {
+        if (root.awaitingAnswer) {
+            return root.pendingIsHandoff
+                ? "Holding a HAND-OFF request. Press Complete when the action is "
+                + "really done — the requester gets its answer and you STAY here, "
+                + "because the intent declared \"handoff\": true."
+                : "Holding a request. Press Complete when the action is done — the "
+                + "requester gets its answer and the shell brings you BACK to it."
+        }
+        switch (root.lastHandled) {
+        case "handed-off":
+            return "Completed as a hand-off. The requester has its ok and you are "
+                 + "still here — that is the whole difference.\n\n"
+                 + "To see what it received, open Intent Requester from the sidebar."
+        case "handled":
+            return "Completed. You should have been returned to the requester."
+        case "cancelled":
+            return "Cancelled. Where you are now depends on which intent this was: "
+                 + "a hand-off leaves you here, a transaction takes you back."
+        default:
+            return "Idle. Ask for test.manual or test.handoff from the requester."
+        }
+    }
+
+    Column {
+        anchors.centerIn: parent
+        spacing: 8
+
+        Text {
+            objectName: "providerMarker"
+            color: "#ffffff"
+            text: "PROVIDER_MANUAL_VIEW " + root.lastHandled
+        }
+
+        Text {
+            objectName: "providerRequesterLine"
+            width: 340
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            color: "#8fb8d8"
+            visible: root.lastRequester !== ""
+            text: root.pendingIntent + "  ←  requested by  " + root.lastRequester
+        }
+
+        Text {
+            width: 340
+            wrapMode: Text.WordWrap
+            horizontalAlignment: Text.AlignHCenter
+            color: root.awaitingAnswer ? "#e0e0e0" : "#9a9a9a"
+            text: root.statusLine
+        }
+
+        Rectangle {
+            objectName: "btnComplete"
+            width: 200; height: 32
+            color: root.awaitingAnswer ? "#2f5d3a" : "#333333"
+            Text {
+                anchors.centerIn: parent
+                color: root.awaitingAnswer ? "#ffffff" : "#777777"
+                text: root.pendingIsHandoff ? "Complete (stay here)"
+                                            : "Complete (go back)"
+            }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.awaitingAnswer
+                onClicked: root.answer(true, "")
+            }
+        }
+
+        Rectangle {
+            objectName: "btnCancel"
+            width: 200; height: 32
+            color: root.awaitingAnswer ? "#5d2f2f" : "#333333"
+            Text {
+                anchors.centerIn: parent
+                color: root.awaitingAnswer ? "#ffffff" : "#777777"
+                text: "Cancel request"
+            }
+            MouseArea {
+                anchors.fill: parent
+                enabled: root.awaitingAnswer
+                onClicked: root.answer(false, "cancelled")
+            }
+        }
+    }
+
+    Connections {
+        target: logos
+        function onIntentRequested(requestId, intent, params, requesterName) {
+            // Both shapes wait for the user. The only thing read off the intent
+            // is which one it is, so the banner and the button can say what
+            // pressing Complete will do — the shell decides the rest from the
+            // provider's own `handoff` declaration, not from anything here.
+            //
+            // Worth knowing when holding a request open for real work: a
+            // provider that accepted has 10 minutes before the backstop reports
+            // `timeout` to the requester. Fine for a button press, not for
+            // something waiting on a network or a chain.
+            root.pendingRequestId = requestId;
+            root.pendingIsHandoff = (intent === "test.handoff");
+            root.lastRequester = requesterName;
+            root.pendingIntent = intent;
+            root.lastHandled = "waiting";
+        }
+    }
+}

--- a/tests/fixtures/intents/intent_provider_manual/metadata.json
+++ b/tests/fixtures/intents/intent_provider_manual/metadata.json
@@ -1,0 +1,19 @@
+{
+  "name": "intent_provider_manual",
+  "display_name": "Manual Provider",
+  "version": "1.0.0",
+  "description": "Intent test fixture (test artifact, not a real app)",
+  "type": "ui_qml",
+  "view": "Main.qml",
+  "dependencies": [],
+  "category": "misc",
+  "provides": [
+    {
+      "intent": "test.manual"
+    },
+    {
+      "intent": "test.handoff",
+      "handoff": true
+    }
+  ]
+}

--- a/tests/fixtures/intents/intent_requester_demo/Main.qml
+++ b/tests/fixtures/intents/intent_requester_demo/Main.qml
@@ -181,6 +181,26 @@ Rectangle {
             MouseArea { anchors.fill: parent; onClicked: root.requestRoundTrip() }
         }
 
+        // ── Auto-return, drivable by hand ──────────────────────────────
+        //
+        // Both go to intent_provider_manual, which is the only provider of
+        // either. Same `ok:true` comes back from both; only the provider's
+        // "handoff" declaration differs, and that is what decides whether the
+        // shell brings you back here or leaves you there.
+        Rectangle {
+            objectName: "btnManual"
+            width: 200; height: 32; color: "#333333"
+            Text { anchors.centerIn: parent; color: "#ffffff"; text: "Manual (returns here)" }
+            MouseArea { anchors.fill: parent; onClicked: root.request("test.manual") }
+        }
+
+        Rectangle {
+            objectName: "btnHandoff"
+            width: 200; height: 32; color: "#333333"
+            Text { anchors.centerIn: parent; color: "#ffffff"; text: "Hand-off (stays there)" }
+            MouseArea { anchors.fill: parent; onClicked: root.request("test.handoff") }
+        }
+
         // NOT in metadata.json — must yield not_declared.
         Rectangle {
             objectName: "btnUndeclared"

--- a/tests/fixtures/intents/intent_requester_demo/metadata.json
+++ b/tests/fixtures/intents/intent_requester_demo/metadata.json
@@ -16,6 +16,12 @@
     },
     {
       "intent": "test.roundtrip"
+    },
+    {
+      "intent": "test.manual"
+    },
+    {
+      "intent": "test.handoff"
     }
   ]
 }

--- a/tests/fixtures/intents/stage.sh
+++ b/tests/fixtures/intents/stage.sh
@@ -13,13 +13,14 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PLUGINS="$USER_DIR/plugins"
 
 mkdir -p "$PLUGINS"
-for app in intent_requester_demo intent_provider_a intent_provider_b; do
+for app in intent_requester_demo intent_provider_a intent_provider_b intent_provider_manual; do
     # Human label the chooser shows — deliberately distinct from the module
     # name so the test can tell which string the dialog rendered.
     case "$app" in
         intent_requester_demo) disp="Intent Requester" ;;
         intent_provider_a)     disp="Provider A" ;;
         intent_provider_b)     disp="Provider B" ;;
+        intent_provider_manual) disp="Manual Provider" ;;
         *)                     disp="$app" ;;
     esac
     dest="$PLUGINS/$app"

--- a/tests/intent_broker_test.cpp
+++ b/tests/intent_broker_test.cpp
@@ -95,10 +95,33 @@ public:
     QStringList loaded;
     QStringList ensureCalls;
     QStringList presented;
+    QString     frontmost;
+    bool        dialogOpen = false;
 
     bool isAppLoaded(const QString& appName) const override { return loaded.contains(appName); }
     void ensureAppLoaded(const QString& appName) override { ensureCalls.append(appName); }
-    void presentApp(const QString& appName) override { presented.append(appName); }
+
+    // Presenting an app makes it the one on screen — modelling the real shell,
+    // where the return trip's own presentApp is what clears the frontmost
+    // provider. Without this a test could not tell a return from a no-op.
+    void presentApp(const QString& appName) override
+    {
+        presented.append(appName);
+        frontmost = appName;
+    }
+
+    bool isAppFrontmost(const QString& appName) const override
+    {
+        return !appName.isEmpty() && frontmost == appName;
+    }
+    bool anyDialogOpen() const override { return dialogOpen; }
+
+    // "provider was raised, then the requester was raised again" — the shape a
+    // completed round trip leaves behind.
+    bool returnedTo(const QString& requester) const
+    {
+        return presented.size() >= 2 && presented.last() == requester;
+    }
 };
 
 QString writeApp(QTemporaryDir& root, const QString& dirName, const QByteArray& json)
@@ -182,6 +205,24 @@ private slots:
     void testInstallableProvidersNeverReachResolve();
     void testSecondChoiceQueuesInsteadOfRepointingTheDialog();
     void testAmbiguousWithChooserAsksAndRoutesTheChoice();
+
+    // ── Auto-return ─────────────────────────────────────────────────────
+    void testProviderResponseReturnsToRequester();
+    void testCancelledResponseAlsoReturns();
+    void testHandoffProviderLeavesTheUserThere();
+    void testTimeoutNeverReturns();
+    void testProviderDeathNeverReturns();
+    void testUserWhoMovedOnIsNotDraggedBack();
+    void testDialogOpenSuppressesTheReturn();
+    void testUnloadedRequesterIsNotPresented();
+    void testShellProviderNeverReturns();
+    void testReturnBreakerStopsRunawayNavigation();
+    void testOrdinaryUseDoesNotTripTheBreaker();
+    void testBreakerRecoversAfterQuiet();
+    void testDwellFloorDelaysTheReturn();
+    void testRequesterUnloadedDuringDwellIsNotPresented();
+    void testUserWhoMovesOnDuringDwellIsNotDraggedBack();
+    void testDialogOpenedDuringDwellSuppressesTheReturn();
 };
 
 void TestIntentBroker::buildTwoProviderWorld(QTemporaryDir& root, IntentRegistry& registry)
@@ -273,7 +314,7 @@ void TestIntentBroker::testRestrictedRequesterIsDeniedIndistinguishably()
 
     // The shell really does provide it — so a leak here would be observable.
     registry.registerShellProvider(QStringLiteral("main_ui"),
-        { QStringLiteral("logos.packages.confirm_uninstall") },
+        { QStringLiteral("logos.packages.confirm_uninstall") }, {},
         QStringLiteral("Logos"), QString());
     registry.restrictIntentToRequesters(
         QStringLiteral("logos.packages.confirm_uninstall"),
@@ -818,7 +859,7 @@ void TestIntentBroker::testShellProviderIsNeverLoadedOrPresented()
     registry.rebuild(plugins, [](const QString& n) { return n; },
                              [](const QString&) { return QString(); });
     registry.registerShellProvider(QStringLiteral("main_ui"),
-                                   {QStringLiteral("logos.repositories.manage")},
+                                   {QStringLiteral("logos.repositories.manage")}, {},
                                    QStringLiteral("Logos"), QString());
 
 
@@ -1375,6 +1416,403 @@ void TestIntentBroker::testAnAppProvidingItsOwnIntentSkipsTheChooser()
     QVERIFY(chooser.presented.isEmpty());
     QCOMPARE(pmEndpoint.requests.size(), 1);
     QCOMPARE(otherEndpoint.requests.size(), 0);
+}
+
+// ── Auto-return ──────────────────────────────────────────────────────────────
+//
+// Dispatch already moves the user to the provider. These are about the move
+// back, and nearly all of them are about NOT making it: the guard set exists so
+// the shell only navigates for a reason the user can see on screen.
+
+namespace {
+
+// chat_ui uses two intents; wallet_ui provides one as a transaction and one as
+// a hand-off. Everything below turns on which of the two was asked for.
+struct ReturnWorld {
+    QTemporaryDir root;
+    IntentRegistry registry;
+    FakePresenter presenter;
+    FakeChooser chooser;
+    FakeEndpoint chatEndpoint;
+    FakeEndpoint walletEndpoint;
+    std::unique_ptr<IntentBroker> broker;
+
+    ReturnWorld()
+    {
+        const QString chat = writeApp(root, QStringLiteral("chat"),
+            R"({"uses":[{"intent":"wallet.send"},{"intent":"wallet.open"}]})");
+        const QString wallet = writeApp(root, QStringLiteral("wallet"),
+            R"({"provides":[{"intent":"wallet.send"},
+                            {"intent":"wallet.open","handoff":true}]})");
+        registry.rebuild({ { QStringLiteral("chat_ui"),   plugin(chat) },
+                           { QStringLiteral("wallet_ui"), plugin(wallet) } },
+                         nullptr, nullptr);
+
+        presenter.loaded << QStringLiteral("chat_ui") << QStringLiteral("wallet_ui");
+        // The user starts in the requester, which is where a request comes from.
+        presenter.frontmost = QStringLiteral("chat_ui");
+
+        broker = std::make_unique<IntentBroker>(&registry, &presenter);
+        broker->setTimeouts(1000, 400, 20);
+        broker->setReturnDwellFloorMs(20);
+        broker->setChooser(&chooser);
+        broker->registerEndpoint(QStringLiteral("chat_ui"), &chatEndpoint);
+        broker->registerEndpoint(QStringLiteral("wallet_ui"), &walletEndpoint);
+    }
+
+    // Submit, answer the chooser, and land on the provider. Returns the
+    // dispatchId the provider must answer with.
+    QString dispatch(const QString& intent)
+    {
+        submitAndConfirm(*broker, chooser, &chatEndpoint, QStringLiteral("req-1"),
+                         intent, QStringLiteral("wallet_ui"));
+        return walletEndpoint.requests.isEmpty()
+                 ? QString()
+                 : walletEndpoint.requests.last().dispatchId;
+    }
+};
+
+} // namespace
+
+void TestIntentBroker::testProviderResponseReturnsToRequester()
+{
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+    QVERIFY(!dispatchId.isEmpty());
+
+    // Dispatch put the user in the wallet, and left them there.
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true,
+                             QVariantMap{ { QStringLiteral("tx"), QStringLiteral("0x1") } },
+                             QString());
+    spin(120);
+
+    QVERIFY2(w.presenter.returnedTo(QStringLiteral("chat_ui")),
+             "answering should have brought the user back to the requester");
+    // And the result still reached the requester — the return is navigation
+    // only, never a substitute for delivering.
+    QCOMPARE(w.chatEndpoint.results.size(), 1);
+}
+
+void TestIntentBroker::testCancelledResponseAlsoReturns()
+{
+    // Backing out is the outcome that most wants a ride home: the user decided
+    // not to do the thing, and leaving them parked in the provider afterwards
+    // is the worst of both.
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, false, QVariantMap{},
+                             QStringLiteral("cancelled"));
+    spin(120);
+
+    QVERIFY(w.presenter.returnedTo(QStringLiteral("chat_ui")));
+}
+
+void TestIntentBroker::testHandoffProviderLeavesTheUserThere()
+{
+    // Same instant ok:true as a transaction. The ONLY difference is the
+    // provider's declaration, and it must be the whole difference.
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.open"));
+    QVERIFY(!dispatchId.isEmpty());
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(120);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+    QCOMPARE(w.presenter.frontmost, QStringLiteral("wallet_ui"));
+    // Still answered. A hand-off completes its request like anything else; it
+    // just does not move the user.
+    QCOMPARE(w.chatEndpoint.results.size(), 1);
+}
+
+void TestIntentBroker::testTimeoutNeverReturns()
+{
+    // The case that rules out "just navigate on any terminal outcome". A
+    // deadline fires with nothing on screen to explain it, and for a provider
+    // that ACCEPTED the request it is the 10-minute backstop — long enough that
+    // the user has forgotten the request ever existed.
+    //
+    // Driven here through the mute-provider deadline instead, because that one
+    // is affordable to wait out. Same CompletionPath::Deadline, same
+    // didNavigate: the user was moved to the wallet and it never answered.
+    ReturnWorld w;
+    w.walletEndpoint.receiverCount = 0;   // declared the capability, no handler
+    QVERIFY(!w.dispatch(QStringLiteral("wallet.send")).isEmpty());
+
+    spin(900);   // past the 400 ms response timeout set in ReturnWorld
+
+    QCOMPARE(w.chatEndpoint.error(), QStringLiteral("timeout"));
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testProviderDeathNeverReturns()
+{
+    ReturnWorld w;
+    QVERIFY(!w.dispatch(QStringLiteral("wallet.send")).isEmpty());
+
+    w.broker->endpointDestroyed(&w.walletEndpoint);
+    spin(120);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testUserWhoMovedOnIsNotDraggedBack()
+{
+    // They left the provider while it was thinking. Whatever they are doing now
+    // outranks a request they walked away from.
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+    w.presenter.frontmost = QStringLiteral("settings");
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(120);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+    QCOMPARE(w.chatEndpoint.results.size(), 1);
+}
+
+void TestIntentBroker::testDialogOpenSuppressesTheReturn()
+{
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+    w.presenter.dialogOpen = true;
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(120);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testUnloadedRequesterIsNotPresented()
+{
+    // Nowhere to go. presentApp on an unloaded app would be a load, and a
+    // navigation must never become one.
+    ReturnWorld w;
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+    w.presenter.loaded.removeAll(QStringLiteral("chat_ui"));
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(120);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testShellProviderNeverReturns()
+{
+    // The shell is never presented, so nothing displaced the user and there is
+    // nothing to undo — its handler did whatever navigating happened.
+    QTemporaryDir root;
+    const QString chat = writeApp(root, QStringLiteral("chat"),
+        R"({"uses":[{"intent":"logos.repositories.manage"}]})");
+    IntentRegistry registry;
+    registry.registerShellProvider(QStringLiteral("main_ui"),
+                                   { QStringLiteral("logos.repositories.manage") },
+                                   { QStringLiteral("logos.repositories.manage") },
+                                   QStringLiteral("Logos"), QString());
+    registry.rebuild({ { QStringLiteral("chat_ui"), plugin(chat) } }, nullptr, nullptr);
+
+    FakePresenter presenter;
+    presenter.loaded << QStringLiteral("chat_ui");
+    presenter.frontmost = QStringLiteral("chat_ui");
+    IntentBroker broker(&registry, &presenter);
+    broker.setTimeouts(1000, 1000, 20);
+    broker.setReturnDwellFloorMs(20);
+
+    FakeEndpoint chatEndpoint, shellEndpoint;
+    broker.registerEndpoint(QStringLiteral("chat_ui"), &chatEndpoint);
+    broker.registerEndpoint(QStringLiteral("main_ui"), &shellEndpoint);
+
+    broker.submit(&chatEndpoint, QStringLiteral("req-1"),
+                  QStringLiteral("logos.repositories.manage"), {});
+    spin(120);
+    QCOMPARE(shellEndpoint.requests.size(), 1);
+
+    broker.submitResponse(&shellEndpoint, shellEndpoint.requests.last().dispatchId,
+                          true, QVariantMap{}, QString());
+    spin(120);
+
+    QVERIFY2(presenter.presented.isEmpty(),
+             "the shell provider must neither be presented nor returned from");
+}
+
+void TestIntentBroker::testReturnBreakerStopsRunawayNavigation()
+{
+    // Nothing detects intent cycles and a provider may submit while handling
+    // one, so a runaway is reachable. This drives one with no delay at all
+    // between round trips — the shape a loop has and a human cannot produce.
+    ReturnWorld w;
+
+    for (int i = 0; i < 12; ++i) {
+        w.presenter.frontmost = QStringLiteral("chat_ui");
+        submitAndConfirm(*w.broker, w.chooser, &w.chatEndpoint,
+                         QStringLiteral("req-%1").arg(i),
+                         QStringLiteral("wallet.send"), QStringLiteral("wallet_ui"));
+        const auto& requests = w.walletEndpoint.requests;
+        if (requests.isEmpty()) continue;
+        w.broker->submitResponse(&w.walletEndpoint, requests.last().dispatchId,
+                                 true, QVariantMap{}, QString());
+        spin(80);
+    }
+
+    const int returns = w.presenter.presented.count(QStringLiteral("chat_ui"));
+    QVERIFY2(returns >= 1, "the first few returns should still have happened");
+    QVERIFY2(returns < 12,
+             qPrintable(QStringLiteral("breaker never tripped — %1 auto-returns")
+                            .arg(returns)));
+}
+
+void TestIntentBroker::testOrdinaryUseDoesNotTripTheBreaker()
+{
+    // THE REGRESSION. At 3-in-10s the intent suite tripped this by doing four
+    // ordinary round trips in a row, and auto-return then stayed dead for the
+    // rest of the session — the feature silently switching itself off on a
+    // pattern a real user produces without trying.
+    //
+    // Paced at ~1.2 s per trip: far faster than anyone clicking through a
+    // chooser and acting in a provider, and it must still be fine.
+    ReturnWorld w;
+
+    for (int i = 0; i < 4; ++i) {
+        w.presenter.frontmost = QStringLiteral("chat_ui");
+        submitAndConfirm(*w.broker, w.chooser, &w.chatEndpoint,
+                         QStringLiteral("req-%1").arg(i),
+                         QStringLiteral("wallet.send"), QStringLiteral("wallet_ui"));
+        const auto& requests = w.walletEndpoint.requests;
+        QVERIFY(!requests.isEmpty());
+        w.broker->submitResponse(&w.walletEndpoint, requests.last().dispatchId,
+                                 true, QVariantMap{}, QString());
+        spin(1000);
+    }
+
+    QCOMPARE(w.presenter.presented.count(QStringLiteral("chat_ui")), 4);
+}
+
+void TestIntentBroker::testBreakerRecoversAfterQuiet()
+{
+    // A one-way door means one burst costs the user the feature until they
+    // restart. Whatever the loop was, it is over by the time things go quiet.
+    ReturnWorld w;
+    w.broker->setReturnBreakerCooldownMs(300);
+
+    for (int i = 0; i < 12; ++i) {
+        w.presenter.frontmost = QStringLiteral("chat_ui");
+        submitAndConfirm(*w.broker, w.chooser, &w.chatEndpoint,
+                         QStringLiteral("burst-%1").arg(i),
+                         QStringLiteral("wallet.send"), QStringLiteral("wallet_ui"));
+        const auto& requests = w.walletEndpoint.requests;
+        if (requests.isEmpty()) continue;
+        w.broker->submitResponse(&w.walletEndpoint, requests.last().dispatchId,
+                                 true, QVariantMap{}, QString());
+        spin(20);
+    }
+    const int duringBurst = w.presenter.presented.count(QStringLiteral("chat_ui"));
+    QVERIFY2(duringBurst < 12, "breaker never tripped, so recovery is untested");
+
+    spin(500);   // past the cooldown
+
+    w.presenter.frontmost = QStringLiteral("chat_ui");
+    submitAndConfirm(*w.broker, w.chooser, &w.chatEndpoint,
+                     QStringLiteral("after"), QStringLiteral("wallet.send"),
+                     QStringLiteral("wallet_ui"));
+    w.broker->submitResponse(&w.walletEndpoint,
+                             w.walletEndpoint.requests.last().dispatchId,
+                             true, QVariantMap{}, QString());
+    spin(200);
+
+    QVERIFY2(w.presenter.presented.count(QStringLiteral("chat_ui")) > duringBurst,
+             "auto-return never came back after the cooldown");
+}
+
+// ── The dwell floor's deferred path ─────────────────────────────────────────
+//
+// A provider that answers faster than the floor does not return the user
+// immediately — the trip is held on a timer so it reads as motion rather than
+// a flicker. That branch re-checks every guard on the way out, because the
+// window is exactly long enough for the world to change underneath it.
+//
+// Every other test in this file responds well after the floor and so takes the
+// immediate path; these four are the only ones that exercise the timer at all.
+// ReturnWorld's floor is deliberately raised in each, so "before" and "after"
+// are far enough apart to assert separately.
+
+void TestIntentBroker::testDwellFloorDelaysTheReturn()
+{
+    // The floor must DELAY, not merely permit. A version that fired instantly
+    // would pass every assertion below except the first.
+    ReturnWorld w;
+    w.broker->setReturnDwellFloorMs(800);
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(150);
+    QVERIFY2(!w.presenter.returnedTo(QStringLiteral("chat_ui")),
+             "returned inside the dwell floor — the flicker it exists to prevent");
+
+    // The result itself is NOT held back. Only the navigation waits.
+    QCOMPARE(w.chatEndpoint.results.size(), 1);
+
+    spin(1000);
+    QVERIFY2(w.presenter.returnedTo(QStringLiteral("chat_ui")),
+             "the deferred return never fired");
+}
+
+void TestIntentBroker::testRequesterUnloadedDuringDwellIsNotPresented()
+{
+    // THE CASE THE RE-CHECKS EXIST FOR. Loaded when the answer arrived, gone
+    // by the time the timer runs. Presenting it now would either no-op or ask
+    // the shell to load an app the user closed.
+    ReturnWorld w;
+    w.broker->setReturnDwellFloorMs(800);
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(100);
+    w.presenter.loaded.removeAll(QStringLiteral("chat_ui"));
+    spin(1200);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testUserWhoMovesOnDuringDwellIsNotDraggedBack()
+{
+    // They answered and then went somewhere else inside the same half second.
+    // Whatever they are doing now outranks the trip home.
+    ReturnWorld w;
+    w.broker->setReturnDwellFloorMs(800);
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(100);
+    w.presenter.frontmost = QStringLiteral("settings");
+    spin(1200);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
+}
+
+void TestIntentBroker::testDialogOpenedDuringDwellSuppressesTheReturn()
+{
+    // A background-triggered gate can raise a dialog at any moment, including
+    // this one. Declined rather than retried: the sidebar is the fallback.
+    ReturnWorld w;
+    w.broker->setReturnDwellFloorMs(800);
+    const QString dispatchId = w.dispatch(QStringLiteral("wallet.send"));
+
+    w.broker->submitResponse(&w.walletEndpoint, dispatchId, true, QVariantMap{},
+                             QString());
+    spin(100);
+    w.presenter.dialogOpen = true;
+    spin(1200);
+
+    QCOMPARE(w.presenter.presented, QStringList{ QStringLiteral("wallet_ui") });
 }
 
 QTEST_MAIN(TestIntentBroker)

--- a/tests/intent_registry_test.cpp
+++ b/tests/intent_registry_test.cpp
@@ -57,6 +57,10 @@ private slots:
     void testRestrictedIntentAllowsOnlyListedRequesters();
     void testEmptyRequesterListIsRefusedNotAnOpenDoor();
     void testRestrictionSurvivesRebuild();
+    void testHandoffIsReadPerProviderIntent();
+    void testNonBooleanHandoffIsDiagnosedNotCoerced();
+    void testProvidersMayDisagreeAboutHandoff();
+    void testShellHandoffSurvivesRebuild();
 };
 
 void TestIntentRegistry::testResolvesSingleProvider()
@@ -135,7 +139,8 @@ void TestIntentRegistry::testReservedNamespaceRefusedFromApps()
         R"({"provides":[{"intent":"logos.repositories.manage"},{"intent":"evil.ok"}]})");
 
     IntentRegistry registry;
-    registry.registerShellProvider(QStringLiteral("main_ui"), {}, QStringLiteral("Basecamp"), {});
+    registry.registerShellProvider(QStringLiteral("main_ui"), {}, {},
+                                   QStringLiteral("Basecamp"), {});
     registry.rebuild({ { QStringLiteral("evil_ui"), plugin(dir) } }, nullptr, nullptr);
 
     QCOMPARE(registry.resolve(QStringLiteral("logos.repositories.manage")).status,
@@ -156,7 +161,7 @@ void TestIntentRegistry::testShellMayProvideReservedNamespace()
 {
     IntentRegistry registry;
     registry.registerShellProvider(QStringLiteral("main_ui"),
-                                   { QStringLiteral("logos.repositories.manage") },
+                                   { QStringLiteral("logos.repositories.manage") }, {},
                                    QStringLiteral("Logos Basecamp"),
                                    QStringLiteral("qrc:/logo.png"));
 
@@ -174,7 +179,7 @@ void TestIntentRegistry::testDiskRecordCannotClaimShellIdentity()
 
     IntentRegistry registry;
     registry.registerShellProvider(QStringLiteral("main_ui"),
-                                   { QStringLiteral("logos.x.y") }, {}, {});
+                                   { QStringLiteral("logos.x.y") }, {}, {}, {});
     registry.rebuild({ { QStringLiteral("main_ui"), plugin(dir) } }, nullptr, nullptr);
 
     // The shell's own registration is intact and the imposter contributed nothing.
@@ -262,7 +267,7 @@ void TestIntentRegistry::testShellRegistrationSurvivesRebuild()
     // Installing or removing an app must not deregister the shell.
     IntentRegistry registry;
     registry.registerShellProvider(QStringLiteral("main_ui"),
-                                   { QStringLiteral("logos.a.b") }, {}, {});
+                                   { QStringLiteral("logos.a.b") }, {}, {}, {});
     QCOMPARE(registry.resolve(QStringLiteral("logos.a.b")).status, IntentRegistry::Ok);
 
     registry.rebuild({}, nullptr, nullptr);
@@ -364,6 +369,96 @@ void TestIntentRegistry::testRestrictionSurvivesRebuild()
 
     QVERIFY(!registry.requesterAllowed(QStringLiteral("logos.packages.confirm_uninstall"),
                                        QStringLiteral("evil_ui")));
+}
+
+void TestIntentRegistry::testHandoffIsReadPerProviderIntent()
+{
+    // Does servicing this intent END, or does it hand the user off? Absent is
+    // false — the common case is a transaction, and opting out is the rare one.
+    QTemporaryDir root;
+    const QString dir = makeApp(root, QStringLiteral("wallet_ui"), R"({
+        "name": "wallet_ui", "type": "ui_qml",
+        "provides": [
+            {"intent": "wallet.sign"},
+            {"intent": "wallet.open", "handoff": true},
+            {"intent": "wallet.close", "handoff": false}
+        ]
+    })");
+    IntentRegistry registry;
+    registry.rebuild({ { QStringLiteral("wallet_ui"), plugin(dir) } }, nullptr, nullptr);
+
+    QVERIFY(registry.isHandoff(QStringLiteral("wallet_ui"), QStringLiteral("wallet.open")));
+    QVERIFY(!registry.isHandoff(QStringLiteral("wallet_ui"), QStringLiteral("wallet.sign")));
+    QVERIFY(!registry.isHandoff(QStringLiteral("wallet_ui"), QStringLiteral("wallet.close")));
+    // An intent this provider does not declare at all.
+    QVERIFY(!registry.isHandoff(QStringLiteral("wallet_ui"), QStringLiteral("nope.nope")));
+}
+
+void TestIntentRegistry::testNonBooleanHandoffIsDiagnosedNotCoerced()
+{
+    // QVariant("true").toBool() is true, so coercing would silently give a
+    // transactional intent the opposite navigation from the one its author
+    // wrote. Refuse and say so.
+    QTemporaryDir root;
+    const QString dir = makeApp(root, QStringLiteral("wallet_ui"), R"({
+        "name": "wallet_ui", "type": "ui_qml",
+        "provides": [{"intent": "wallet.open", "handoff": "true"}]
+    })");
+    IntentRegistry registry;
+    registry.rebuild({ { QStringLiteral("wallet_ui"), plugin(dir) } }, nullptr, nullptr);
+
+    QVERIFY(!registry.isHandoff(QStringLiteral("wallet_ui"), QStringLiteral("wallet.open")));
+    // The capability itself still registers — a bad flag is not a bad intent.
+    QCOMPARE(registry.resolve(QStringLiteral("wallet.open")).status, IntentRegistry::Ok);
+    QVERIFY(!registry.diagnostics().filter(QStringLiteral("handoff")).isEmpty());
+}
+
+void TestIntentRegistry::testProvidersMayDisagreeAboutHandoff()
+{
+    // Per (provider, intent), like paramsSpecFor and for the same reason: two
+    // apps may implement one capability differently and there is no per-intent
+    // schema to arbitrate. The chosen provider's answer is the one that counts.
+    QTemporaryDir root;
+    const QString a = makeApp(root, QStringLiteral("a_ui"), R"({
+        "name": "a_ui", "type": "ui_qml",
+        "provides": [{"intent": "notes.open", "handoff": true}]
+    })");
+    const QString b = makeApp(root, QStringLiteral("b_ui"), R"({
+        "name": "b_ui", "type": "ui_qml",
+        "provides": [{"intent": "notes.open"}]
+    })");
+    IntentRegistry registry;
+    registry.rebuild({ { QStringLiteral("a_ui"), plugin(a) },
+                       { QStringLiteral("b_ui"), plugin(b) } }, nullptr, nullptr);
+
+    QVERIFY(registry.isHandoff(QStringLiteral("a_ui"), QStringLiteral("notes.open")));
+    QVERIFY(!registry.isHandoff(QStringLiteral("b_ui"), QStringLiteral("notes.open")));
+    QCOMPARE(registry.resolve(QStringLiteral("notes.open")).status,
+             IntentRegistry::Ambiguous);
+}
+
+void TestIntentRegistry::testShellHandoffSurvivesRebuild()
+{
+    // The shell's declaration is code, not disk, so installing an app must not
+    // quietly turn its hand-off back into a transaction.
+    IntentRegistry registry;
+    registry.registerShellProvider(QStringLiteral("main_ui"),
+                                   { QStringLiteral("logos.repositories.manage"),
+                                     QStringLiteral("logos.packages.confirm_install") },
+                                   { QStringLiteral("logos.repositories.manage") },
+                                   QStringLiteral("Logos"), {});
+
+    QVERIFY(registry.isHandoff(QStringLiteral("main_ui"),
+                               QStringLiteral("logos.repositories.manage")));
+    QVERIFY(!registry.isHandoff(QStringLiteral("main_ui"),
+                                QStringLiteral("logos.packages.confirm_install")));
+
+    registry.rebuild({}, nullptr, nullptr);
+
+    QVERIFY(registry.isHandoff(QStringLiteral("main_ui"),
+                               QStringLiteral("logos.repositories.manage")));
+    QVERIFY(!registry.isHandoff(QStringLiteral("main_ui"),
+                                QStringLiteral("logos.packages.confirm_install")));
 }
 
 QTEST_MAIN(TestIntentRegistry)

--- a/tests/ui-tests.mjs
+++ b/tests/ui-tests.mjs
@@ -999,6 +999,83 @@ async function providerMarker(app, which) {
   return typeof r.result === "string" ? r.result : "";
 }
 
+// backend.currentVisibleApp — "which app is the user actually looking at".
+//
+// Read through the overlay root because it lives in the SHELL's engine, where
+// `backend` is a context property; a fixture's anchor is in the plugin's own
+// engine and has no `backend` at all. This is the observable auto-return moves,
+// so every assertion below turns on it.
+async function currentVisibleApp(app) {
+  const overlay = await app.inspector.send("findByProperty", {
+    property: "objectName", value: "overlayDialogs",
+  });
+  if (!overlay.matches || !overlay.matches.length)
+    throw new Error("shell overlay not found — cannot read backend state");
+  const r = await app.inspector.send("evaluate", {
+    objectId: overlay.matches[0].id, expression: "backend.currentVisibleApp",
+  });
+  return typeof r.result === "string" ? r.result : "";
+}
+
+// Ask for `intent`, then answer the confirmation with intent_provider_manual.
+// Returns once the provider's view is up and the shell has actually moved
+// there — the precondition every auto-return assertion needs, and the one that
+// makes "it never returned" distinguishable from "it never left".
+async function dispatchToManualProvider(app, anchor, intent) {
+  await app.inspector.send("evaluate", {
+    objectId: anchor, expression: `root.request("${intent}")`,
+  });
+
+  let delegateId = null;
+  await app.waitFor(async () => {
+    const d = await app.inspector.send("findByProperty", {
+      property: "objectName", value: "intentProvider_intent_provider_manual",
+    });
+    if (!d.matches || !d.matches.length)
+      throw new Error("chooser has no delegate for intent_provider_manual");
+    delegateId = d.matches[0].id;
+  }, { timeout: 8000, interval: 250, description: "confirmation dialog" });
+
+  await app.inspector.send("click", { objectId: delegateId });
+
+  await app.waitFor(async () => {
+    const visible = await currentVisibleApp(app);
+    if (visible !== "intent_provider_manual")
+      throw new Error(`shell is on "${visible}", not the provider`);
+  }, { timeout: 45000, interval: 500, description: "dispatch moved the user" });
+}
+
+// Wait until the manual provider is actually HOLDING a request.
+//
+// dispatchTo() presents the provider BEFORE delivering to it, so the shell
+// arriving is not evidence the QML handler has run. The fixture's buttons are
+// disabled until it has, so clicking on the strength of the navigation alone
+// silently does nothing and the test fails much later, somewhere else.
+async function waitForManualProviderHolding(app) {
+  await app.waitFor(async () => {
+    const found = await app.inspector.send("findByProperty", {
+      property: "objectName", value: "providerRootManual",
+    });
+    if (!found.matches || !found.matches.length)
+      throw new Error("manual provider view not up");
+    const handled = await app.inspector.send("evaluate", {
+      objectId: found.matches[0].id, expression: "root.lastHandled",
+    });
+    if (handled.result !== "waiting")
+      throw new Error(`provider is "${handled.result}", not holding a request`);
+  }, { timeout: 20000, interval: 500, description: "provider holding the request" });
+}
+
+// Click a button inside the manual provider's view.
+async function clickInManualProvider(app, objectName) {
+  const found = await app.inspector.send("findByProperty", {
+    property: "objectName", value: objectName,
+  });
+  if (!found.matches || !found.matches.length)
+    throw new Error(`manual provider has no ${objectName}`);
+  await app.inspector.send("click", { objectId: found.matches[0].id });
+}
+
 async function lastResult(app, anchorId) {
   return (await app.inspector.send("evaluate", {
     objectId: anchorId, expression: "root.lastResult",
@@ -1103,6 +1180,84 @@ test("intents: a single provider still asks before dispatching", async (app) => 
     const r = await lastResult(app, anchor);
     if (r !== "ok:intent_provider_a") throw new Error(`got "${r}"`);
   }, { timeout: 45000, interval: 500, description: "provider_a answered" });
+});
+
+test("intents: answering a request returns the user to the caller", async (app) => {
+  // The round trip. Dispatch already moves the user to the provider; this is
+  // about the move BACK, which nothing did before — you approved something in
+  // another app and were left standing there.
+  //
+  // The provider answers only when a button is pressed, so the return is
+  // triggered by a real user action rather than by a timer, which is the whole
+  // reason this fixture exists.
+  const anchor = await openIntentRequester(app);
+  await dispatchToManualProvider(app, anchor, "test.manual");
+
+  await waitForManualProviderHolding(app);
+  await clickInManualProvider(app, "btnComplete");
+
+  await app.waitFor(async () => {
+    const visible = await currentVisibleApp(app);
+    if (visible !== "intent_requester_demo")
+      throw new Error(`still on "${visible}" — the user was never brought back`);
+  }, { timeout: 20000, interval: 250, description: "returned to the requester" });
+
+  // Navigation only. The result must still have been delivered — a return that
+  // swallowed the answer would be worse than no return.
+  const r = await lastResult(app, anchor);
+  if (r !== "ok:intent_provider_manual")
+    throw new Error(`returned, but the requester got "${r}"`);
+});
+
+test("intents: cancelling also returns the user to the caller", async (app) => {
+  // Backing out is the outcome that most wants a ride home — the user decided
+  // not to do the thing, and being parked in the provider afterwards is the
+  // worst of both.
+  const anchor = await openIntentRequester(app);
+  await dispatchToManualProvider(app, anchor, "test.manual");
+
+  await waitForManualProviderHolding(app);
+  await clickInManualProvider(app, "btnCancel");
+
+  await app.waitFor(async () => {
+    const visible = await currentVisibleApp(app);
+    if (visible !== "intent_requester_demo")
+      throw new Error(`still on "${visible}" after a cancel`);
+  }, { timeout: 20000, interval: 250, description: "returned after cancel" });
+
+  const r = await lastResult(app, anchor);
+  if (r !== "cancelled") throw new Error(`expected cancelled, got "${r}"`);
+});
+
+test("intents: a hand-off leaves the user where it took them", async (app) => {
+  // THE PAIR IS THE POINT. Identical provider, identical button, identical
+  // ok:true — differing only by "handoff": true in metadata.json. If the shell
+  // returns here, the declaration is not being read.
+  const anchor = await openIntentRequester(app);
+  await dispatchToManualProvider(app, anchor, "test.handoff");
+
+  // Same button, same moment in the flow as the transaction above. WHEN a
+  // provider answers is its own business; `handoff` governs only what the
+  // shell does next, and holding both constant is what isolates that.
+  await waitForManualProviderHolding(app);
+  await clickInManualProvider(app, "btnComplete");
+
+  await app.waitFor(async () => {
+    const r = await lastResult(app, anchor);
+    if (r !== "ok:intent_provider_manual")
+      throw new Error(`hand-off not answered yet, requester has "${r}"`);
+  }, { timeout: 20000, interval: 250, description: "hand-off answered" });
+
+  // The answer has landed. Give the dwell floor room to fire a return if the
+  // guard is broken — asserting immediately would pass even with the feature
+  // misbehaving, because the wrong behaviour is merely late, not absent.
+  await new Promise((resolve) => setTimeout(resolve, 1500));
+
+  const visible = await currentVisibleApp(app);
+  if (visible !== "intent_provider_manual")
+    throw new Error(
+      `a hand-off bounced the user to "${visible}" — the whole point is that ` +
+      "they were sent somewhere to stay");
 });
 
 test("intents: a payload the provider declared unusable never reaches it", async (app) => {


### PR DESCRIPTION
…es back once completed

<!--
Thanks for the PR. A short template so triage and review don't stall.
Delete sections that don't apply — don't leave placeholder text.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->

## Screenshots / recordings

<!-- Required for any user-visible UI change. Before/after if it's a fix. -->

## Test plan

<!-- How you validated the change. Tick what applies. -->

- [ ] `nix build .#app` succeeds
- [ ] `nix build .#smoke-test -L` passes
- [ ] `nix build .#integration-test -L` passes (if UI-visible)
- [ ] Doctests pass (`nix build .#doctests -L` if touched)
- [ ] Manual verification on:
  - [ ] Linux (AppImage)
  - [ ] Linux (Nix local build)
  - [ ] macOS
- [ ] N/A — docs/CI/tooling only

## Release notes

<!-- One line for the changelog. Prefix with fix:/feat:/chore:/docs:/test:/ci:
     to match the commit-style already used on master. -->

## Checklist

- [ ] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [ ] No unrelated changes bundled in
- [ ] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [ ] Uncommitted binaries, screenshots, or `.DS_Store` files removed
