### PR TITLE
feat: Shell preview on the iOS simulator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ doctests/result*
 
 # user-dirs staged by doctest run: blocks when executed from the repo root
 testdata/
+
+# agent build logs and simulator screenshots (a dirty tree copies untracked files into src = ./.)
+*.log
+shell-ios-sim*.png

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,17 @@
       # attributes evaluate anywhere and realise on x86_64-linux. Keying it as a
       # system rather than a package-name suffix is what lets the 34
       # `dep.packages.${system}.x` interpolations below stay untouched.
+      # Mobile pseudo-systems (aarch64-android, aarch64-ios-simulator) are
+      # opt-in and carry their own cross package set. The design system is a
+      # QML-only library, so it is built here from its source with that set
+      # instead of through its own flake, which only enumerates forAllTargets.
+      forAllMobileTargets = f: logos-nix.lib.forAllMobileTargets ({ system, pkgs, buildSystem }:
+        let
+          dsCommon = import "${logos-design-system}/nix/common.nix" { inherit pkgs; };
+        in f {
+          inherit system pkgs buildSystem;
+          logosDesignSystem = import "${logos-design-system}/nix/library.nix" { inherit pkgs; common = dsCommon; };
+        });
       forAllSystems = f: logos-nix.lib.forAllTargets ({ system, pkgs }:
         let buildSystem = buildSystemFor system; in f {
         inherit system pkgs;
@@ -182,7 +193,10 @@
       });
     in
     {
-      packages = forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
+      packages = forAllMobileTargets ({ pkgs, system, buildSystem, logosDesignSystem }: {
+        # Slices 04/06 add main-ui-plugin, shell-preview-android/ios here.
+        design-system = logosDesignSystem;
+      }) // forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
         let
           # Common configuration
           common = import ./nix/default.nix {

--- a/flake.nix
+++ b/flake.nix
@@ -196,7 +196,22 @@
       packages = forAllMobileTargets ({ pkgs, system, buildSystem, logosDesignSystem }: {
         # Slices 04/06 add main-ui-plugin, shell-preview-android/ios here.
         design-system = logosDesignSystem;
-      }) // forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
+      } // nixpkgs.lib.optionalAttrs (nixpkgs.lib.hasPrefix "aarch64-ios" system) (
+        # iOS replaces design-system too: its stages must compile on Xcode's
+        # clang, which the nixpkgs iOS stdenv behind
+        # logosDesignSystem does not.
+        import ./nix/shell-preview-ios.nix {
+          inherit pkgs;
+          src = ./.;
+          # Only .version is read; the logos inputs never reach these stages.
+          version = (import ./nix/default.nix {
+            inherit pkgs;
+            logosSdk = null; logosProtocolPkg = null; logosQtHost = null;
+            logosModule = null; logosLiblogos = null;
+          }).version;
+          designSystemSrc = logos-design-system;
+        }
+      )) // forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
         let
           # Common configuration
           common = import ./nix/default.nix {
@@ -634,6 +649,13 @@
         bin-bundle-dir = {
           type = "app";
           program = "${self.packages.${system}.bin-bundle-dir}/bin/LogosBasecamp";
+        };
+      } // nixpkgs.lib.optionalAttrs (system == "aarch64-darwin") {
+        # nix run .#run-ios-sim -- the impure half of shell-preview-ios:
+        # Xcode-generator configure, unsigned xcodebuild, simctl.
+        run-ios-sim = {
+          type = "app";
+          program = "${self.packages.aarch64-ios-simulator.run-ios-sim}/bin/run-ios-sim";
         };
       });
 

