### PR TITLE
fix: when a module dependency for app needs to be upgraded, it showed…

### DIFF
--- a/app/AppsModel.cpp
+++ b/app/AppsModel.cpp
@@ -208,6 +208,21 @@ void AppsModel::recomputeInstallStatus(Row& r)
         r.installStatus = InstallStatus::DifferentHash;
         return;
     }
+
+    InstallStatus::Value worstDep = InstallStatus::Installed;
+    const auto isWorse = [](InstallStatus::Value candidate,
+                            InstallStatus::Value current) {
+        const auto rank = [](InstallStatus::Value v) {
+            switch (v) {
+            case InstallStatus::DifferentHash:      return 3;
+            case InstallStatus::DowngradeAvailable: return 2;
+            case InstallStatus::UpgradeAvailable:   return 1;
+            default:                                return 0;
+            }
+        };
+        return rank(candidate) > rank(current);
+    };
+
     for (const QVariant& v : r.dependencies) {
         const QVariantMap dep = v.toMap();
         const QString depName = dep.value("name").toString();
@@ -216,16 +231,35 @@ void AppsModel::recomputeInstallStatus(Row& r)
         if (depIdx < 0) continue;   // dep not in this repo — see comment above
         const Row& depRow = m_rows[depIdx];
         if (depRow.versions.isEmpty()) continue;
+
+        const QString depRelease = depRow.latestVersion;
+        if (!depRelease.isEmpty() && !depRow.installedVersion.isEmpty()) {
+            const int depCmp = versionCmp(depRow.installedVersion, depRelease);
+            if (depCmp < 0) {
+                if (isWorse(InstallStatus::UpgradeAvailable, worstDep))
+                    worstDep = InstallStatus::UpgradeAvailable;
+                continue;
+            }
+            if (depCmp > 0) {
+                if (isWorse(InstallStatus::DowngradeAvailable, worstDep))
+                    worstDep = InstallStatus::DowngradeAvailable;
+                continue;
+            }
+        }
+
+        // Same version (or no version to compare): a hash mismatch is
+        // corruption, and only a reinstall repairs it.
         const QString expectedDepHash =
             depRow.versions.first().toMap().value("rootHash").toString();
         const QString installedDepHash = depRow.installedHash;
         if (expectedDepHash.isEmpty() || installedDepHash.isEmpty()) continue;
-        if (expectedDepHash != installedDepHash) {
-            r.installStatus = InstallStatus::DifferentHash;
-            return;
+        if (expectedDepHash != installedDepHash
+            && isWorse(InstallStatus::DifferentHash, worstDep)) {
+            worstDep = InstallStatus::DifferentHash;
         }
     }
-    r.installStatus = InstallStatus::Installed;
+
+    r.installStatus = worstDep;
 }
 
 void AppsModel::recomputeVersionDerivedFields(Row& r)

--- a/tests/apps_model_test.cpp
+++ b/tests/apps_model_test.cpp
@@ -287,6 +287,129 @@ private slots:
                  InstallStatus::DifferentHash);
     }
 
