### PR TITLE
feat: Shell preview on a physical iOS device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,6 @@ testdata/
 # agent build logs and simulator screenshots (a dirty tree copies untracked files into src = ./.)
 *.log
 shell-ios-sim*.png
+shell-ios-device*
 shell-android*.png
+AGENT-NOTES.md

--- a/flake.nix
+++ b/flake.nix
@@ -691,6 +691,12 @@
           type = "app";
           program = "${self.packages.aarch64-ios-simulator.run-ios-sim}/bin/run-ios-sim";
         };
+        # nix run .#run-ios-device -- same, for iphoneos: automatic signing
+        # with LOGOS_IOS_TEAM_ID, then devicectl (--device <udid> when several).
+        run-ios-device = {
+          type = "app";
+          program = "${self.packages.aarch64-ios.run-ios-device}/bin/run-ios-device";
+        };
       } // pkgs.lib.optionalAttrs (builtins.elem system logos-nix.lib.androidBuildSystems) {
         # Installs the Shell preview APK on the attached device and launches it
         # (--device <serial> or ANDROID_SERIAL when several are attached).

--- a/nix/shell-preview-ios.nix
+++ b/nix/shell-preview-ios.nix
@@ -1,5 +1,6 @@
 # shell-preview for iOS: the pure half as static archives (pkgs.mkIosCmakeStage),
-# plus run-ios-sim, the impure Xcode-generator link and simctl step.
+# plus run-ios-sim / run-ios-device, the impure Xcode-generator link and
+# simctl / devicectl step for whichever SDK this package set targets.
 { pkgs, src, version, designSystemSrc }:
 
 let
@@ -30,20 +31,22 @@ let
     sourceDir = "shell-preview/platform/ios/stage";
   };
 
