### PR TITLE
Test/MCP UI dashboard shows version, build type and commits

### DIFF
--- a/tests/ui-tests.mjs
+++ b/tests/ui-tests.mjs
@@ -2835,6 +2835,162 @@ test("app manager: dialog wording for an already-installed app", async (app) => 
   await closeAddApplicationDialog(app, dialogId);
 });
 
+// --- Settings (A16): Dashboard shows version, build type and commits ---
+//
+// Spec §2.A A16. Gates, all derived from the backend: backend.buildVersion
+// rendered when non-empty, Version row hidden when empty (dirty local builds
+// bake "") · "Commits" heading · commit-row count equals
+// backend.buildCommits.length (≥ 1) · first row shows buildCommits[0] ·
+// "Portable build" iff backend.isPortableBuild else "Dev build", never both.
+//
+// DashboardView has no objectNames, so the gates run as one JS tree walk
+// scoped to the view (which also keeps the sidebar footer's own build-type
+// token out of the never-both check). Commit rows are the children of the
+// "Commits" column that hold exactly two text nodes: name, then commit.
+
+test("settings: Dashboard shows version, build type and commit list", async (app) => {
+  await app.click("Settings", sidebarSection);
+  await app.waitFor(
+    async () => { await app.expectTexts(["Dashboard", "Apps Inspector", "Module Inspector"]); },
+    { timeout: 10000, interval: 500, description: "Settings entries to render" }
+  );
+  await app.click("Dashboard", { type: "LogosItemDelegate" });
+
+  // DashboardView is instantiated eagerly; only visible proves it is selected.
+  let dashboard = null;
+  await app.waitFor(async () => {
+    const res = await app.inspector.send("findByType", { typeName: "DashboardView" });
+    if (res.error) throw new Error(`findByType(DashboardView) failed: ${res.error}`);
+    dashboard = (res.matches ?? [])[0] || null;
+    if (!dashboard) throw new Error("no DashboardView instance in the QML tree");
+    const visible = await evalOn(app, dashboard.id, "visible");
+    if (visible !== true) {
+      throw new Error(`DashboardView visible=${visible} (expected true)`);
+    }
+  }, { timeout: 10000, interval: 500, description: "Dashboard view to become visible" });
+
+  // Expected values, one primitive per evaluate call. Empty buildVersion is valid.
+  const buildVersion = await evalOn(app, dashboard.id, "backend.buildVersion");
+  if (typeof buildVersion !== "string") {
+    throw new Error(
+      `backend.buildVersion=${JSON.stringify(buildVersion)} (expected string)`);
+  }
+  const commitCount = await evalOn(app, dashboard.id, "backend.buildCommits.length");
+  if (typeof commitCount !== "number" || commitCount < 1) {
+    throw new Error(
+      `backend.buildCommits.length=${JSON.stringify(commitCount)} (expected ≥ 1)`);
+  }
+  const firstName = await evalOn(app, dashboard.id, "backend.buildCommits[0].name");
+  const firstCommit = await evalOn(app, dashboard.id, "backend.buildCommits[0].commit");
+  if (typeof firstName !== "string" || firstName.length === 0 ||
+      typeof firstCommit !== "string" || firstCommit.length === 0) {
+    throw new Error(
+      `backend.buildCommits[0] name=${JSON.stringify(firstName)} ` +
+      `commit=${JSON.stringify(firstCommit)} (expected non-empty strings)`);
+  }
+  const isPortable = await evalOn(app, dashboard.id, "backend.isPortableBuild");
+  if (typeof isPortable !== "boolean") {
+    throw new Error(
+      `backend.isPortableBuild=${JSON.stringify(isPortable)} (expected boolean)`);
+  }
+
+  // One walk per attempt, returned as JSON (evaluate only round-trips primitives).
+  const snapshotDashboard = async () => {
+    const res = await app.inspector.send("evaluate", {
+      objectId: dashboard.id,
+      expression: `(() => {
+        const out = {
+          hasVersion: false, versionLabelVisible: false, hasCommits: false,
+          hasPortable: false, hasDev: false, rows: null,
+        };
+        const walk = (node) => {
+          if (!node) return;
+          if (node.text === ${JSON.stringify(buildVersion)}) out.hasVersion = true;
+          // Item.visible is effective visibility, so it tracks the hidden row.
+          if (node.text === "Version" && node.visible === true) {
+            out.versionLabelVisible = true;
+          }
+          if (node.text === "Portable build") out.hasPortable = true;
+          if (node.text === "Dev build") out.hasDev = true;
+          const kids = node.children;
+          if (!kids || typeof kids.length !== "number") return;
+          let hasHeading = false;
+          for (let i = 0; i < kids.length; i += 1) {
+            if (kids[i] && kids[i].text === "Commits") hasHeading = true;
+          }
+          if (hasHeading) {
+            out.hasCommits = true;
+            out.rows = [];
+            for (let i = 0; i < kids.length; i += 1) {
+              const k = kids[i];
+              const two =
+                k && k.children && k.children.length === 2 ? k.children : null;
+              if (two && typeof two[0].text === "string" &&
+                  typeof two[1].text === "string") {
+                out.rows.push({ name: two[0].text, commit: two[1].text });
+              }
+            }
+            return;
+          }
+          for (let i = 0; i < kids.length; i += 1) walk(kids[i]);
+        };
+        walk(this);
+        return JSON.stringify(out);
+      })()`,
+    });
+    if (res.error) throw new Error(`evaluate(dashboard snapshot) failed: ${res.error}`);
+    return JSON.parse(res.result);
+  };
+
+  const expectedType = isPortable ? "Portable build" : "Dev build";
+  const otherType = isPortable ? "Dev build" : "Portable build";
+  await app.waitFor(async () => {
+    const snap = await snapshotDashboard();
+
+    // Gate 1: non-empty version rendered, empty version hides the row.
+    if (buildVersion.length > 0) {
+      if (snap.hasVersion !== true) {
+        throw new Error(
+          `no text equal to buildVersion=${JSON.stringify(buildVersion)} ` +
+          `in the Dashboard view`);
+      }
+    } else if (snap.versionLabelVisible !== false) {
+      throw new Error(
+        'the "Version" row is visible although backend.buildVersion is empty');
+    }
+
+    // Gate 2: "Commits" heading.
+    if (snap.hasCommits !== true) {
+      throw new Error('"Commits" heading not found in the Dashboard view');
+    }
+
+    // Gate 3: row count equals backend.buildCommits.length.
+    if (!Array.isArray(snap.rows) || snap.rows.length !== commitCount) {
+      throw new Error(
+        `${Array.isArray(snap.rows) ? snap.rows.length : "no"} commit rows ` +
+        `rendered (expected backend.buildCommits.length=${commitCount})`);
+    }
+
+    // Gate 4: first row shows buildCommits[0].
+    if (snap.rows[0].name !== firstName || snap.rows[0].commit !== firstCommit) {
+      throw new Error(
+        `first commit row=${JSON.stringify(snap.rows[0])} (expected ` +
+        `name=${JSON.stringify(firstName)} commit=${JSON.stringify(firstCommit)})`);
+    }
+
+    // Gate 5: the matching build-type text, never the other one.
+    const hasExpected = isPortable ? snap.hasPortable : snap.hasDev;
+    const hasOther = isPortable ? snap.hasDev : snap.hasPortable;
+    if (hasExpected !== true || hasOther !== false) {
+      throw new Error(
+        `build-type texts: "${expectedType}"=${hasExpected} ` +
+        `"${otherType}"=${hasOther} (isPortableBuild=${isPortable} — ` +
+        `expected the matching one alone, never both)`);
+    }
+  }, { timeout: 10000, interval: 500,
+       description: "Dashboard to render version, build type and commit rows" });
+});
+
 // --- Package Manager ---
 //
 // PMUI is no longer launched from the sidebar app launcher (filtered out


### PR DESCRIPTION
## Summary

Add `settings: Dashboard shows version, build type and commit list` MCP UI test.

## Test plan

- [x] `nix build .#app` succeeds
- [x] `nix build .#smoke-test -L` passes
- [x] `nix build .#integration-test -L` passes (if UI-visible)
- [x] Doctests pass (`nix build .#doctests -L` if touched)

## Checklist

- [x] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [x] No unrelated changes bundled in
- [x] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [x] Uncommitted binaries, screenshots, or `.DS_Store` files removed