--- a/nix/shell-preview-ios.nix
+++ b/nix/shell-preview-ios.nix
@@ -1,0 +1,105 @@
+# shell-preview for iOS: the pure half as static archives (pkgs.mkIosCmakeStage),
+# plus run-ios-sim, the impure Xcode-generator link and simctl step.
+{ pkgs, src, version, designSystemSrc }:
+
+let
+  inherit (pkgs) lib;
+  buildPkgs = pkgs.pkgsBuildBuild;
+  appleSdk = pkgs.qt6.qtbase.appleSdk;
+
+  designSystem = pkgs.mkIosCmakeStage {
+    pname = "logos-design-system-ios";
+    version = "1.0.0";
+    src = designSystemSrc;
+  };
+
+  mainUi = pkgs.mkIosCmakeStage {
+    pname = "logos-basecamp-main-ui-ios";
+    inherit version src;
+    sourceDir = "src";
+    buildInputs = [ designSystem ];
+    cmakeFlags = [
+      "-DMAIN_UI_STATIC=ON"
+      "-DLogosDesignSystem_DIR=${designSystem}/lib/cmake/LogosDesignSystem"
+    ];
+  };
+
+  stage = pkgs.mkIosCmakeStage {
+    pname = "logos-basecamp-shell-preview-ios";
+    inherit version src;
+    sourceDir = "shell-preview/platform/ios/stage";
+  };
+
+  runIosSim = buildPkgs.writeShellApplication {
+    name = "run-ios-sim";
+    runtimeInputs = [ buildPkgs.cmake pkgs.xcodeWrapper ];
+    text = ''
+      # The stages were gated at build time; the link step runs later, so
+      # gate again before touching xcodebuild.
+      ${pkgs.xcodeWrapper.versionGate}
+
+      app_src=${src}/shell-preview/platform/ios/app
+      bundle_id=co.logos.basecamp.shellpreview
+      # keyed on the stage store path: CMake refuses a cache made from other inputs
+      build_dir="''${LOGOS_IOS_SHELL_PREVIEW_BUILD_DIR:-''${TMPDIR:-/tmp}/basecamp-shell-preview-ios/$(basename ${stage})}"
+      mkdir -p "$build_dir"
+
+      # CMAKE_FIND_ROOT_PATH too: an iOS sysroot puts find_package in
+      # root-only mode, where CMAKE_PREFIX_PATH alone finds nothing.
+      echo "==> configure ($build_dir)"
+      cmake -S "$app_src" -B "$build_dir" -G Xcode \
+        -DCMAKE_TOOLCHAIN_FILE=${pkgs.logosQtCrossToolchainFile} \
+        ${lib.escapeShellArgs pkgs.logosQtCrossCmakeFlags} \
+        "-DCMAKE_PREFIX_PATH=${stage};${mainUi};${designSystem}" \
+        "-DCMAKE_FIND_ROOT_PATH=${stage};${mainUi};${designSystem}" \
+        "-DBASECAMP_QML_SCAN_ROOTS=${src}/src/Basecamp;${designSystemSrc}/src/qml" \
+        "-DBASECAMP_FIXTURE=${src}/shell-preview/fixtures/shell-fixture.json"
+
+      echo "==> xcodebuild (unsigned, ${appleSdk}; full log: $build_dir/xcodebuild.log)"
+      app="$build_dir/Debug-${appleSdk}/BasecampShellPreview.app"
+      rm -rf "$app"
+      # errexit+pipefail would exit on grep's status before the message below
+      set +e
+      xcodebuild -project "$build_dir/BasecampShellPreviewIos.xcodeproj" -target BasecampShellPreview \
+        -configuration Debug -sdk ${appleSdk} -arch arm64 \
+        CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= \
+        build 2>&1 | tee "$build_dir/xcodebuild.log" | grep -E '^\*\*|error:|warning: .*ld'
+      xcode_status=''${PIPESTATUS[0]}
+      set -e
+      if [ "$xcode_status" -ne 0 ]; then
+        echo "xcodebuild failed; see $build_dir/xcodebuild.log" >&2
+        exit 1
+      fi
+      [ -d "$app" ] || { echo "xcodebuild produced no $app" >&2; exit 1; }
+
+      udid=$(xcrun simctl list devices booted | grep -o -m1 '[0-9A-F-]\{36\}' || true)
+      if [ -z "$udid" ]; then
+        udid=$(xcrun simctl list devices available | grep -m1 'iPhone' | grep -o '[0-9A-F-]\{36\}')
+        echo "==> no simulator booted; booting $udid"
+        xcrun simctl boot "$udid"
+      fi
+      open -a Simulator --args -CurrentDeviceUDID "$udid"
+      xcrun simctl bootstatus "$udid" -b >/dev/null
+
+      echo "==> install + launch on $udid (console attached; extra arguments reach the app)"
+      echo "    more: xcrun simctl spawn $udid log stream --level info --predicate 'process == \"BasecampShellPreview\"'"
+      xcrun simctl install "$udid" "$app"
+      # simctl returns 0 whatever the app did, so an attached app that is gone
+      # within seconds is treated as the startup qFatal it almost always is.
+      launched=$(date +%s)
+      xcrun simctl launch --console-pty "$udid" "$bundle_id" "$@"
+      if [ $(( $(date +%s) - launched )) -lt 5 ]; then
+        echo "app exited right after launch; the console output above says why" >&2
+        exit 1
+      fi
+    '';
+  };
+in
+{
+  design-system = designSystem;
+  main-ui-plugin = mainUi;
+  shell-preview-ios = stage;
+}
+// lib.optionalAttrs (appleSdk == "iphonesimulator") {
+  run-ios-sim = runIosSim;
+}

