### PR TITLE
fix(deps): an optional dependency must not block a load

### DIFF
--- a/app/utils/DependencyBlocker.h
+++ b/app/utils/DependencyBlocker.h
@@ -41,6 +41,10 @@ namespace logos {
 //     liblogos' own resolver, which remains the authority on whether a load
 //     succeeds. Refusing on a word this build does not know would block loads
 //     that work.
+//
+//   `optional: true` — orthogonal to status, and it wins over ALL of them.
+//     The resolver never fails a load over an optional edge, so neither may
+//     this. See dependencyBlocksLoad. Pinned by tests.
 
 enum class DependencyBlockKind {
     // Satisfied, cyclic, a publisher we could not check, or a status this
@@ -56,6 +60,10 @@ enum class DependencyBlockKind {
 
 struct DependencyBlocker {
     DependencyBlockKind kind = DependencyBlockKind::None;
+    // Was the edge declared `optional_dependencies`? Kept beside `kind` rather
+    // than folded into it: the package is still absent, so the GRAPH questions
+    // below must answer exactly as they did — only the load verdict changes.
+    bool optional = false;
     QString name;
     // Declared semver range, e.g. "^2.0.0". Empty for a bare-name dependency.
     QString requiredVersion;
@@ -86,6 +94,8 @@ inline DependencyBlocker readDependencyBlocker(const QVariant& row)
     b.installedVersion = m.value(QStringLiteral("version")).toString();
     b.requiredSigner   = m.value(QStringLiteral("requiredSigner")).toString();
     b.signerDid        = m.value(QStringLiteral("signerDid")).toString();
+    // Emitted by the module only when true, so an absent key means required.
+    b.optional         = m.value(QStringLiteral("optional")).toBool();
 
     // Named, not excluded. The scanner has already resolved which single
     // constraint failed, so these are alternatives, not a priority list to
@@ -114,6 +124,17 @@ inline DependencyBlocker readDependencyBlocker(const QVariant& row)
 inline bool dependencyIsPresent(const DependencyBlocker& b)
 {
     return b.kind != DependencyBlockKind::NotInstalled;
+}
+
+// Whether the row REFUSES the load — the third question, and the only one
+// optionality changes. An optional edge never blocks, whatever its status:
+// this gate predicts liblogos' resolver, and there optional edges are SOFT —
+// they never expand the load set and an absent one is never `missing`. So
+// refusing here denies a load that works, leaving the plugin unlaunchable
+// behind a popup naming a dependency nothing requires.
+inline bool dependencyBlocksLoad(const DependencyBlocker& b)
+{
+    return b.kind != DependencyBlockKind::None && !b.optional;
 }
 
 // The clause telling the user what to DO about this row, without the module's
@@ -241,7 +262,7 @@ inline DependencyRowSplit splitDependencyRows(const QVariantList& rows)
 
         if (dependencyIsPresent(b)) out.present << b.name;
 
-        if (b.kind != DependencyBlockKind::None) {
+        if (dependencyBlocksLoad(b)) {
             out.blocking << b.name;
             out.blockers << dependencyBlockerToMap(b);
         }

--- a/flake.lock
+++ b/flake.lock
@@ -34668,11 +34668,11 @@
         "logos-package-manager": "logos-package-manager_22"
       },
       "locked": {
-        "lastModified": 1787867012,
-        "narHash": "sha256-U1VNz3hVjct1wKgx9lYIdRwJGWCxzp/yJ9rvZ4P/p2A=",
+        "lastModified": 1788803121,
+        "narHash": "sha256-JY/muWBPL/AcGXOP7XD2/3SnYJ4dLykgUSoAVca2484=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "ade27a50e8d1f796a2defb8f36a43229bb4bd81c",
+        "rev": "6f2b84fce9a8730d4d2599f1442fa7effcb672dd",
         "type": "github"
       },
       "original": {
@@ -35135,11 +35135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787865382,
-        "narHash": "sha256-mM6TxIbIxsFSHUe6Hd+718qksL2RSVyIJlOBifVJnDY=",
+        "lastModified": 1788801286,
+        "narHash": "sha256-pNRp9uNNT9fNf1jaV9f0YHm5189GKJopBgT2H8ch/aI=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "d88abaa1f3f5d4a4268d7cdfbec98d816e0a0385",
+        "rev": "d3af2972f51d9c542537d80d60ad8d20282ddcd1",
         "type": "github"
       },
       "original": {
@@ -37011,11 +37011,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787833864,
-        "narHash": "sha256-v0Nbhy4YXm1d/luboCbIL4yNIgcfkRXVTs1jXucLoVY=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "49151f003690333764d73f956d64e1245e2a0c38",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {

--- a/tests/dependency_gate_test.cpp
+++ b/tests/dependency_gate_test.cpp
@@ -114,6 +114,26 @@ class DependencyGateTest : public QObject {
             R"("status":"installed","version":"1.0.0"})");
     }
 
+    // Declared `optional_dependencies` and not installed. Byte-for-byte what
+    // the absent row above is, plus the one key package-manager-module emits
+    // only when the edge was optional.
+    static QVariant absentOptionalRow()
+    {
+        return wireRow(
+            R"({"installType":"","name":"depsvc","optional":true,)"
+            R"("status":"not_installed","version":""})");
+    }
+
+    // Optional AND installed at a version the edge rejects. The resolver does
+    // not consult optional edges at all, so this loads too.
+    static QVariant optionalMismatchRow()
+    {
+        return wireRow(
+            R"({"installType":"user","name":"depsvc","optional":true,)"
+            R"("requiredVersion":"^2.0.0","status":"version_mismatch",)"
+            R"("version":"1.0.0"})");
+    }
+
 private slots:
     // What blocks a load.
     void a_satisfied_dependency_does_not_block()
@@ -232,6 +252,53 @@ private slots:
         QCOMPARE(split.present, QStringList{QStringLiteral("depsvc")});
         QVERIFY(split.blocking.isEmpty());
         QVERIFY(split.blockers.isEmpty());
+    }
+
+    // Optionality: the resolver never fails a load over an optional edge, so
+    // neither may this gate. The rows still carry a real blocking KIND — only
+    // the load verdict changes — which is what keeps the graph answers right.
+    void an_absent_optional_dependency_does_not_block_a_load()
+    {
+        const auto b = readDependencyBlocker(absentOptionalRow());
+        QVERIFY(b.optional);
+        // Still absent: the kind is unchanged, so nothing downstream that asks
+        // about the package's presence is misled.
+        QCOMPARE(b.kind, DependencyBlockKind::NotInstalled);
+        QVERIFY(!logos::dependencyBlocksLoad(b));
+        // The required twin is identical but for the flag, and still blocks.
+        QVERIFY(logos::dependencyBlocksLoad(readDependencyBlocker(absentRow())));
+    }
+
+    void an_optional_dependency_at_the_wrong_version_does_not_block_either()
+    {
+        const auto b = readDependencyBlocker(optionalMismatchRow());
+        QCOMPARE(b.kind, DependencyBlockKind::VersionMismatch);
+        QVERIFY(!logos::dependencyBlocksLoad(b));
+        QVERIFY(logos::dependencyBlocksLoad(readDependencyBlocker(mismatchRow())));
+    }
+
+    // The whole point: no blocker means no popup, no red cross, and the plugin
+    // stays launchable.
+    void the_split_leaves_an_absent_optional_dependency_unblocked()
+    {
+        const auto split = logos::splitDependencyRows({absentOptionalRow()});
+        QVERIFY(split.blocking.isEmpty());
+        QVERIFY(split.blockers.isEmpty());
+        // Absent is absent — it is NOT on disk, so it must not appear as a
+        // forward graph edge an uninstall plan would walk.
+        QVERIFY(split.present.isEmpty());
+    }
+
+    // A required blocker alongside an optional one still blocks, and the
+    // summary must name only the required one.
+    void an_optional_row_does_not_dilute_a_real_blocker()
+    {
+        const auto split = logos::splitDependencyRows({absentOptionalRow(),
+                                                       mismatchRow()});
+        QCOMPARE(split.blocking, QStringList{QStringLiteral("depsvc")});
+        QCOMPARE(split.blockers.size(), 1);
+        QCOMPARE(summariseDependencyBlockers(split.blockers),
+                 QStringLiteral("mismatch"));
     }
 
     // A row with no name is not a dependency: nothing to act on.


### PR DESCRIPTION
Consumes [logos-package-manager-module#67](https://github.com/logos-co/logos-package-manager-module/pull/67), which put `optional` on the dependency projection. This is the half that acts on it.

## The bug

An absent `optional_dependencies` entry makes a plugin **unlaunchable**. This is not just a stray marker:

- `logos::splitDependencyRows` (`app/utils/DependencyBlocker.h`) counted every `not_installed` row as a blocker, having no way to tell an optional edge from a required one.
- `UIPluginManager::loadUiModule` refuses on any non-empty blocker list — `if (!blockers.isEmpty()) { … emit missingDepsPopupRequested(…); return; }` — so the user gets a popup naming a dependency **nothing requires**, and the plugin never loads.
- The sidebar red-cross (`hasMissingDeps`) and `depBlockKind` marker light off the same list.

## Why an optional edge blocks *nothing*, not just when absent

This gate is an advisory pre-check in front of liblogos' resolver, which is the authority on whether a load succeeds. In that resolver optional edges are **soft** — from `dependency_resolver.h`:

> they do NOT expand the set. Requesting a module never pulls its optional dependencies in, so an absent one is not `missing`.

The resolver never consults an optional edge when deciding load success, so an optional dependency installed at a rejected version loads exactly as an absent one does. Blocking either would deny a load that works — precisely the failure the header already warns about for an unrecognised status. So `optional` wins over **all** statuses, and the exemption is not special-cased to `not_installed`.

## The one thing that had to stay put

`optional` is read into `DependencyBlocker` and applied in a new `dependencyBlocksLoad`, **deliberately not folded into `kind`**. Collapsing an absent optional row to `None` would have made `dependencyIsPresent` return true for a package that is not on disk, quietly adding a forward edge to the graph `UninstallPlan` walks — asymmetric against the reverse edges `resolveFlatDependents` reports. The row keeps its real `kind`; only the load verdict changes. There is a test for exactly this.

## Tests

Four new cases in `tests/dependency_gate_test.cpp`, using the file's verbatim-wire-row convention. All four were verified **load-bearing** — each fails with `&& !b.optional` removed from `dependencyBlocksLoad` and passes with it (`Totals: 34 passed, 4 failed` → `100% tests passed`).

- `an_absent_optional_dependency_does_not_block_a_load` — and the required twin, identical but for the flag, still does.
- `an_optional_dependency_at_the_wrong_version_does_not_block_either`
- `the_split_leaves_an_absent_optional_dependency_unblocked` — and it is still **not** in `present`, which is the graph invariant above.
- `an_optional_row_does_not_dilute_a_real_blocker` — a required blocker alongside an optional one still blocks, and `summariseDependencyBlockers` says `mismatch`, not `mixed`.

```
5/17 Test #5: dependency_gate_test ... Passed
100% tests passed, 0 tests failed out of 17
```

`.#unit-tests` is the check `build.yml` runs.

## Lock diff

3566 nodes before and after, none added or removed. Three moved, all on the relocked input's own path:

| node | from | to |
|---|---|---|
| `logos-package-manager-module` | `ade27a5` | `6f2b84f` |
| `logos-package-manager` (its child) | `d88abaa` | `d3af297` |
| `logos-package` (its grandchild) | `49151f0` | `4cdb302` |

Basecamp's own direct `logos-package-manager` input did not move.

## Not in scope

An optional dependency at a rejected version is now silent. Surfacing that as *advice* — distinct from a blocker — would be a new UI affordance rather than a fix, so it is deliberately left out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)