### PR TITLE
ci(windows): stop staging a pkg/ tree the next checkout cannot delete

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,14 @@ jobs:
     runs-on: ${{ fromJSON(vars.WINDOWS_RUNNER || '["ubuntu-latest"]') }}
 
     steps:
+      # Before checkout, because checkout's own clean is what dies: a workspace
+      # left read-only by an earlier run fails the job at step one with EACCES,
+      # and nothing later in the job ever runs to repair it. The `cp` below no
+      # longer creates such a tree, but the runners already holding one can only
+      # be freed from outside checkout. No-op on a GitHub-hosted runner.
+      - name: Make the persisted workspace writable
+        run: chmod -R u+w . || true
+
       - uses: actions/checkout@v4
 
       - uses: logos-co/setup-nix-cache-action@v1
@@ -120,7 +128,11 @@ jobs:
           staged=$(find -L "$src" -type f | wc -l | tr -d ' ')
           [ "$staged" -gt 0 ] || { echo "::error::the bundle is empty"; exit 1; }
           mkdir -p pkg/logos-basecamp
-          cp -rL "$src"/. pkg/logos-basecamp/
+          # --no-preserve=mode is load-bearing, not tidiness: store directories
+          # are r-xr-xr-x, and propagating that leaves a pkg/ tree whose files
+          # nothing can unlink -- including the NEXT run's checkout, on a runner
+          # whose workspace persists. Same idiom as logos-windows-ci's staging.
+          cp -rL --no-preserve=mode,ownership "$src"/. pkg/logos-basecamp/
           ( cd pkg && zip -qr ../logos-basecamp-x86_64-windows.zip logos-basecamp )
           zipped=$(unzip -l logos-basecamp-x86_64-windows.zip | tail -1 | awk '{print $2}')
           echo "bundle $staged file(s) -> zip $zipped entr(ies)"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,11 +86,8 @@ jobs:
     runs-on: ${{ fromJSON(vars.WINDOWS_RUNNER || '["ubuntu-latest"]') }}
 
     steps:
-      # Before checkout, because checkout's own clean is what dies: a workspace
-      # left read-only by an earlier run fails the job at step one with EACCES,
-      # and nothing later in the job ever runs to repair it. The `cp` below no
-      # longer creates such a tree, but the runners already holding one can only
-      # be freed from outside checkout. No-op on a GitHub-hosted runner.
+      # Frees a self-hosted workspace left read-only by an earlier run. Must
+      # precede checkout: checkout's own clean is what fails on one.
       - name: Make the persisted workspace writable
         run: chmod -R u+w . || true
 
@@ -128,10 +125,8 @@ jobs:
           staged=$(find -L "$src" -type f | wc -l | tr -d ' ')
           [ "$staged" -gt 0 ] || { echo "::error::the bundle is empty"; exit 1; }
           mkdir -p pkg/logos-basecamp
-          # --no-preserve=mode is load-bearing, not tidiness: store directories
-          # are r-xr-xr-x, and propagating that leaves a pkg/ tree whose files
-          # nothing can unlink -- including the NEXT run's checkout, on a runner
-          # whose workspace persists. Same idiom as logos-windows-ci's staging.
+          # --no-preserve=mode is load-bearing: store dirs are r-xr-xr-x, and
+          # copying that leaves a pkg/ tree nothing can later unlink.
           cp -rL --no-preserve=mode,ownership "$src"/. pkg/logos-basecamp/
           ( cd pkg && zip -qr ../logos-basecamp-x86_64-windows.zip logos-basecamp )
           zipped=$(unzip -l logos-basecamp-x86_64-windows.zip | tail -1 | awk '{print $2}')


### PR DESCRIPTION
## The failure

[build-windows on run 33778997779](https://github.com/logos-co/logos-basecamp/actions/runs/33778997779/job/100727751252) fails in `actions/checkout` itself, in under a second:

```
Deleting the contents of '/github-runner/.../logos-basecamp'
##[error]File was unable to be removed Error: EACCES: permission denied,
unlink '.../pkg/logos-basecamp/bin/LogosBasecamp.exe'
```

## Why

`cp -rL` propagates the source mode. Copying the bundle out of the nix store therefore leaves `pkg/logos-basecamp/bin/` at `r-xr-xr-x`, and a file inside a directory with no write bit cannot be unlinked by anyone.

That was harmless while `build-windows` ran on ephemeral GitHub-hosted runners. #383 moved it onto the self-hosted runners, whose workspace persists between runs — so the tree one run stages is the tree the *next* run's checkout has to delete. The runner's own `after_job` cleanup hook fails identically (`rm: cannot remove './pkg/.../Qt6Core.dll': Permission denied`, ~500MB left behind), so the workspace stayed poisoned and every subsequent run failed at step one.

This is the only job affected: it is the only one that can land on a self-hosted runner, and the only one that copies out of the store. `logos-logoscore-cli`'s equivalent step already does `chmod -R u+w` and runs on `ubuntu-latest`.

## The fix

Two parts, because the second cannot rescue a runner that is already stuck.

1. **`--no-preserve=mode,ownership` on the copy** — never create the tree in the first place. This is the same idiom `logos-windows-ci`'s staging already uses. `-L` still dereferences, so the zip entry-count assertion guarding against dropped symlinks is unaffected; the dropped exec bit is meaningless for PEs in a zip bound for Windows, and nothing in CI executes from `pkg/`.

2. **A `chmod -R u+w .` step ahead of checkout** — checkout's clean is what fails, so no step of ours ever runs to repair it. This is what unblocks the runners currently holding a poisoned workspace. `chmod -R` ignores symlinks during traversal, so a leftover `result` link cannot lead it into the nix store (verified against GNU coreutils 9.8). No-op on a GitHub-hosted runner.

## Verification

Reproduced the exact `EACCES` against a simulated 555 store tree, then confirmed the fixed copy yields `drwxr-xr-x` with every file still dereferenced and `rm -rf` clean, and that the guard makes an already-poisoned tree removable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)