--- a/shell-preview/CMakeLists.txt
+++ b/shell-preview/CMakeLists.txt
@@ -14,17 +14,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_AUTOMOC ON)
 
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets)
+# Qml only for ShellSections.h (QML_ELEMENT), which the fixture validates against.
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Qml)
 
-qt_add_executable(basecamp-shell-preview
-    src/main.cpp
-    src/FixtureBackend.cpp
-    src/FixtureBackend.h
-    src/FixtureShellHost.cpp
-    src/FixtureShellHost.h
-    src/FixtureModels.cpp
-    src/FixtureModels.h
-)
+include(sources.cmake)
+
+qt_add_executable(basecamp-shell-preview src/main.cpp ${SHELL_PREVIEW_HOST_SOURCES})
 
 qt_add_resources(basecamp-shell-preview "shell_preview_fixture"
     PREFIX "/shell-preview"
@@ -39,4 +34,16 @@ target_include_directories(basecamp-shell-preview PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/../app/interfaces
 )
 
-target_link_libraries(basecamp-shell-preview PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets)
+target_link_libraries(basecamp-shell-preview PRIVATE Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Qml)
+
+# Link a MAIN_UI_STATIC build of the shell into the host instead of loading
+# main_ui.so at runtime; needs the BasecampMainUI package that build exports.
+option(SHELL_PREVIEW_STATIC_SHELL "Link main_ui statically into the host" OFF)
+if(SHELL_PREVIEW_STATIC_SHELL)
+    find_package(Qt6 REQUIRED COMPONENTS Quick QuickWidgets QuickControls2)
+    find_package(LogosDesignSystem CONFIG REQUIRED)
+    find_package(BasecampMainUI CONFIG REQUIRED)
+    target_compile_definitions(basecamp-shell-preview PRIVATE SHELL_PREVIEW_STATIC_SHELL)
+    target_link_libraries(basecamp-shell-preview PRIVATE Basecamp::MainUI Logos::DesignSystem
+        Qt6::Quick Qt6::QuickWidgets Qt6::QuickControls2)
+endif()

--- a/shell-preview/README.md
+++ b/shell-preview/README.md
@@ -71,6 +71,29 @@ binary.
 QML actually touches ~130 members, concentrated in `Shell/ContentViews.qml` and
 `Sidebar/SidebarPanel.qml`. Adding a view usually means adding a property here.
 
+## iOS simulator
+
+Static Qt cannot dlopen the shell, so on iOS `main_ui` (built with `MAIN_UI_STATIC`)
+is linked into the host (`SHELL_PREVIEW_STATIC_SHELL`, usable on any platform)
+and reached through `QPluginLoader::staticInstances()`; the
+`IShellView` contract and the ABI check are the same. The pure half builds the
+archives on Xcode's clang in nix, the impure half links and launches:
+
+```bash
+nix build .#packages.aarch64-ios-simulator.shell-preview-ios   # static archives only
+nix run .#run-ios-sim                                          # xcodebuild + simctl, unsigned
+nix run .#run-ios-sim -- --fixture /abs/path.json              # arguments reach the app
+```
+
+Sources: `platform/ios/stage` (Ninja, the fixture host archive) and
+`platform/ios/app` (Xcode generator, `main.cpp` and the bundle). A fixture may
+set `currentActiveSectionIndex` to open on App Manager (1) or Settings (3);
+the desktop layout's 800px minimum clips on a phone, expected for now. Logs:
+`xcrun simctl spawn booted log stream --level info --predicate 'process == "BasecampShellPreview"'`.
+
+Gotcha: Qt registers default plugins only from its own prefix, so the static
+qsvg plugin from the qtsvg prefix is linked by hand in `platform/ios/app`.
+
 ## For mobile
 
 The host is a desktop one — `QApplication`, `QMainWindow`, `QQuickWidget`. A

--- a/shell-preview/platform/ios/Info.plist.in
+++ b/shell-preview/platform/ios/Info.plist.in
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundleDisplayName</key>
+    <string>Shell Preview</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>LSRequiresIPhoneOS</key>
+    <true/>
+    <key>UILaunchStoryboardName</key>
+    <string>@qt_ios_launch_screen_plist_entry@</string>
+    <key>UIRequiresFullScreen</key>
+    <true/>
+    <key>UISupportedInterfaceOrientations</key>
+    <array>
+        <string>UIInterfaceOrientationPortrait</string>
+        <string>UIInterfaceOrientationLandscapeLeft</string>
+        <string>UIInterfaceOrientationLandscapeRight</string>
+    </array>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright © 2025 Logos. All rights reserved.</string>
+</dict>
+</plist>

--- a/shell-preview/platform/ios/app/CMakeLists.txt
+++ b/shell-preview/platform/ios/app/CMakeLists.txt
@@ -1,0 +1,66 @@
+# The impure half: configured with the Xcode generator by
+# `nix run .#run-ios-sim` against the store archives from the Ninja stages.
+# Only main.cpp and the fixture resource are compiled here.
+cmake_minimum_required(VERSION 3.24)
+project(BasecampShellPreviewIos LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Quick Qml QuickWidgets QuickControls2 Svg)
+qt_standard_project_setup(REQUIRES 6.5)
+
+find_package(LogosDesignSystem CONFIG REQUIRED)
+find_package(BasecampMainUI CONFIG REQUIRED)
+find_package(BasecampShellPreviewHost CONFIG REQUIRED)
+
+# Directories qmlimportscanner walks to decide which static Qt QML plugins the
+# bundle needs. The archives carry compiled QML, so the scan has to see sources.
+set(BASECAMP_QML_SCAN_ROOTS "" CACHE STRING "QML source roots to scan for Qt plugin imports")
+set(BASECAMP_FIXTURE ${CMAKE_CURRENT_SOURCE_DIR}/../../../fixtures/shell-fixture.json
+    CACHE FILEPATH "Fixture JSON compiled into the bundle")
+
+set(SHELL_PREVIEW_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
+
+qt_add_executable(BasecampShellPreview MACOSX_BUNDLE ${SHELL_PREVIEW_SRC}/main.cpp)
+target_compile_definitions(BasecampShellPreview PRIVATE SHELL_PREVIEW_STATIC_SHELL)
+
+get_filename_component(fixture_dir ${BASECAMP_FIXTURE} DIRECTORY)
+qt_add_resources(BasecampShellPreview "shell_preview_fixture"
+    PREFIX "/shell-preview"
+    BASE ${fixture_dir}
+    FILES ${BASECAMP_FIXTURE}
+)
+
+# Qt6::Svg is linked here and not by the shell: it exists only to pull the
+# static qsvg image format plugin into the bundle for the sidebar icons.
+target_link_libraries(BasecampShellPreview PRIVATE
+    Basecamp::ShellPreviewHost
+    Basecamp::MainUI
+    Logos::DesignSystem
+    Qt6::Widgets
+    Qt6::QuickWidgets
+    Qt6::QuickControls2
+    Qt6::Svg
+)
+
+set(QT_QML_IMPORT_SCANNER_EXTRA_ROOT_PATHS ${BASECAMP_QML_SCAN_ROOTS})
+
+# Qt registers default plugins by globbing its own prefix's Qt6Gui/ directory;
+# qsvg's config sits in the qtsvg prefix, so it is never seen. Blank icons.
+include("${Qt6Svg_DIR}/../Qt6Gui/Qt6QSvgPluginConfig.cmake")
+# The _init object carries the Q_IMPORT_PLUGIN; without it the archive is dead-stripped.
+target_link_libraries(BasecampShellPreview PRIVATE Qt6::QSvgPlugin Qt6::QSvgPlugin_init)
+
+set_target_properties(BasecampShellPreview PROPERTIES
+    MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/../Info.plist.in
+    MACOSX_BUNDLE_GUI_IDENTIFIER co.logos.basecamp.shellpreview
+    MACOSX_BUNDLE_BUNDLE_NAME "Shell Preview"
+    MACOSX_BUNDLE_BUNDLE_VERSION 1
+    MACOSX_BUNDLE_SHORT_VERSION_STRING 0.1
+    XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER co.logos.basecamp.shellpreview
+    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO
+    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO
+    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+)

--- a/shell-preview/platform/ios/stage/CMakeLists.txt
+++ b/shell-preview/platform/ios/stage/CMakeLists.txt
@@ -1,0 +1,52 @@
+# iOS stage of shell-preview: the fixture host as a static archive, built with
+# Ninja inside nix. Everything except main.cpp, which the Xcode project in
+# ../app compiles so the bundle has a real entry point of its own.
+cmake_minimum_required(VERSION 3.24)
+project(BasecampShellPreviewHost LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_AUTOMOC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Qml)
+
+set(SHELL_PREVIEW_SRC ${CMAKE_CURRENT_SOURCE_DIR}/../../../src)
+set(BASECAMP_INTERFACES ${CMAKE_CURRENT_SOURCE_DIR}/../../../../app/interfaces)
+
+include(${CMAKE_CURRENT_SOURCE_DIR}/../../../sources.cmake)
+
+add_library(shell_preview_host STATIC ${SHELL_PREVIEW_HOST_SOURCES})
+
+target_include_directories(shell_preview_host PUBLIC
+    $<BUILD_INTERFACE:${SHELL_PREVIEW_SRC}>
+    $<BUILD_INTERFACE:${BASECAMP_INTERFACES}>
+    $<INSTALL_INTERFACE:include/basecamp-shell-preview>
+)
+
+target_link_libraries(shell_preview_host PUBLIC Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Qml)
+
+set_target_properties(shell_preview_host PROPERTIES EXPORT_NAME ShellPreviewHost)
+
+install(TARGETS shell_preview_host EXPORT BasecampShellPreviewHostTargets
+    ARCHIVE DESTINATION lib)
+install(FILES
+    ${SHELL_PREVIEW_SRC}/FixtureBackend.h
+    ${SHELL_PREVIEW_SRC}/FixtureShellHost.h
+    ${SHELL_PREVIEW_SRC}/FixtureModels.h
+    ${BASECAMP_INTERFACES}/IShellHost.h
+    ${BASECAMP_INTERFACES}/IShellView.h
+    ${BASECAMP_INTERFACES}/BasecampModelRoles.h
+    ${BASECAMP_INTERFACES}/InstallEnums.h
+    ${BASECAMP_INTERFACES}/ShellSections.h
+    DESTINATION include/basecamp-shell-preview)
+install(EXPORT BasecampShellPreviewHostTargets
+    FILE BasecampShellPreviewHostTargets.cmake
+    NAMESPACE Basecamp::
+    DESTINATION lib/cmake/BasecampShellPreviewHost)
+file(CONFIGURE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BasecampShellPreviewHostConfig.cmake CONTENT [[
+include(CMakeFindDependencyMacro)
+find_dependency(Qt6 COMPONENTS Core Gui Widgets Qml)
+include("${CMAKE_CURRENT_LIST_DIR}/BasecampShellPreviewHostTargets.cmake")
+]] @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BasecampShellPreviewHostConfig.cmake
+    DESTINATION lib/cmake/BasecampShellPreviewHost)

--- a/shell-preview/sources.cmake
+++ b/shell-preview/sources.cmake
@@ -1,0 +1,10 @@
+# The fixture host, minus main.cpp: shared by the desktop executable and the
+# iOS stage in platform/ios/stage. Paths are relative to this file.
+set(SHELL_PREVIEW_HOST_SOURCES
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureBackend.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureBackend.h
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureShellHost.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureShellHost.h
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureModels.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/src/FixtureModels.h
+)

--- a/shell-preview/src/FixtureBackend.cpp
+++ b/shell-preview/src/FixtureBackend.cpp
@@ -1,4 +1,5 @@
 #include "FixtureBackend.h"
+#include "ShellSections.h"
 
 #include <QDebug>
 #include <QJsonArray>
@@ -13,6 +14,11 @@ FixtureBackend::FixtureBackend(const QJsonObject& fixture, QObject* parent)
     m_uiModules.setRows(m_fixture.value("uiModules").toArray().toVariantList());
     m_coreModules.setRows(m_fixture.value("coreModules").toArray().toVariantList());
     m_apps.setRows(m_fixture.value("apps").toArray().toVariantList());
+    const int section = m_fixture.value("currentActiveSectionIndex").toInt(m_sectionIndex);
+    if (ShellSection::isValid(section))
+        m_sectionIndex = section;
+    else
+        qWarning() << "fixture: ignoring invalid currentActiveSectionIndex" << section;
 }
 
 int FixtureBackend::currentActiveSectionIndex() const { return m_sectionIndex; }

--- a/shell-preview/src/FixtureShellHost.cpp
+++ b/shell-preview/src/FixtureShellHost.cpp
@@ -1,9 +1,17 @@
 #include "FixtureShellHost.h"
+#include "ShellSections.h"
 
 #include <QDebug>
 
 FixtureShellHost::FixtureShellHost(const QJsonObject& fixture)
-    : m_backend(fixture) {}
+    : m_backend(fixture)
+{
+    // The sidebar writes the section index straight into the backend; the
+    // content stack only follows if the observer hears about it.
+    QObject::connect(&m_backend, &FixtureBackend::currentActiveSectionIndexChanged, &m_backend, [this] {
+        if (m_observer) m_observer->onSectionIndexChanged(m_backend.currentActiveSectionIndex());
+    });
+}
 
 QObject* FixtureShellHost::backendObject() { return &m_backend; }
 
@@ -37,3 +45,11 @@ QString FixtureShellHost::displayNameFor(const QString& name) const
 }
 
 void FixtureShellHost::setObserver(IShellObserver* observer) { m_observer = observer; }