-  runIosSim = buildPkgs.writeShellApplication {
-    name = "run-ios-sim";
-    runtimeInputs = [ buildPkgs.cmake pkgs.xcodeWrapper ];
-    text = ''
-      # The stages were gated at build time; the link step runs later, so
-      # gate again before touching xcodebuild.
-      ${pkgs.xcodeWrapper.versionGate}
+  # Shared by both runners: the version gate, the Xcode-generator configure
+  # against the store archives and the xcodebuild step. Callers pass the
+  # signing choice: `configure_app [-D...]` and `xcodebuild_app [flags...]`.
+  buildApp = ''
+    # The stages were gated at build time; the link step runs later, so
+    # gate again before touching xcodebuild.
+    ${pkgs.xcodeWrapper.versionGate}
 
-      app_src=${src}/shell-preview/platform/ios/app
-      bundle_id=co.logos.basecamp.shellpreview
-      # keyed on the stage store path: CMake refuses a cache made from other inputs
-      build_dir="''${LOGOS_IOS_SHELL_PREVIEW_BUILD_DIR:-''${TMPDIR:-/tmp}/basecamp-shell-preview-ios/$(basename ${stage})}"
+    app_src=${src}/shell-preview/platform/ios/app
+    bundle_id=co.logos.basecamp.shellpreview
+    # keyed on the stage store path: CMake refuses a cache made from other inputs
+    build_dir="''${LOGOS_IOS_SHELL_PREVIEW_BUILD_DIR:-''${TMPDIR:-/tmp}/basecamp-shell-preview-ios/$(basename ${stage})}"
+    app="$build_dir/Debug-${appleSdk}/BasecampShellPreview.app"
+
+    configure_app() {
       mkdir -p "$build_dir"
-
       # CMAKE_FIND_ROOT_PATH too: an iOS sysroot puts find_package in
       # root-only mode, where CMAKE_PREFIX_PATH alone finds nothing.
       echo "==> configure ($build_dir)"
@@ -53,16 +56,17 @@ let
         "-DCMAKE_PREFIX_PATH=${stage};${mainUi};${designSystem}" \
         "-DCMAKE_FIND_ROOT_PATH=${stage};${mainUi};${designSystem}" \
         "-DBASECAMP_QML_SCAN_ROOTS=${src}/src/Basecamp;${designSystemSrc}/src/qml" \
-        "-DBASECAMP_FIXTURE=${src}/shell-preview/fixtures/shell-fixture.json"
+        "-DBASECAMP_FIXTURE=${src}/shell-preview/fixtures/shell-fixture.json" \
+        "$@"
+    }
 
-      echo "==> xcodebuild (unsigned, ${appleSdk}; full log: $build_dir/xcodebuild.log)"
-      app="$build_dir/Debug-${appleSdk}/BasecampShellPreview.app"
+    xcodebuild_app() {
+      echo "==> xcodebuild (${appleSdk}; full log: $build_dir/xcodebuild.log)"
       rm -rf "$app"
       # errexit+pipefail would exit on grep's status before the message below
       set +e
       xcodebuild -project "$build_dir/BasecampShellPreviewIos.xcodeproj" -target BasecampShellPreview \
-        -configuration Debug -sdk ${appleSdk} -arch arm64 \
-        CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY= \
+        -configuration Debug -sdk ${appleSdk} -arch arm64 "$@" \
         build 2>&1 | tee "$build_dir/xcodebuild.log" | grep -E '^\*\*|error:|warning: .*ld'
       xcode_status=''${PIPESTATUS[0]}
       set -e
@@ -71,6 +75,28 @@ let
         exit 1
       fi
       [ -d "$app" ] || { echo "xcodebuild produced no $app" >&2; exit 1; }
+    }
+
+    # simctl and devicectl return 0 whatever the app did, so an attached app
+    # that is gone within seconds is treated as the startup qFatal it almost
+    # always is.
+    launched_at=0
+    mark_launch() { launched_at=$(date +%s); }
+    check_launch() {
+      if [ $(( $(date +%s) - launched_at )) -lt 5 ]; then
+        echo "app exited right after launch; the console output above says why" >&2
+        exit 1
+      fi
+    }
+  '';
+
+  runIosSim = buildPkgs.writeShellApplication {
+    name = "run-ios-sim";
+    runtimeInputs = [ buildPkgs.cmake pkgs.xcodeWrapper ];
+    text = ''
+      ${buildApp}
+      configure_app -DBASECAMP_IOS_DEVELOPMENT_TEAM=
+      xcodebuild_app CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=
 
       udid=$(xcrun simctl list devices booted | grep -o -m1 '[0-9A-F-]\{36\}' || true)
       if [ -z "$udid" ]; then
@@ -84,14 +110,68 @@ let
       echo "==> install + launch on $udid (console attached; extra arguments reach the app)"
       echo "    more: xcrun simctl spawn $udid log stream --level info --predicate 'process == \"BasecampShellPreview\"'"
       xcrun simctl install "$udid" "$app"
-      # simctl returns 0 whatever the app did, so an attached app that is gone
-      # within seconds is treated as the startup qFatal it almost always is.
-      launched=$(date +%s)
+      mark_launch
       xcrun simctl launch --console-pty "$udid" "$bundle_id" "$@"
-      if [ $(( $(date +%s) - launched )) -lt 5 ]; then
-        echo "app exited right after launch; the console output above says why" >&2
+      check_launch
+    '';
+  };
+
+  # Automatic signing for the team in LOGOS_IOS_TEAM_ID, then devicectl on the
+  # one available device (--device / LOGOS_IOS_DEVICE when several are).
+  runIosDevice = buildPkgs.writeShellApplication {
+    name = "run-ios-device";
+    runtimeInputs = [ buildPkgs.cmake pkgs.xcodeWrapper ];
+    text = ''
+      device="''${LOGOS_IOS_DEVICE:-}"
+      while [ $# -gt 0 ]; do
+        case "$1" in
+          --device|-d)
+            [ $# -ge 2 ] || { echo "run-ios-device: --device needs a udid" >&2; exit 1; }
+            device="$2"; shift 2 ;;
+          --device=*) device="''${1#--device=}"; shift ;;
+          -h|--help)
+            echo "usage: run-ios-device [--device <udid>] [app arguments...]"
+            echo "  needs LOGOS_IOS_TEAM_ID=<apple team id>; LOGOS_IOS_DEVICE=<udid> is the same as --device"
+            exit 0 ;;
+          *) break ;;
+        esac
+      done
+
+      team="''${LOGOS_IOS_TEAM_ID:-}"
+      if [ -z "$team" ]; then
+        echo "run-ios-device: LOGOS_IOS_TEAM_ID is unset; export the Apple development team id (Xcode > Settings > Accounts, e.g. LOGOS_IOS_TEAM_ID=ABCDE12345)" >&2
         exit 1
       fi
+
+      # devicectl installs to `available (paired)` and to `connected` (unlocked, active).
+      available=$(xcrun devicectl list devices --hide-headers 2>/dev/null \
+        | grep -oE '[0-9A-F-]{36} +(available \(paired\)|connected)' | cut -d' ' -f1 || true)
+      if [ -z "$device" ]; then
+        count=$(printf '%s\n' "$available" | grep -c . || true)
+        if [ "$count" -eq 0 ]; then
+          echo "run-ios-device: no available device; connect and pair one, then see xcrun devicectl list devices" >&2
+          exit 1
+        elif [ "$count" -gt 1 ]; then
+          echo "run-ios-device: several devices available; pick one with --device <udid> or LOGOS_IOS_DEVICE (xcrun devicectl list devices):" >&2
+          xcrun devicectl list devices --hide-headers --filter "State BEGINSWITH 'available' OR State == 'connected'" >&2 || true
+          exit 1
+        fi
+        device=$available
+      elif ! printf '%s\n' "$available" | grep -qxF "$device"; then
+        echo "run-ios-device: $device is not an available device (xcrun devicectl list devices)" >&2
+        exit 1
+      fi
+
+      ${buildApp}
+      configure_app "-DBASECAMP_IOS_DEVELOPMENT_TEAM=$team"
+      xcodebuild_app -allowProvisioningUpdates
+
+      echo "==> install + launch on $device (console attached; extra arguments reach the app)"
+      xcrun devicectl device install app --device "$device" "$app"
+      mark_launch
+      xcrun devicectl device process launch --activate --console --terminate-existing \
+        --device "$device" "$bundle_id" "$@"
+      check_launch
     '';
   };
 in
