### PR TITLE
ci(windows): let build-windows target the self-hosted runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,9 @@ jobs:
   # path.
   build-windows:
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
-    runs-on: ubuntu-latest
+    # Self-hosted when the WINDOWS_RUNNER repo variable holds a JSON label array
+    # (["self-hosted","linux","x64"]); clear it to fall back to GitHub-hosted.
+    runs-on: ${{ fromJSON(vars.WINDOWS_RUNNER || '["ubuntu-latest"]') }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Why

`build-windows` keeps losing its GitHub-hosted runner to capacity reclaim. On [run 33672197603](https://github.com/logos-co/logos-basecamp/actions/runs/33672197603) attempt 1, step 4 (`One-runtime symbol gate`) was `cancelled`, every later step `skipped`, and the job still reported `success` at "Complete job" — the eviction signature, not a build failure. Attempt 2 landed on a different hosted runner.

Both attempts ran on `ubuntu-latest` / runner group `GitHub Actions`. No workflow in `logos-co` currently targets the self-hosted pool.

## What

```yaml
runs-on: ${{ fromJSON(vars.WINDOWS_RUNNER || '["ubuntu-latest"]') }}
```

`WINDOWS_RUNNER` is **already set** to `["self-hosted","linux","x64"]`, so this is live rather than inert: this PR's own `build-windows` picked up `linux-03.he-eu-hel1.ci.github_logos-co-node-02` in the `logos enterprise` group. The PR therefore doubles as the first real exercise of the self-hosted path.

To fall back at any point: `gh variable delete WINDOWS_RUNNER --repo logos-co/logos-basecamp` — with the variable unset the expression evaluates to `["ubuntu-latest"]`, the pre-PR behaviour. To re-enable:

```
gh variable set WINDOWS_RUNNER --repo logos-co/logos-basecamp --body '["self-hosted","linux","x64"]'
```

Either takes effect on the next run; neither needs a PR.

## Design notes

**Why an explicit switch and not automatic fallback.** GitHub has no fallback in `runs-on`. A label with no online runner *queues* — up to 24h — rather than failing, and `timeout-minutes` does not cover queue time. So the usual `continue-on-error` + fallback-job pattern silently never fires in exactly the case it exists for (runners absent); it only covers "runner died mid-build". A truly automatic picker would need a job querying the runner API, which needs an org-scoped PAT secret: the runners are enterprise-level, and `administration` is not a settable `permissions:` key, so `GITHUB_TOKEN` cannot list them.

**Why `fromJSON` and not `${{ vars.X || 'ubuntu-latest' }}`.** An Actions variable is a string, so the plain form carries only one label. The pool is enterprise-scoped and may not stay homogeneous, and this job cross-builds the PE on Linux — hence pinning `self-hosted` + `linux` + `x64` rather than matching any self-hosted machine.

**Scope.** `build-windows` only, per request. `build-appimage` and `test-linux` (including the `ubuntu-24.04-arm` legs) are on the same hosted pool and equally exposed, but are left alone here.

## Validation

`actionlint` clean.

## Before flipping the switch

- **Fork PRs.** This repo is public with forking enabled (0 fork PRs in the last 50, so latent rather than live). Self-hosted runners are persistent and enterprise-shared, so the runner group should have "Require approval for all external contributors" enabled — I could not verify that setting.
- **Nix install.** `setup-nix-cache-action` keeps `install-nix: true`, so `cachix/install-nix-action@v31` runs every job. That is a clean install on an ephemeral runner but contends with a system nix daemon on a persistent one. If the first self-hosted run fails at step 3, the fix is `install-nix: 'false'`.
- **Queueing.** With 14 shared runners, a busy pool means this job waits rather than falling back. Worth watching the first few runs against the eviction rate it replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