+    // ── A dependency's state propagates to the parent's ACTION ──────────
+    //
+    // recomputeInstallStatus ends by looking at dependencies, and that status
+    // becomes the Add Application dialog's primary button verb. It therefore
+    // has to say WHICH action would fix things, not merely that something is
+    // wrong. The bug these pin: an outdated dependency reported DifferentHash,
+    // so the button offered "Reinstall" — which reinstalls the parent at the
+    // same version and leaves the dependency exactly as it was. Observed with
+    // Radicle: app row v0.2.3 INSTALLED, module row v0.2.3 UPGRADE, footer
+    // "1 out of 2 ... have become outdated", button "Reinstall".
+    //
+    // The parent's OWN state always wins — these only apply once its version
+    // and hash both match the catalog.
+
+    // Dependency on an older build → the fix is an update, not a reinstall.
+    void outdatedDependencyMakesParentUpgradeable()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("radicle_module") }),
+            makeCatalogRow("repo1", "radicle_module", "0.2.3", "H_mod_023"),
+        });
+        model.markInstalled("radicle", "0.2.3", "H_radicle_023");
+        model.markInstalled("radicle_module", "0.2.2", "H_mod_022");
+
+        QCOMPARE(statusOf(model, "radicle_module", "repo1"),
+                 InstallStatus::UpgradeAvailable);
+        QCOMPARE(statusOf(model, "radicle", "repo1"),
+                 InstallStatus::UpgradeAvailable);
+    }
+
+    // Dependency ahead of the catalog → downgrade, mirroring the parent's own
+    // newer-version case.
+    void newerDependencyMakesParentDowngradeable()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("radicle_module") }),
+            makeCatalogRow("repo1", "radicle_module", "0.2.3", "H_mod_023"),
+        });
+        model.markInstalled("radicle", "0.2.3", "H_radicle_023");
+        model.markInstalled("radicle_module", "0.3.0", "H_mod_030");
+
+        QCOMPARE(statusOf(model, "radicle_module", "repo1"),
+                 InstallStatus::DowngradeAvailable);
+        QCOMPARE(statusOf(model, "radicle", "repo1"),
+                 InstallStatus::DowngradeAvailable);
+    }
+
+    // Dependency at the RIGHT version but the wrong payload — corruption, or a
+    // rebuild under the same tag. Reinstall is genuinely the fix here, and this
+    // is the one case the old blanket DifferentHash got right.
+    void corruptDependencyKeepsParentReinstallable()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("radicle_module") }),
+            makeCatalogRow("repo1", "radicle_module", "0.2.3", "H_mod_023"),
+        });
+        model.markInstalled("radicle", "0.2.3", "H_radicle_023");
+        model.markInstalled("radicle_module", "0.2.3", "H_mod_TAMPERED");
+
+        QCOMPARE(statusOf(model, "radicle_module", "repo1"),
+                 InstallStatus::DifferentHash);
+        QCOMPARE(statusOf(model, "radicle", "repo1"),
+                 InstallStatus::DifferentHash);
+    }
+
+    // Everything current → nothing to offer but Launch.
+    void healthyDependencyLeavesParentInstalled()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("radicle_module") }),
+            makeCatalogRow("repo1", "radicle_module", "0.2.3", "H_mod_023"),
+        });
+        model.markInstalled("radicle", "0.2.3", "H_radicle_023");
+        model.markInstalled("radicle_module", "0.2.3", "H_mod_023");
+
+        QCOMPARE(statusOf(model, "radicle", "repo1"), InstallStatus::Installed);
+    }
+
+    // Worst-wins across several dependencies: corruption outranks a version
+    // change, because no version change repairs a bad payload.
+    void worstDependencyStateWins()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("mod_old"), makeDep("mod_broken") }),
+            makeCatalogRow("repo1", "mod_old",    "0.2.3", "H_old_023"),
+            makeCatalogRow("repo1", "mod_broken", "0.2.3", "H_broken_023"),
+        });
+        model.markInstalled("radicle", "0.2.3", "H_radicle_023");
+        model.markInstalled("mod_old",    "0.2.2", "H_old_022");        // upgrade
+        model.markInstalled("mod_broken", "0.2.3", "H_broken_TAMPERED"); // reinstall
+
+        QCOMPARE(statusOf(model, "radicle", "repo1"),
+                 InstallStatus::DifferentHash);
+    }
+
+    // The parent's own state is decided before dependencies are consulted, so
+    // a dependency can never mask a problem with the package itself.
+    void parentOwnStateOutranksItsDependencies()
+    {
+        AppsModel model;
+        model.replaceCatalog({
+            makeCatalogRow("repo1", "radicle", "0.2.3", "H_radicle_023",
+                           { makeDep("radicle_module") }),
+            makeCatalogRow("repo1", "radicle_module", "0.2.3", "H_mod_023"),
+        });
+        // Parent itself is behind; dependency is merely corrupt.
+        model.markInstalled("radicle", "0.2.2", "H_radicle_022");
+        model.markInstalled("radicle_module", "0.2.3", "H_mod_TAMPERED");
+
+        QCOMPARE(statusOf(model, "radicle", "repo1"),
+                 InstallStatus::UpgradeAvailable);
+    }
+
     // ── Partial install (deps missing) ──────────────────────────────────
     void missingDepsForcesNotInstalled()
     {


### PR DESCRIPTION
… reintall instead of update. This fixes that behaviour

<!--
Thanks for the PR. A short template so triage and review don't stall.
Delete sections that don't apply — don't leave placeholder text.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->

## Screenshots / recordings


https://github.com/user-attachments/assets/5bfaeb78-8d40-4f4f-bd89-4af6ecc830d3


## Test plan

<!-- How you validated the change. Tick what applies. -->

- [ ] `nix build .#app` succeeds
- [ ] `nix build .#smoke-test -L` passes
- [ ] `nix build .#integration-test -L` passes (if UI-visible)
- [ ] Doctests pass (`nix build .#doctests -L` if touched)
- [ ] Manual verification on:
  - [ ] Linux (AppImage)
  - [ ] Linux (Nix local build)
  - [ ] macOS
- [ ] N/A — docs/CI/tooling only

## Release notes

<!-- One line for the changelog. Prefix with fix:/feat:/chore:/docs:/test:/ci:
     to match the commit-style already used on master. -->

## Checklist

- [ ] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [ ] No unrelated changes bundled in
- [ ] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [ ] Uncommitted binaries, screenshots, or `.DS_Store` files removed