+
+void FixtureShellHost::replaySection()
+{
+    // The shell starts on the workspace and only moves on a callback; the
+    // fixture's section was set before any observer could hear the signal.
+    if (m_observer && m_backend.currentActiveSectionIndex() != ShellSection::Workspace)
+        m_observer->onSectionIndexChanged(m_backend.currentActiveSectionIndex());
+}

--- a/shell-preview/src/FixtureShellHost.h
+++ b/shell-preview/src/FixtureShellHost.h
@@ -26,6 +26,11 @@ public:
     QString  displayNameFor(const QString& name) const override;
     void     setObserver(IShellObserver* observer) override;
 
+    // Call once after the shell is created: announces a fixture that opens
+    // on a section other than the workspace. Later changes reach the
+    // observer through the signal connected in the constructor.
+    void replaySection();
+
 private:
     FixtureBackend  m_backend;
     IShellObserver* m_observer = nullptr;

--- a/shell-preview/src/main.cpp
+++ b/shell-preview/src/main.cpp
@@ -25,6 +25,38 @@
 #include <QMainWindow>
 #include <QPluginLoader>
 
+#if defined(SHELL_PREVIEW_STATIC_SHELL)
+// main_ui built with MAIN_UI_STATIC is linked in (always on iOS, where static
+// Qt cannot dlopen a plugin) and reached through staticInstances() instead.
+Q_IMPORT_PLUGIN(MainShellView)
+#endif
+
+namespace {
+
+IShellView* resolveShell(const QString& shellPath)
+{
+#if defined(SHELL_PREVIEW_STATIC_SHELL)
+    Q_UNUSED(shellPath);
+    for (QObject* instance : QPluginLoader::staticInstances()) {
+        if (auto* shell = qobject_cast<IShellView*>(instance))
+            return shell;
+    }
+    qFatal("No static plugin implements IShellView; was main_ui linked with Q_IMPORT_PLUGIN?");
+#else
+    auto* loader = new QPluginLoader(shellPath, QCoreApplication::instance());
+    if (!loader->load())
+        qFatal("Failed to load the shell from %s: %s",
+               qUtf8Printable(shellPath), qUtf8Printable(loader->errorString()));
+
+    auto* shell = qobject_cast<IShellView*>(loader->instance());
+    if (!shell)
+        qFatal("%s does not implement IShellView", qUtf8Printable(shellPath));
+    return shell;
+#endif
+}
+
+} // namespace
+
 int main(int argc, char* argv[])
 {
     QApplication app(argc, argv);
@@ -66,28 +98,28 @@ int main(int argc, char* argv[])
             fixture = QJsonDocument::fromJson(f.readAll()).object();
     }
 
