### PR TITLE
chore(deps): bump logos-liblogos 634c958 -> a3bc9d9

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788384573,
-        "narHash": "sha256-UyXIulN84mSbK3GjI1BNLqs1oN2d34zBTzdbG9TzkWo=",
+        "lastModified": 1788471596,
+        "narHash": "sha256-ru7kJXaakp4TV6Gu67RSFBtivPukOqQ77Z0Htoaj9TA=",
         "owner": "logos-co",
         "repo": "logos-container-subprocess",
-        "rev": "f05a8beabc02f2eb8d21d2ca6bcd84a97b2a7e1d",
+        "rev": "24e103a3a1a24e8fd639e8ee58ea999b229f3dd5",
         "type": "github"
       },
       "original": {
@@ -5495,11 +5495,11 @@
         "process-stats": "process-stats_2"
       },
       "locked": {
-        "lastModified": 1788443401,
-        "narHash": "sha256-S2ZfDXJnuonVl64LTgO7lcX05kqgnZ+tQ7Y03mTLdTU=",
+        "lastModified": 1788473572,
+        "narHash": "sha256-dXnX2CUHW4aghITWTYWJEu0pJo5LBdTj3ikB/eC7WN8=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "634c958103f5e14bec274529aa3ddfa7abdd7383",
+        "rev": "a3bc9d9363dce006e8431858f9d2428300b39fb8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
One liblogos commit, whose entire payload is a pin: liblogos now takes `logos-container-subprocess` `24e103a`, which spawns module hosts with **`posix_spawn`** instead of Boost.Process v2's forking POSIX launcher.

bp2's forked child called `ctx.notify_fork(fork_child)` before `execve`, taking asio's `service_registry` mutex — which every pipe construction also takes, and the container builds six pipes per launch — and the reactor's descriptor mutex, taken by pipe teardown on the io thread. Either held by another thread at fork time is inherited **locked with no owner**: the child never reaches `execve`, and the parent never returns from an untimed read of the exec-status pipe.

**The previous bump did not carry this.** [#384](https://github.com/logos-co/logos-basecamp/pull/384) went to `634c958`, which predates liblogos' container pin move — so basecamp has still been resolving the forking launcher since then.

Only the `logos-liblogos` root input moved; the nested `default-container` now resolves to `24e103a`.

### Verification (aarch64-darwin)

`nix build .#default` — **pass**. Twelve of the thirteen checks passed on the run for this lock.

### On the red checks — a correction I nearly got wrong

`host-services-test`, `integration-test`, `shutdown-test` and `mock-tests` were **all failing before this bump**, at this repo's own master. On the run for this lock, three of them passed, and that looked like the container fix having repaired them.

**It isn't.** Re-running `host-services-test` with `nix build --rebuild` — which forces execution instead of reusing a cached result — **fails on master and on this branch alike, twice each**:

| | master `634c958` | this branch `a3bc9d9` |
|---|---|---|
| round 1 | FAIL | FAIL |
| round 2 | FAIL | FAIL |

So they are **flaky, mostly red**, and this bump neither fixes nor breaks them. `mock-tests` failed on both runs. Worth someone owning separately — a suite that passes a check once and fails it twice is worse than one that is simply red, because a green run means nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