@@ -102,4 +182,7 @@ in
 }
 // lib.optionalAttrs (appleSdk == "iphonesimulator") {
   run-ios-sim = runIosSim;
+}
+// lib.optionalAttrs (appleSdk == "iphoneos") {
+  run-ios-device = runIosDevice;
 }

--- a/shell-preview/README.md
+++ b/shell-preview/README.md
@@ -94,6 +94,23 @@ the desktop layout's 800px minimum clips on a phone, expected for now. Logs:
 Gotcha: Qt registers default plugins only from its own prefix, so the static
 qsvg plugin from the qtsvg prefix is linked by hand in `platform/ios/app`.
 
+### iPhone / iPad
+
+The same stages under the `aarch64-ios` (`iphoneos`) package set, signed
+automatically for the team in `LOGOS_IOS_TEAM_ID` (Xcode > Settings >
+Accounts) and deployed with `devicectl` to the one available device, or the
+one named by `--device <udid>` / `LOGOS_IOS_DEVICE`:
+
+```bash
+nix build .#packages.aarch64-ios.shell-preview-ios
+LOGOS_IOS_TEAM_ID=ABCDE12345 nix run .#run-ios-device
+LOGOS_IOS_TEAM_ID=ABCDE12345 nix run .#run-ios-device -- --device <udid>
+```
+
+A missing team id or device fails before anything is configured. Xcode must be
+signed into an Apple ID in that team, and the device must have Developer Mode
+on; `xcrun devicectl list devices` shows what is paired and available.
+
 ## Android
 
 The same host and the same `libmain_ui.so`, packaged as a debug-signed APK by

--- a/shell-preview/platform/ios/app/CMakeLists.txt
+++ b/shell-preview/platform/ios/app/CMakeLists.txt
@@ -1,5 +1,6 @@
 # The impure half: configured with the Xcode generator by
-# `nix run .#run-ios-sim` against the store archives from the Ninja stages.
+# `nix run .#run-ios-sim` / `.#run-ios-device` against the store archives
+# from the Ninja stages.
 # Only main.cpp and the fixture resource are compiled here.
 cmake_minimum_required(VERSION 3.24)
 project(BasecampShellPreviewIos LANGUAGES CXX)
@@ -60,7 +61,20 @@ set_target_properties(BasecampShellPreview PROPERTIES
     MACOSX_BUNDLE_BUNDLE_VERSION 1
     MACOSX_BUNDLE_SHORT_VERSION_STRING 0.1
     XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER co.logos.basecamp.shellpreview
-    XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO
-    XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO
-    XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
 )
+
+# A team id means a device build with automatic signing (the runner adds
+# -allowProvisioningUpdates); empty means the unsigned simulator build.
+set(BASECAMP_IOS_DEVELOPMENT_TEAM "" CACHE STRING "Apple development team id for automatic signing")
+if(BASECAMP_IOS_DEVELOPMENT_TEAM)
+    set_target_properties(BasecampShellPreview PROPERTIES
+        XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic
+        XCODE_ATTRIBUTE_DEVELOPMENT_TEAM ${BASECAMP_IOS_DEVELOPMENT_TEAM}
+    )
+else()
+    set_target_properties(BasecampShellPreview PROPERTIES
+        XCODE_ATTRIBUTE_CODE_SIGNING_ALLOWED NO
+        XCODE_ATTRIBUTE_CODE_SIGNING_REQUIRED NO
+        XCODE_ATTRIBUTE_CODE_SIGN_IDENTITY ""
+    )
+endif()


### PR DESCRIPTION
The Basecamp Shell preview on a physical iOS device, built through nix and deployed with one command. Stacked on #395; completes the iOS half of milestone 1 alongside #394 (simulator).

- `packages.aarch64-ios.{design-system,main-ui-plugin,shell-preview-ios}`: the same static stages as the simulator, built against the `iphoneos` Qt from logos-nix.
- `apps.aarch64-darwin.run-ios-device`: Xcode-generator configure against the store archives, automatic signing with `LOGOS_IOS_TEAM_ID` (fails before configuring when unset; `-allowProvisioningUpdates` fetches the profile), `xcodebuild` for `iphoneos`, then `devicectl` install and launch with the console attached. Single available or connected device auto-selected; `--device <udid>` / `LOGOS_IOS_DEVICE` when several; clear errors for none. The team id never enters a derivation.
- The runner body is shared with `run-ios-sim` (`configure_app`, `xcodebuild_app`, launch check); the simulator stays unsigned via an empty team.

Verified on an iPad Air (4th generation): signed with team 8B5X2M6H2Y, installed, launched, console shows `IShellHost ABI 3, host has 3`; static-only gate holds; `nm` shows no Logos runtime symbol; the simulator runner still builds and launches.

Out of scope: distribution signing, a mobile-shaped UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