-    QPluginLoader loader(shellPath);
-    if (!loader.load())
-        qFatal("Failed to load the shell from %s: %s",
-               qUtf8Printable(shellPath), qUtf8Printable(loader.errorString()));
-
-    auto* shell = qobject_cast<IShellView*>(loader.instance());
-    if (!shell)
-        qFatal("%s does not implement IShellView", qUtf8Printable(shellPath));
+    IShellView* shell = resolveShell(shellPath);
 
     // Same check the real host makes: a shell built against a different
     // revision of IShellHost.h would jump through a mismatched vtable.
     if (shell->hostAbiVersion() != IShellHost_abi)
         qFatal("shell was built against IShellHost ABI %d, host is %d",
                shell->hostAbiVersion(), IShellHost_abi);
+    qInfo("shell-preview: shell reports IShellHost ABI %d, host has %d", shell->hostAbiVersion(),
+          IShellHost_abi);
 
     FixtureShellHost host(fixture);
 
     QMainWindow window;
     window.setWindowTitle("Logos Basecamp — shell preview (fixture data)");
     window.setCentralWidget(shell->createShell(&host));
+    host.replaySection();
+#if defined(Q_OS_IOS)
+    window.showFullScreen();
+#else
     window.resize(1280, 860);
     window.show();
+#endif
 
     const int rc = app.exec();
     shell->destroyShell(window.centralWidget());

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,10 +51,22 @@ set(SOURCES
     ${BASECAMP_INTERFACES}/BasecampModelRoles.h
 )
 
