### PR TITLE
feat: load optional dependencies by default

### DIFF
--- a/app/CoreModuleManager.cpp
+++ b/app/CoreModuleManager.cpp
@@ -91,7 +91,10 @@ QStringList CoreModuleManager::loadedModules() const
 
 bool CoreModuleManager::loadModule(const QString& name)
 {
-    return m_core->loadModule(name, /*withDependencies=*/true);
+    // Widened deliberately, and stated here rather than left to the interface
+    // default: Basecamp wants the optional collaborators an operator installed,
+    // and none of them can fail this call.
+    return m_core->loadModule(name, LoadPolicy::RequiredAndOptional);
 }
 
 bool CoreModuleManager::unloadModule(const QString& name)

--- a/app/QtLogosCoreRuntime.cpp
+++ b/app/QtLogosCoreRuntime.cpp
@@ -27,9 +27,15 @@ QStringList  QtLogosCoreRuntime::loadedModules() const    { return m_core->loade
 void         QtLogosCoreRuntime::refreshModules()         { m_core->refreshModules(); }
 QVariantList QtLogosCoreRuntime::allStats() const         { return m_core->allStats(); }
 
-bool QtLogosCoreRuntime::loadModule(const QString& name, bool withDependencies)
+bool QtLogosCoreRuntime::loadModule(const QString& name, LoadPolicy policy)
 {
-    return m_core->loadModule(name, withDependencies);
+    LogosLoadDeps deps = LOGOS_LOAD_REQUIRED_AND_OPTIONAL;
+    switch (policy) {
+    case LoadPolicy::ModuleOnly:          deps = LOGOS_LOAD_MODULE_ONLY; break;
+    case LoadPolicy::RequiredDeps:        deps = LOGOS_LOAD_REQUIRED_DEPS; break;
+    case LoadPolicy::RequiredAndOptional: deps = LOGOS_LOAD_REQUIRED_AND_OPTIONAL; break;
+    }
+    return m_core->loadModule(name, deps);
 }
 
 bool QtLogosCoreRuntime::unloadModule(const QString& name, bool withDependents)

--- a/app/QtLogosCoreRuntime.h
+++ b/app/QtLogosCoreRuntime.h
@@ -20,7 +20,7 @@ public:
     void        start() override;
     QStringList knownModules() const override;
     QStringList loadedModules() const override;
-    bool        loadModule(const QString& name, bool withDependencies) override;
+    bool        loadModule(const QString& name, LoadPolicy policy) override;
     bool        unloadModule(const QString& name, bool withDependents) override;
     void        refreshModules() override;
     QVariantList allStats() const override;

--- a/app/interfaces/ICoreRuntime.h
+++ b/app/interfaces/ICoreRuntime.h
@@ -16,6 +16,15 @@
 //
 // Deliberately the smallest surface that satisfies Basecamp — every method here
 // is something a future core must keep providing.
+// How much of a module's dependency graph a load should pull in. Mirrors the
+// runtime's LogosLoadDeps without naming it: FixtureCoreRuntime implements this
+// interface against Qt alone, and QtLogosCoreRuntime maps the two.
+enum class LoadPolicy {
+    ModuleOnly,          // just this module; resolve nothing
+    RequiredDeps,        // + its required closure; a missing one fails the load
+    RequiredAndOptional, // + optionals that are installed; absence is not failure
+};
+
 class ICoreRuntime {
 public:
     // Everything the runtime needs before start(). Mirrors the ordering
@@ -48,7 +57,8 @@ public:
     // "Ensure loaded", not "load fresh": returns true when the module ends up
     // loaded, INCLUDING when it already was. Callers use it as an idempotent
     // guard, so a strict "did I load it just now" reading breaks them.
-    virtual bool loadModule(const QString& name, bool withDependencies = true) = 0;
+    virtual bool loadModule(const QString& name,
+                            LoadPolicy policy = LoadPolicy::RequiredDeps) = 0;
 
     // withDependents=true takes down everything that transitively depends on
     // `name` first, leaves-first, so nothing is briefly left pointing at a

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -278,7 +278,10 @@ int main(int argc, char *argv[])
     core->start();
     std::cout << "Logos Core started successfully!" << std::endl;
 
-    bool loaded = core->loadModule(QStringLiteral("package_manager"));
+    // Explicit, not the interface default: this path bypasses
+    // CoreModuleManager, so nothing else would widen it.
+    bool loaded = core->loadModule(QStringLiteral("package_manager"),
+                                   LoadPolicy::RequiredAndOptional);
 
     if (loaded) {
         qInfo() << "package_manager module loaded by default.";
@@ -286,7 +289,8 @@ int main(int argc, char *argv[])
         qWarning() << "Failed to load package_manager module by default.";
     }
 
-    bool downloaderLoaded = core->loadModule(QStringLiteral("package_downloader"));
+    bool downloaderLoaded = core->loadModule(QStringLiteral("package_downloader"),
+                                             LoadPolicy::RequiredAndOptional);
     if (downloaderLoaded) {
         qInfo() << "package_downloader module loaded by default.";
     } else {

--- a/docs/project.md
+++ b/docs/project.md
@@ -127,14 +127,14 @@ All `logos_core_*` calls are made from two locations: `app/main.cpp` (startup/sh
 | `logos_core_add_modules_dir(embeddedDir)` | Add the embedded modules directory (read-only, pre-installed at build time) |
 | `logos_core_add_modules_dir(userDir)` | Add the user-writable modules directory for runtime installs |
 | `logos_core_start()` | Scan module directories, initialize the capability module, start the remote object registry |
-| `logos_core_load_module("package_manager", true)` | Auto-load the package manager module (with dependencies) at startup |
+| `logos_core_load_module("package_manager", LOGOS_LOAD_REQUIRED_AND_OPTIONAL)` | Auto-load the package manager module at startup, with its required dependencies and any installed optional ones |
 | `logos_core_get_loaded_modules()` | Query loaded module names for initial status display |
 
 **Runtime Logos Module management** (`app/MainUIBackend.cpp`):
 
 | Call | Purpose |
 |------|---------|
-| `logos_core_load_module(name, true)` | Load a Logos Module and all its declared dependencies (topological sort). Also called when loading a UI App that depends on Logos Modules. |
+| `logos_core_load_module(name, LOGOS_LOAD_REQUIRED_AND_OPTIONAL)` | Load a Logos Module and all its declared dependencies (topological sort), plus any optional ones that are installed. Also called when loading a UI App that depends on Logos Modules. |
 | `logos_core_unload_module(name, false)` | Terminate a Logos Module's host process and clean up |
 | `logos_core_refresh_modules()` | Re-scan module directories after a package install |
 | `logos_core_get_loaded_modules()` | Query which Logos Modules are currently running (for Modules view status) |
@@ -207,9 +207,9 @@ The shell's entire contract is `IShellHost`: a `QWidget*` out, eight named opera
 
 | Method | Description |
 |--------|-------------|
-| `loadUiModule(name)` | Load a UI App (QML or C++ plugin) — resolve Logos Module dependencies via `logos_core_load_module(name, true)`, then load the Qt plugin and create a tab in MDI |
+| `loadUiModule(name)` | Load a UI App (QML or C++ plugin) — resolve Logos Module dependencies via `logos_core_load_module(name, LOGOS_LOAD_REQUIRED_AND_OPTIONAL)`, then load the Qt plugin and create a tab in MDI |
 | `unloadUiModule(name)` | Remove tab from MDI, destroy widget, clean up tracking state. Logos Module dependencies are left running. |
-| `loadCoreModule(name)` | Load a Logos Module via `logos_core_load_module(name, true)`, spawning a `logos_host` process |
+| `loadCoreModule(name)` | Load a Logos Module via `logos_core_load_module(name, LOGOS_LOAD_REQUIRED_AND_OPTIONAL)`, spawning a `logos_host` process |
 | `unloadCoreModule(name)` | Unload a Logos Module via `logos_core_unload_module(name, false)`, terminating its host process |
 | `refreshCoreModules()` | Call `logos_core_refresh_modules()` then `logos_core_get_known_modules()` to refresh the Logos Module list |
 | `updateModuleStats()` | Call `logos_core_get_module_stats()`, parse JSON, update `m_moduleStats` map for Logos Modules |
@@ -299,7 +299,7 @@ main()
  ├─ logos_core_add_modules_dir(<app>/../modules)       # Embedded modules (read-only)
  ├─ logos_core_add_modules_dir(~/.local/share/.../modules)  # User modules (writable)
  ├─ logos_core_start()                                 # Scan dirs, init capability module, start registry
- ├─ logos_core_load_module("package_manager", true)    # Auto-load package manager
+ ├─ logos_core_load_module("package_manager", REQUIRED_AND_OPTIONAL)  # Auto-load package manager
  ├─ logos_core_get_loaded_modules()                    # Log loaded modules
  ├─ LogosAPI("core", nullptr)                          # Create SDK instance
  ├─ Window(&logosAPI)
@@ -329,7 +329,7 @@ User clicks "Load" in UI Apps tab (or clicks app icon in sidebar)
  └─ MainUIBackend::loadUiModule(name)
      ├─ Look up app metadata from m_uiPluginMetadata cache
      ├─ Load Logos Module dependencies (if any)
-     │   └─ logos_core_load_module(dep, true) for each dependency
+     │   └─ logos_core_load_module(dep, REQUIRED_AND_OPTIONAL) for each dependency
      ├─ Create QQuickWidget (loaded in Basecamp process, NOT via liblogos)
      ├─ Configure QML engine:
      │   ├─ Set import/plugin paths
@@ -374,7 +374,7 @@ User clicks close on tab or "Unload" in UI Apps tab
 ```
 User clicks "Load" in Logos Modules tab
  └─ MainUIBackend::loadCoreModule(name)
-     ├─ logos_core_load_module(name, true)              # liblogos spawns logos_host process
+     ├─ logos_core_load_module(name, REQUIRED_AND_OPTIONAL)   # liblogos spawns logos_host process
      └─ emit coreModulesChanged()
 
 User clicks "Unload" in Logos Modules tab

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -154,7 +154,7 @@ Discovered ──► Loading ──► Running ──► Unloading ──► Dis
 ```
 
 1. **Discovery**: Basecamp queries the package manager for installed UI Apps. They appear in the UI Modules tab.
-2. **Loading**: Basecamp loads the plugin directly into its own process. For C++ plugins, `QPluginLoader` loads the shared library and calls `createWidget(LogosAPI*)`. For QML plugins, a `QQuickWidget` is created with a sandboxed QML engine (network-deny, filesystem-restricted, and barred from loading native code from the app's own directory — see [QML App Sandboxing](#qml-app-sandboxing)). If the UI App declares Logos Module dependencies, those are loaded first via `logos_core_load_module_with_dependencies()`. A new tab is added to the MDI workspace.
+2. **Loading**: Basecamp loads the plugin directly into its own process. For C++ plugins, `QPluginLoader` loads the shared library and calls `createWidget(LogosAPI*)`. For QML plugins, a `QQuickWidget` is created with a sandboxed QML engine (network-deny, filesystem-restricted, and barred from loading native code from the app's own directory — see [QML App Sandboxing](#qml-app-sandboxing)). If the UI App declares Logos Module dependencies, those are loaded first via `logos_core_load_module()` in its required-plus-optional mode, so an optional collaborator that is installed comes up too and one that is absent is not an error. A new tab is added to the MDI workspace.
 3. **Running**: The UI App's widget is displayed in a tab. The user interacts with it. The app may call Logos Modules via the QML bridge or LogosAPI.
 4. **Unloading**: The tab is removed from the MDI area, the widget is destroyed, and the plugin is unloaded. Any Logos Module dependencies remain loaded (they may be shared with other apps).
 

--- a/flake.lock
+++ b/flake.lock
@@ -3258,11 +3258,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788740226,
-        "narHash": "sha256-gLxNuXAgpIye4qbSoCrK3KeNqv1eweOKOjnIumfsOBE=",
+        "lastModified": 1788883616,
+        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e1d6bf202d2d22a0a5987868aa30b2dfe16e3b75",
+        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
         "type": "github"
       },
       "original": {
@@ -4748,11 +4748,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788366778,
-        "narHash": "sha256-68REIomik94/2reVnhzswxPdilNKHXuskfVusbhCvYo=",
+        "lastModified": 1788883616,
+        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "8d19af0709fd87c208ba811950a00e2928a8716a",
+        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
         "type": "github"
       },
       "original": {
@@ -4806,11 +4806,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1788883616,
+        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
         "type": "github"
       },
       "original": {
@@ -5495,11 +5495,11 @@
         "process-stats": "process-stats_2"
       },
       "locked": {
-        "lastModified": 1788744494,
-        "narHash": "sha256-FZ6JGF8NSMKkjmaYd9Q17pQGULroEw626Zh6BWFuES0=",
+        "lastModified": 1788886337,
+        "narHash": "sha256-QgMlBCbnEeUUjOliGiPQjrAoa1oRdWt1Zmz3dtNsScE=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "a49d301b5db64fbfdb09ad890b032cc86f01d3c1",
+        "rev": "95105df5a922220a7d05c6a66dc3e336cfebf668",
         "type": "github"
       },
       "original": {
@@ -5873,11 +5873,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -10968,11 +10968,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -11026,11 +11026,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -49911,11 +49911,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788370664,
-        "narHash": "sha256-B32jySa3pHnkq2Giqiyw7ZTjY4HzIjzpKPRe0kS1t6w=",
+        "lastModified": 1788886355,
+        "narHash": "sha256-EyG/0hSzNkEmNePt+aEdCx+UnQ+f4DShlzRuemllUow=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "7056229a95322f12d086fd0d7d753cebf3d5c3e6",
+        "rev": "2dd4be54f29803c813094c48cdd2eabdfb625ef5",
         "type": "github"
       },
       "original": {

--- a/mock/src/FixtureCoreRuntime.cpp
+++ b/mock/src/FixtureCoreRuntime.cpp
@@ -131,14 +131,16 @@ QStringList FixtureCoreRuntime::transitiveDependents(const QString& name) const
     return ordered;
 }
 
-bool FixtureCoreRuntime::loadModule(const QString& name, bool withDependencies)
+bool FixtureCoreRuntime::loadModule(const QString& name, LoadPolicy policy)
 {
     if (!isKnown(name)) {
         qWarning() << "FixtureCoreRuntime: unknown module" << name
                    << "- not in the fixture's `modules` array";
         return false;
     }
-    if (withDependencies) {
+    // The fixture models required dependencies only, so both non-ModuleOnly
+    // policies behave alike here; an absent one is still a failure.
+    if (policy != LoadPolicy::ModuleOnly) {
         for (const QString& dep : transitiveDependencies(name)) {
             if (!isKnown(dep)) {
                 qWarning() << "FixtureCoreRuntime: dependency" << dep << "of" << name

--- a/mock/src/FixtureCoreRuntime.h
+++ b/mock/src/FixtureCoreRuntime.h
@@ -19,7 +19,7 @@ public:
     void         start() override;
     QStringList  knownModules() const override;
     QStringList  loadedModules() const override;
-    bool         loadModule(const QString& name, bool withDependencies) override;
+    bool         loadModule(const QString& name, LoadPolicy policy) override;
     bool         unloadModule(const QString& name, bool withDependents) override;
     void         refreshModules() override;
     QVariantList allStats() const override;


### PR DESCRIPTION
`ICoreRuntime::loadModule`'s `bool withDependencies` becomes a `LoadPolicy`, and all three of Basecamp's load paths pass `RequiredAndOptional` by name.

**The interface default stays `RequiredDeps`**, which is exactly what `= true` meant. Widening a default moves callers silently; the widening is stated where it is wanted. No SDK-side default changes are required or proposed.

### Basecamp has two load paths, and the second is easy to miss

`CoreModuleManager::loadModule` is the obvious one — `PluginLoader` and `UIPluginManager` both route through it, and it takes no mode parameter, so hard-coding it there covers them.

But `main.cpp:281` and `:289` — the startup auto-loads of `package_manager` and `package_downloader` — hold a `std::unique_ptr<ICoreRuntime>` and call `loadModule(name)` directly, bypassing `CoreModuleManager` entirely. Left on the default, those two would quietly never get their optional dependencies. They now name the mode themselves.

### Why Basecamp's own enum and not `LogosLoadDeps`

`ICoreRuntime.h` states the seam it maintains — *"QtLogosCoreRuntime is the only file that names the core"* — and `FixtureCoreRuntime` implements the interface against `Qt6::Core` alone. Taking `LogosLoadDeps` here would drag liblogos headers into the mock backend to satisfy a type it never uses. `QtLogosCoreRuntime` maps the two, exactly as it already translates `Config` ("the two are separate types on purpose"). A `bool` cannot carry the third state, which is why the parameter had to change type at all.

### Docs

`docs/project.md` described this call as `logos_core_load_module(name, true)` in seven places, and `docs/spec.md` named a `logos_core_load_module_with_dependencies()` that liblogos no longer exports. Both now match the shipped API.

### Verification

`nix build .#default` green; mock suite 16/16 with the retyped fixture.

`.#checks.aarch64-darwin.mock-tests` fails on darwin with `g++: command not found` — that reproduces identically on untouched master, so it is pre-existing and unrelated. Ran `mock/tests/run-standalone.sh` directly against a toolchain to verify the fixture instead.

Relocks `logos-qt-sdk`, `logos-cpp-sdk`, `logos-liblogos` — the previous pins predate the three-valued enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)