### PR TITLE
chore(deps): bump package_downloader for the private download staging

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34601,11 +34601,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788345837,
-        "narHash": "sha256-nInsi0fMiivkB+Bs88IkpA7+l7pt6ft6Dsy5SQH9tX8=",
+        "lastModified": 1788902518,
+        "narHash": "sha256-XR7K6WB0NTKm9zZcecXOOAI/jac2B0quQKcQA673JcE=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "0f4c2300757f1ffa4b09f07cb1e4451b0a380688",
+        "rev": "c8b22faba75c38629f9c7e928298f15b720df7fa",
         "type": "github"
       },
       "original": {
@@ -34620,11 +34620,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1788346723,
-        "narHash": "sha256-/2WUNoBkdCoZZ0CKXQ7rSjJFJYclg1xMnHLEob/dPjk=",
+        "lastModified": 1788903889,
+        "narHash": "sha256-iAYmDNf5zfjkC3c3fMoAKQLJBqF2Yr0b8xcc0MixV1E=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "5e1b27fdebf4e64bdc34c6d8dcfdc79c553c3be2",
+        "rev": "917cf3cb12a2b0b9f04ecfcb81fdc3402519f1e4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
`logos-package-downloader-module` `5e1b27f` → `917cf3c`, which carries `logos-package-downloader` `0f4c230` → `c8b22fa` through its own lock. Six lines of `flake.lock`, no source change.

## What this picks up

[logos-package-downloader#37](https://github.com/logos-co/logos-package-downloader/pull/37) — downloads were staged in the **shared temp root** under a filename derived from package+version, so two accounts on one host collide on a single path. The loser can neither overwrite the file (`0644`, foreign owner) nor unlink it (the temp root is sticky), so that one package stays wedged for that user until someone with root clears it. Seen in the wild as an instant `download failed for 'blockchain_module'` with nothing in the log:

```
-rw-r--r-- 1 logos logos 143317792 Sep  7 19:09 /tmp/blockchain_module-0.2.4.lgx
```

Staging is now a per-uid `0700` directory. Also included: the download failure paths that previously returned an empty path in silence now report a reason, and `refreshCatalogs()` actually fetches the indexes it has always claimed to.

[logos-package-downloader-module#35](https://github.com/logos-co/logos-package-downloader-module/pull/35) is the matching module bump; its `pinnedDownload` already appended the lib's reason, so no source change was needed there either.

## Verification

`nix build path:./repos/logos-basecamp` through this repo's own lock — exit 0, rebuilding `package_downloader-module`, `package_manager_ui-module` and `logos-basecamp` itself.

The module's exposed API is unchanged (`downloadPinned`, `downloadResolvedDependencies`, `resolveDependencies`, `getCatalog`, `refreshCatalog`, `listRepositories` all keep their arity), so nothing on the calling side moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)