+# iOS cannot dlopen a Qt plugin against static Qt frameworks: the
+# host imports the archive with Q_IMPORT_PLUGIN instead of QPluginLoader.
+option(MAIN_UI_STATIC "Build main_ui as a static archive for Q_IMPORT_PLUGIN" OFF)
+
 # SHARED, not MODULE: QPluginLoader is happy with either, and with the
 # PREFIX/SUFFIX block below SHARED produces exactly the artefact names
 # app/window.cpp and the bundler look for.
-add_library(main_ui SHARED ${SOURCES})
+if(MAIN_UI_STATIC)
+    # Not qt_add_plugin(STATIC): that adds a main_ui_init object with its own
+    # Q_IMPORT_PLUGIN for consumers, duplicating the host's explicit import.
+    add_library(main_ui STATIC ${SOURCES})
+    # moc emits qt_static_plugin_MainShellView() only under this define.
+    target_compile_definitions(main_ui PRIVATE QT_STATICPLUGIN)
+else()
+    add_library(main_ui SHARED ${SOURCES})
+endif()
 
 # ── QML modules ─────────────────────────────────────────────────────────────
 # QML_FILES/RESOURCES resolve against CMAKE_CURRENT_SOURCE_DIR, and a `../`
@@ -71,6 +83,7 @@ qt_add_qml_module(basecamp_backend_qml
     URI Basecamp.Backend
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_backend_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Backend
     SOURCES
@@ -87,6 +100,7 @@ qt_add_qml_module(basecamp_common_qml
     URI Basecamp.Common
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_common_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Common
     QML_FILES
@@ -98,6 +112,7 @@ qt_add_qml_module(basecamp_sidebar_qml
     URI Basecamp.Sidebar
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_sidebar_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Sidebar
     QML_FILES
@@ -111,6 +126,7 @@ qt_add_qml_module(basecamp_appmanager_qml
     URI Basecamp.AppManager
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_appmanager_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/AppManager
     QML_FILES
@@ -131,6 +147,7 @@ qt_add_qml_module(basecamp_settings_qml
     URI Basecamp.Settings
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_settings_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Settings
     QML_FILES
@@ -149,6 +166,7 @@ qt_add_qml_module(basecamp_shell_qml
     URI Basecamp.Shell
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_shell_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Shell
     QML_FILES
@@ -166,6 +184,7 @@ qt_add_qml_module(basecamp_icons_qml
     URI Basecamp.Icons
     VERSION 1.0
     STATIC
+    OUTPUT_TARGETS basecamp_icons_qml_extra_targets
     RESOURCE_PREFIX /qt/qml
     OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/Basecamp/Icons
     QML_FILES
@@ -209,16 +228,54 @@ target_link_libraries(main_ui
         basecamp_settings_qml
         basecamp_shell_qml
         basecamp_icons_qml
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_backend_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_common_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_sidebar_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_appmanager_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_settings_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_shell_qmlplugin>
-        $<LINK_LIBRARY:WHOLE_ARCHIVE,basecamp_icons_qmlplugin>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_backend_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_common_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_sidebar_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_appmanager_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_settings_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_shell_qmlplugin>>
+        $<LINK_LIBRARY:WHOLE_ARCHIVE,$<TARGET_NAME:basecamp_icons_qmlplugin>>
 )
 
-if(APPLE)
+if(MAIN_UI_STATIC)
+    # Exported as Basecamp::MainUI. Qt's resource/init OBJECT libraries must be
+    # in the set too or the imported link interface dangles (as LogosDesignSystem).
+    set_target_properties(main_ui PROPERTIES EXPORT_NAME MainUI)
+    install(TARGETS main_ui
+        basecamp_backend_qml    basecamp_backend_qmlplugin
+        basecamp_common_qml     basecamp_common_qmlplugin
+        basecamp_sidebar_qml    basecamp_sidebar_qmlplugin
+        basecamp_appmanager_qml basecamp_appmanager_qmlplugin
+        basecamp_settings_qml   basecamp_settings_qmlplugin
+        basecamp_shell_qml      basecamp_shell_qmlplugin
+        basecamp_icons_qml      basecamp_icons_qmlplugin
+        ${basecamp_backend_qml_extra_targets}
+        ${basecamp_common_qml_extra_targets}
+        ${basecamp_sidebar_qml_extra_targets}
+        ${basecamp_appmanager_qml_extra_targets}
+        ${basecamp_settings_qml_extra_targets}
+        ${basecamp_shell_qml_extra_targets}
+        ${basecamp_icons_qml_extra_targets}
+        EXPORT BasecampMainUITargets
+        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib
+        RUNTIME DESTINATION bin
+        OBJECTS DESTINATION lib/objects
+    )
+    install(EXPORT BasecampMainUITargets
+        FILE BasecampMainUITargets.cmake
+        NAMESPACE Basecamp::
+        DESTINATION lib/cmake/BasecampMainUI
+    )
+    file(CONFIGURE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/BasecampMainUIConfig.cmake CONTENT [[
+include(CMakeFindDependencyMacro)
+find_dependency(Qt6 COMPONENTS Core Gui Widgets Quick Qml QuickWidgets QuickControls2)
+find_dependency(LogosDesignSystem CONFIG)
+include("${CMAKE_CURRENT_LIST_DIR}/BasecampMainUITargets.cmake")
+]] @ONLY)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BasecampMainUIConfig.cmake
+        DESTINATION lib/cmake/BasecampMainUI)
+elseif(APPLE)
     set_target_properties(main_ui PROPERTIES
         BUNDLE FALSE
         FRAMEWORK FALSE
@@ -241,4 +298,6 @@ else()
     )
 endif()
 
-install(TARGETS main_ui LIBRARY DESTINATION lib RUNTIME DESTINATION lib)
+if(NOT MAIN_UI_STATIC)
+    install(TARGETS main_ui LIBRARY DESTINATION lib RUNTIME DESTINATION lib)
+endif()


### PR DESCRIPTION
The Basecamp Shell preview (real `main_ui` against the fixture, no Logos code) running on the iOS simulator, built through nix. First basecamp slice of the mobile track; Android follows stacked on this branch.

- `feat/mobile-scaffolding` (base): mobile toolchains from upstream `logos-nix` (logos-co/logos-nix#7/#8, already in master's lock), `forAllMobileTargets`, and the design system built from its source with the cross package set.
- `packages.aarch64-ios-simulator.{design-system,main-ui-plugin,shell-preview-ios}`: static archives only (gated per derivation), built with `pkgs.mkIosCmakeStage` from logos-nix. `main_ui` gains a `MAIN_UI_STATIC` option; the desktop SHARED path is unchanged.
- `apps.aarch64-darwin.run-ios-sim`: the impure half: Xcode generator, unsigned `xcodebuild`, `simctl` install and launch with the console attached; a startup crash fails the run.
- Host: the Shell can be linked in instead of loaded at runtime (`SHELL_PREVIEW_STATIC_SHELL`, pairing with `MAIN_UI_STATIC`; works on any platform, required on iOS where static Qt cannot dlopen) and is then resolved via `staticInstances()`; the `IShellHost` ABI check stays. The fixture can select the initial section; sidebar changes reach the shell.
- `shell-preview/sources.cmake` shared by desktop and iOS so a new fixture source can't compile on one and fail on the other.

Verified: launches on an arm64 simulator showing sidebar, App Manager and Settings with fixture data; ABI 3 on both sides; no Logos runtime symbol in the binary. Desktop layout on a phone (800 px minimum), as expected for milestone 1.

Out of scope: device target, signing, a mobile-shaped UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



