### PR TITLE
fix(nix): pair qt-host with the protocol the app stages, and check it in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -250,6 +250,21 @@ jobs:
           nix build .#symbol-gate -L
           nix build .#symbol-gate-negative -L
 
+      # The gate above reads what we SHIP -- one liblogos_protocol in $out/lib
+      # -- which stays true while qt-host was compiled against a second one that
+      # only the closure names, and that is an 8-byte heap overrun on every
+      # getClient(). The rule lives in logos-protocol, where the ABI is owned;
+      # run it from the revision we lock, not master, so the check and the build
+      # agree. It reads the lock, so one platform covers both.
+      - name: qt-host/protocol pairing
+        run: |
+          nix build .#app -o result-abi-subject -L
+          # Resolve the ROOT logos-protocol edge. The flat node of that name
+          # belongs to whichever edge claimed it first, which is not ours.
+          rev=$(nix flake metadata --json |
+            jq -r '.locks as $l | $l.nodes[$l.nodes[$l.root].inputs["logos-protocol"]].locked.rev')
+          nix run "github:logos-co/logos-protocol/$rev#abi-closure-check" -- ./result-abi-subject
+
       # Report-only non-blocking for now
       - name: Coverage report
         continue-on-error: true

--- a/flake.lock
+++ b/flake.lock
@@ -28,7 +28,7 @@
     "default-container_2": {
       "inputs": {
         "logos-container": "logos-container_6",
-        "logos-nix": "logos-nix_81",
+        "logos-nix": "logos-nix_80",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -57,7 +57,7 @@
     "default-container_3": {
       "inputs": {
         "logos-container": "logos-container_13",
-        "logos-nix": "logos-nix_174",
+        "logos-nix": "logos-nix_168",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -85,7 +85,7 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
-        "logos-nix": "logos-nix_253",
+        "logos-nix": "logos-nix_247",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -113,7 +113,7 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_299",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -145,7 +145,7 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
-        "logos-nix": "logos-nix_425",
+        "logos-nix": "logos-nix_419",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -173,7 +173,7 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_33",
-        "logos-nix": "logos-nix_477",
+        "logos-nix": "logos-nix_471",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -205,7 +205,7 @@
     "default-container_8": {
       "inputs": {
         "logos-container": "logos-container_38",
-        "logos-nix": "logos-nix_591",
+        "logos-nix": "logos-nix_585",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -233,7 +233,7 @@
     "default-container_9": {
       "inputs": {
         "logos-container": "logos-container_43",
-        "logos-nix": "logos-nix_643",
+        "logos-nix": "logos-nix_637",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -269,7 +269,7 @@
         "logos-module": "logos-module_6",
         "logos-module-loader": "logos-module-loader",
         "logos-nix": "logos-nix_34",
-        "logos-protocol": "logos-protocol_7",
+        "logos-protocol": "logos-protocol_6",
         "logos-qt-sdk": "logos-qt-sdk_3",
         "nixpkgs": [
           "logos-liblogos",
@@ -279,11 +279,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788486878,
-        "narHash": "sha256-gP8iRHh8tUcX7TeRz4u+bRdxjFNkHkE8HzbKEwKXXwQ=",
+        "lastModified": 1788892274,
+        "narHash": "sha256-MwIDGS/W4Mkz4BTfI2DzJ49oBq/zQHbPkgLejB1emq0=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "1eadfec1b401932473e09b59db5989fe2e06d5e1",
+        "rev": "b48871c78369ea664745aa2f3d6ef7a3cfcc3bec",
         "type": "github"
       },
       "original": {
@@ -305,7 +305,7 @@
         ],
         "logos-module": "logos-module_19",
         "logos-module-loader": "logos-module-loader_3",
-        "logos-nix": "logos-nix_85",
+        "logos-nix": "logos-nix_84",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -357,9 +357,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_40",
+        "logos-module": "logos-module_38",
         "logos-module-loader": "logos-module-loader_6",
-        "logos-nix": "logos-nix_178",
+        "logos-nix": "logos-nix_172",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -401,12 +401,12 @@
     "default-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_19",
-        "logos-cpp-sdk": "logos-cpp-sdk_24",
-        "logos-module": "logos-module_56",
+        "logos-cpp-sdk": "logos-cpp-sdk_22",
+        "logos-module": "logos-module_54",
         "logos-module-loader": "logos-module-loader_8",
-        "logos-nix": "logos-nix_258",
-        "logos-protocol": "logos-protocol_44",
-        "logos-qt-sdk": "logos-qt-sdk_19",
+        "logos-nix": "logos-nix_252",
+        "logos-protocol": "logos-protocol_40",
+        "logos-qt-sdk": "logos-qt-sdk_18",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -445,9 +445,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_69",
+        "logos-module": "logos-module_67",
         "logos-module-loader": "logos-module-loader_10",
-        "logos-nix": "logos-nix_309",
+        "logos-nix": "logos-nix_303",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -501,12 +501,12 @@
     "default-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_29",
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
-        "logos-module": "logos-module_90",
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-module": "logos-module_88",
         "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_430",
-        "logos-protocol": "logos-protocol_73",
-        "logos-qt-sdk": "logos-qt-sdk_30",
+        "logos-nix": "logos-nix_424",
+        "logos-protocol": "logos-protocol_69",
+        "logos-qt-sdk": "logos-qt-sdk_29",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -545,9 +545,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_103",
+        "logos-module": "logos-module_101",
         "logos-module-loader": "logos-module-loader_14",
-        "logos-nix": "logos-nix_481",
+        "logos-nix": "logos-nix_475",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -601,12 +601,12 @@
     "default-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_39",
-        "logos-cpp-sdk": "logos-cpp-sdk_52",
-        "logos-module": "logos-module_123",
+        "logos-cpp-sdk": "logos-cpp-sdk_50",
+        "logos-module": "logos-module_121",
         "logos-module-loader": "logos-module-loader_16",
-        "logos-nix": "logos-nix_596",
-        "logos-protocol": "logos-protocol_102",
-        "logos-qt-sdk": "logos-qt-sdk_41",
+        "logos-nix": "logos-nix_590",
+        "logos-protocol": "logos-protocol_98",
+        "logos-qt-sdk": "logos-qt-sdk_40",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -645,9 +645,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_136",
+        "logos-module": "logos-module_134",
         "logos-module-loader": "logos-module-loader_18",
-        "logos-nix": "logos-nix_647",
+        "logos-nix": "logos-nix_641",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -946,7 +946,7 @@
     },
     "logos-container_11": {
       "inputs": {
-        "logos-nix": "logos-nix_154",
+        "logos-nix": "logos-nix_148",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-container",
@@ -1034,7 +1034,7 @@
     },
     "logos-container_14": {
       "inputs": {
-        "logos-nix": "logos-nix_175",
+        "logos-nix": "logos-nix_169",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -1099,7 +1099,7 @@
     },
     "logos-container_16": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_200",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -1196,7 +1196,7 @@
     },
     "logos-container_19": {
       "inputs": {
-        "logos-nix": "logos-nix_254",
+        "logos-nix": "logos-nix_248",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1286,7 +1286,7 @@
     },
     "logos-container_21": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_283",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1391,7 +1391,7 @@
     },
     "logos-container_24": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_300",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1468,7 +1468,7 @@
     },
     "logos-container_26": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_331",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1577,7 +1577,7 @@
     },
     "logos-container_29": {
       "inputs": {
-        "logos-nix": "logos-nix_426",
+        "logos-nix": "logos-nix_420",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1673,7 +1673,7 @@
     },
     "logos-container_31": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_455",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1778,7 +1778,7 @@
     },
     "logos-container_34": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_472",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1855,7 +1855,7 @@
     },
     "logos-container_36": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_503",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1964,7 +1964,7 @@
     },
     "logos-container_39": {
       "inputs": {
-        "logos-nix": "logos-nix_592",
+        "logos-nix": "logos-nix_586",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2053,7 +2053,7 @@
     },
     "logos-container_41": {
       "inputs": {
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2158,7 +2158,7 @@
     },
     "logos-container_44": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_638",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2235,7 +2235,7 @@
     },
     "logos-container_46": {
       "inputs": {
-        "logos-nix": "logos-nix_675",
+        "logos-nix": "logos-nix_669",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2375,7 +2375,7 @@
     },
     "logos-container_7": {
       "inputs": {
-        "logos-nix": "logos-nix_82",
+        "logos-nix": "logos-nix_81",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2443,7 +2443,7 @@
     },
     "logos-container_9": {
       "inputs": {
-        "logos-nix": "logos-nix_113",
+        "logos-nix": "logos-nix_112",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2502,48 +2502,7 @@
     },
     "logos-cpp-sdk_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_29",
-        "logos-nix": "logos-nix_86",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_11": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_36",
+        "logos-lidl": "logos-lidl_35",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2555,7 +2514,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_18",
+        "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2565,6 +2524,43 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_11": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_37",
+        "logos-nix": "logos-nix_113",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2586,22 +2582,20 @@
     },
     "logos-cpp-sdk_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_38",
-        "logos-nix": "logos-nix_114",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_43",
+        "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2623,31 +2617,25 @@
     },
     "logos-cpp-sdk_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_44",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+        "logos-lidl": "logos-lidl_45",
+        "logos-nix": "logos-nix_149",
+        "logos-protocol": [
+          "logos-module-loader-qt",
+          "logos-protocol"
         ],
-        "logos-protocol": "logos-protocol_23",
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-module-loader-qt",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2658,24 +2646,16 @@
     },
     "logos-cpp-sdk_14": {
       "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_47",
+        "logos-nix": "logos-nix_156",
         "logos-protocol": [
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2697,25 +2677,24 @@
     },
     "logos-cpp-sdk_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_48",
-        "logos-nix": "logos-nix_155",
-        "logos-protocol": [
-          "logos-module-loader-qt",
-          "logos-protocol"
-        ],
+        "logos-lidl": "logos-lidl_52",
+        "logos-nix": "logos-nix_167",
+        "logos-protocol": "logos-protocol_27",
         "nixpkgs": [
-          "logos-module-loader-qt",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -2726,15 +2705,23 @@
     },
     "logos-cpp-sdk_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_50",
-        "logos-nix": "logos-nix_162",
+        "logos-lidl": "logos-lidl_53",
+        "logos-nix": "logos-nix_173",
         "logos-protocol": [
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -2742,11 +2729,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -2757,74 +2744,7 @@
     },
     "logos-cpp-sdk_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_55",
-        "logos-nix": "logos-nix_173",
-        "logos-protocol": "logos-protocol_31",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_18": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_56",
-        "logos-nix": "logos-nix_179",
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_19": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_63",
+        "logos-lidl": "logos-lidl_60",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -2835,13 +2755,81 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_34",
+        "logos-protocol": "logos-protocol_30",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_18": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_62",
+        "logos-nix": "logos-nix_201",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_19": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_68",
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_35",
+        "nixpkgs": [
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -2898,31 +2886,27 @@
     },
     "logos-cpp-sdk_20": {
       "inputs": {
-        "logos-lidl": "logos-lidl_65",
-        "logos-nix": "logos-nix_207",
+        "logos-lidl": "logos-lidl_70",
+        "logos-nix": "logos-nix_235",
         "logos-protocol": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2933,29 +2917,24 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-lidl": "logos-lidl_71",
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_75",
+        "logos-nix": "logos-nix_246",
         "logos-protocol": "logos-protocol_39",
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2966,16 +2945,22 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-        "logos-lidl": "logos-lidl_73",
-        "logos-nix": "logos-nix_241",
+        "logos-lidl": "logos-lidl_76",
+        "logos-nix": "logos-nix_249",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2998,12 +2983,23 @@
     "logos-cpp-sdk_23": {
       "inputs": {
         "logos-lidl": "logos-lidl_78",
-        "logos-nix": "logos-nix_252",
-        "logos-protocol": "logos-protocol_43",
+        "logos-nix": "logos-nix_256",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3025,33 +3021,37 @@
     },
     "logos-cpp-sdk_24": {
       "inputs": {
-        "logos-lidl": "logos-lidl_79",
-        "logos-nix": "logos-nix_255",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_85",
+        "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_44",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3062,15 +3062,13 @@
     },
     "logos-cpp-sdk_25": {
       "inputs": {
-        "logos-lidl": "logos-lidl_81",
-        "logos-nix": "logos-nix_262",
+        "logos-lidl": "logos-lidl_87",
+        "logos-nix": "logos-nix_284",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3078,8 +3076,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3102,8 +3098,130 @@
     "logos-cpp-sdk_26": {
       "inputs": {
         "logos-lidl": "logos-lidl_88",
+        "logos-nix": "logos-nix_287",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_27": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_93",
+        "logos-nix": "logos-nix_298",
+        "logos-protocol": "logos-protocol_48",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_28": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_94",
+        "logos-nix": "logos-nix_304",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_29": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_101",
         "logos-nix": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3112,9 +3230,13 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_48",
+        "logos-protocol": "logos-protocol_51",
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3140,117 +3262,13 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_27": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_90",
-        "logos-nix": "logos-nix_290",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_28": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_91",
-        "logos-nix": "logos-nix_293",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_29": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_96",
-        "logos-nix": "logos-nix_304",
-        "logos-protocol": "logos-protocol_52",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_3": {
       "inputs": {
         "logos-lidl": "logos-lidl_10",
         "logos-nix": "logos-nix_27",
-        "logos-protocol": "logos-protocol_6",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-cpp-sdk",
           "logos-nix",
@@ -3258,11 +3276,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788883616,
-        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
+        "lastModified": 1788891074,
+        "narHash": "sha256-wRkB7y/NJ9CFjpj718W5VKrC3WiB83n4yTHJ5lPT/MQ=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
+        "rev": "41ca4491f0163e0735511b6ac7d9020dec88a84c",
         "type": "github"
       },
       "original": {
@@ -3273,8 +3291,8 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_97",
-        "logos-nix": "logos-nix_310",
+        "logos-lidl": "logos-lidl_103",
+        "logos-nix": "logos-nix_332",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3284,8 +3302,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3297,19 +3313,17 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3320,7 +3334,7 @@
     },
     "logos-cpp-sdk_31": {
       "inputs": {
-        "logos-lidl": "logos-lidl_104",
+        "logos-lidl": "logos-lidl_109",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3328,24 +3342,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_55",
+        "logos-protocol": "logos-protocol_56",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3368,90 +3374,6 @@
       }
     },
     "logos-cpp-sdk_32": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_106",
-        "logos-nix": "logos-nix_338",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_33": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_112",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_60",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_34": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -3502,16 +3424,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_35": {
+    "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-lidl": "logos-lidl_119",
+        "logos-lidl": "logos-lidl_116",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_68",
+        "logos-protocol": "logos-protocol_64",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3535,10 +3457,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_36": {
+    "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-lidl": "logos-lidl_121",
-        "logos-nix": "logos-nix_413",
+        "logos-lidl": "logos-lidl_118",
+        "logos-nix": "logos-nix_407",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3547,6 +3469,71 @@
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_35": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_123",
+        "logos-nix": "logos-nix_418",
+        "logos-protocol": "logos-protocol_68",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_36": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_124",
+        "logos-nix": "logos-nix_421",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3569,12 +3556,23 @@
     "logos-cpp-sdk_37": {
       "inputs": {
         "logos-lidl": "logos-lidl_126",
-        "logos-nix": "logos-nix_424",
-        "logos-protocol": "logos-protocol_72",
+        "logos-nix": "logos-nix_428",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3596,33 +3594,37 @@
     },
     "logos-cpp-sdk_38": {
       "inputs": {
-        "logos-lidl": "logos-lidl_127",
-        "logos-nix": "logos-nix_427",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_133",
+        "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_73",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3633,15 +3635,13 @@
     },
     "logos-cpp-sdk_39": {
       "inputs": {
-        "logos-lidl": "logos-lidl_129",
-        "logos-nix": "logos-nix_434",
+        "logos-lidl": "logos-lidl_135",
+        "logos-nix": "logos-nix_456",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3649,8 +3649,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3688,6 +3686,45 @@
         ]
       },
       "locked": {
+        "lastModified": 1788891074,
+        "narHash": "sha256-wRkB7y/NJ9CFjpj718W5VKrC3WiB83n4yTHJ5lPT/MQ=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "41ca4491f0163e0735511b6ac7d9020dec88a84c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_40": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_136",
+        "logos-nix": "logos-nix_459",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1787605334,
         "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
@@ -3701,11 +3738,94 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_40": {
+    "logos-cpp-sdk_41": {
       "inputs": {
-        "logos-lidl": "logos-lidl_136",
+        "logos-lidl": "logos-lidl_141",
+        "logos-nix": "logos-nix_470",
+        "logos-protocol": "logos-protocol_77",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_42": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_142",
+        "logos-nix": "logos-nix_476",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_43": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_149",
         "logos-nix": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3714,9 +3834,13 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_77",
+        "logos-protocol": "logos-protocol_80",
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -3742,116 +3866,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_41": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_138",
-        "logos-nix": "logos-nix_462",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_42": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_139",
-        "logos-nix": "logos-nix_465",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_43": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_144",
-        "logos-nix": "logos-nix_476",
-        "logos-protocol": "logos-protocol_81",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-lidl": "logos-lidl_145",
-        "logos-nix": "logos-nix_482",
+        "logos-lidl": "logos-lidl_151",
+        "logos-nix": "logos-nix_504",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3861,8 +3879,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3874,19 +3890,17 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3897,7 +3911,7 @@
     },
     "logos-cpp-sdk_45": {
       "inputs": {
-        "logos-lidl": "logos-lidl_152",
+        "logos-lidl": "logos-lidl_157",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3905,24 +3919,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_84",
+        "logos-protocol": "logos-protocol_85",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3945,90 +3951,6 @@
       }
     },
     "logos-cpp-sdk_46": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_154",
-        "logos-nix": "logos-nix_510",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_47": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_160",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_89",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_48": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -4079,16 +4001,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_49": {
+    "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-lidl": "logos-lidl_167",
+        "logos-lidl": "logos-lidl_164",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_97",
+        "logos-protocol": "logos-protocol_93",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4104,6 +4026,65 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_48": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_166",
+        "logos-nix": "logos-nix_574",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788740226,
+        "narHash": "sha256-gLxNuXAgpIye4qbSoCrK3KeNqv1eweOKOjnIumfsOBE=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e1d6bf202d2d22a0a5987868aa30b2dfe16e3b75",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_49": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_171",
+        "logos-nix": "logos-nix_584",
+        "logos-protocol": "logos-protocol_97",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -4147,27 +4128,33 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
-        "logos-lidl": "logos-lidl_169",
-        "logos-nix": "logos-nix_580",
+        "logos-lidl": "logos-lidl_172",
+        "logos-nix": "logos-nix_587",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1788740226,
-        "narHash": "sha256-gLxNuXAgpIye4qbSoCrK3KeNqv1eweOKOjnIumfsOBE=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e1d6bf202d2d22a0a5987868aa30b2dfe16e3b75",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -4179,12 +4166,23 @@
     "logos-cpp-sdk_51": {
       "inputs": {
         "logos-lidl": "logos-lidl_174",
-        "logos-nix": "logos-nix_590",
-        "logos-protocol": "logos-protocol_101",
+        "logos-nix": "logos-nix_594",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4206,83 +4204,7 @@
     },
     "logos-cpp-sdk_52": {
       "inputs": {
-        "logos-lidl": "logos-lidl_175",
-        "logos-nix": "logos-nix_593",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_53": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_177",
-        "logos-nix": "logos-nix_600",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_54": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_184",
+        "logos-lidl": "logos-lidl_181",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4293,7 +4215,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_106",
+        "logos-protocol": "logos-protocol_102",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4321,10 +4243,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_55": {
+    "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-lidl": "logos-lidl_186",
-        "logos-nix": "logos-nix_628",
+        "logos-lidl": "logos-lidl_183",
+        "logos-nix": "logos-nix_622",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4348,6 +4270,77 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_54": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_184",
+        "logos-nix": "logos-nix_625",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_55": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_189",
+        "logos-nix": "logos-nix_636",
+        "logos-protocol": "logos-protocol_106",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -4358,14 +4351,18 @@
     },
     "logos-cpp-sdk_56": {
       "inputs": {
-        "logos-lidl": "logos-lidl_187",
-        "logos-nix": "logos-nix_631",
+        "logos-lidl": "logos-lidl_190",
+        "logos-nix": "logos-nix_642",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
@@ -4376,17 +4373,21 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -4397,86 +4398,7 @@
     },
     "logos-cpp-sdk_57": {
       "inputs": {
-        "logos-lidl": "logos-lidl_192",
-        "logos-nix": "logos-nix_642",
-        "logos-protocol": "logos-protocol_110",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_58": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_193",
-        "logos-nix": "logos-nix_648",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_59": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_200",
+        "logos-lidl": "logos-lidl_197",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4491,7 +4413,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_113",
+        "logos-protocol": "logos-protocol_109",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4502,6 +4424,90 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_58": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_199",
+        "logos-nix": "logos-nix_670",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_59": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_205",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_114",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -4533,7 +4539,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_11",
+        "logos-protocol": "logos-protocol_10",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -4560,90 +4566,6 @@
     },
     "logos-cpp-sdk_60": {
       "inputs": {
-        "logos-lidl": "logos-lidl_202",
-        "logos-nix": "logos-nix_676",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_61": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_208",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_118",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_62": {
-      "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4693,83 +4615,19 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_63": {
+    "logos-cpp-sdk_61": {
       "inputs": {
-        "logos-lidl": "logos-lidl_215",
+        "logos-lidl": "logos-lidl_212",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_126",
+        "logos-protocol": "logos-protocol_122",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_64": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-nix": [
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788883616,
-        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_65": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_219",
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_131",
-        "nixpkgs": [
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
@@ -4793,36 +4651,7 @@
     "logos-cpp-sdk_7": {
       "inputs": {
         "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_66",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788883616,
-        "narHash": "sha256-aYnrQBmI/Y/00x0cgxmy2tpfP18BPZlLUe/6mjV3bto=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "9cfb4a22e506fe5588522ea22a36513db76fc33f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_8": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_23",
-        "logos-nix": "logos-nix_69",
+        "logos-nix": "logos-nix_68",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -4852,16 +4681,57 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_9": {
+    "logos-cpp-sdk_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_28",
-        "logos-nix": "logos-nix_80",
-        "logos-protocol": "logos-protocol_15",
+        "logos-lidl": "logos-lidl_27",
+        "logos-nix": "logos-nix_79",
+        "logos-protocol": "logos-protocol_14",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_9": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_28",
+        "logos-nix": "logos-nix_85",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4911,7 +4781,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_294",
+        "logos-nix": "logos-nix_288",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
@@ -4943,7 +4813,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_311",
+        "logos-nix": "logos-nix_305",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nix-bundle-macos-app": "nix-bundle-macos-app_11",
@@ -4979,7 +4849,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_414",
+        "logos-nix": "logos-nix_408",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nix-bundle-macos-app": "nix-bundle-macos-app_12",
@@ -5007,7 +4877,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_435",
+        "logos-nix": "logos-nix_429",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nix-bundle-macos-app": "nix-bundle-macos-app_13",
@@ -5039,7 +4909,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_466",
+        "logos-nix": "logos-nix_460",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nix-bundle-macos-app": "nix-bundle-macos-app_14",
@@ -5071,7 +4941,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_483",
+        "logos-nix": "logos-nix_477",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nix-bundle-macos-app": "nix-bundle-macos-app_15",
@@ -5107,7 +4977,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_581",
+        "logos-nix": "logos-nix_575",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_90",
         "nix-bundle-macos-app": "nix-bundle-macos-app_16",
@@ -5135,7 +5005,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_601",
+        "logos-nix": "logos-nix_595",
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_91",
         "nix-bundle-macos-app": "nix-bundle-macos-app_17",
@@ -5167,7 +5037,7 @@
     },
     "logos-design-system_18": {
       "inputs": {
-        "logos-nix": "logos-nix_632",
+        "logos-nix": "logos-nix_626",
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_96",
         "nix-bundle-macos-app": "nix-bundle-macos-app_18",
@@ -5199,7 +5069,7 @@
     },
     "logos-design-system_19": {
       "inputs": {
-        "logos-nix": "logos-nix_649",
+        "logos-nix": "logos-nix_643",
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nix-bundle-macos-app": "nix-bundle-macos-app_19",
@@ -5290,7 +5160,7 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_70",
+        "logos-nix": "logos-nix_69",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_12",
         "nix-bundle-macos-app": "nix-bundle-macos-app_4",
@@ -5319,7 +5189,7 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_87",
+        "logos-nix": "logos-nix_86",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_13",
         "nix-bundle-macos-app": "nix-bundle-macos-app_5",
@@ -5352,7 +5222,7 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_163",
+        "logos-nix": "logos-nix_157",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nix-bundle-macos-app": "nix-bundle-macos-app_6",
@@ -5380,7 +5250,7 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_180",
+        "logos-nix": "logos-nix_174",
         "nix-bundle-appimage": "nix-bundle-appimage_12",
         "nix-bundle-dir": "nix-bundle-dir_25",
         "nix-bundle-macos-app": "nix-bundle-macos-app_7",
@@ -5412,7 +5282,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_242",
+        "logos-nix": "logos-nix_236",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
@@ -5440,7 +5310,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_263",
+        "logos-nix": "logos-nix_257",
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
@@ -5476,17 +5346,25 @@
         "default-module-loader": "default-module-loader",
         "logos-capability-module": "logos-capability-module_2",
         "logos-container": "logos-container_4",
-        "logos-cpp-sdk": "logos-cpp-sdk_7",
+        "logos-cpp-sdk": [
+          "logos-cpp-sdk"
+        ],
         "logos-module": "logos-module_14",
         "logos-module-loader": "logos-module-loader_2",
         "logos-modules-state-module": "logos-modules-state-module",
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_145",
         "logos-package-manager": [
           "logos-package-manager"
         ],
-        "logos-plugin-qt": "logos-plugin-qt_19",
-        "logos-protocol": "logos-protocol_26",
-        "logos-qt-sdk": "logos-qt-sdk_11",
+        "logos-plugin-qt": [
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-qt-sdk"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-nix",
@@ -5495,11 +5373,11 @@
         "process-stats": "process-stats_2"
       },
       "locked": {
-        "lastModified": 1788886337,
-        "narHash": "sha256-QgMlBCbnEeUUjOliGiPQjrAoa1oRdWt1Zmz3dtNsScE=",
+        "lastModified": 1788908252,
+        "narHash": "sha256-qXgKzrpzpkkkkNnl5CsiQv2MkxYfhJeIIOx7UofB8+E=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "95105df5a922220a7d05c6a66dc3e336cfebf668",
+        "rev": "209e9824e1f867a761a37c8c04df44cd310f6d52",
         "type": "github"
       },
       "original": {
@@ -5514,13 +5392,13 @@
         "default-module-loader": "default-module-loader_2",
         "logos-capability-module": "logos-capability-module_3",
         "logos-container": "logos-container_9",
-        "logos-cpp-sdk": "logos-cpp-sdk_12",
+        "logos-cpp-sdk": "logos-cpp-sdk_11",
         "logos-module": "logos-module_26",
         "logos-module-loader": "logos-module-loader_4",
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_116",
         "logos-package-manager": "logos-package-manager_4",
         "logos-plugin-qt": "logos-plugin-qt_15",
-        "logos-protocol": "logos-protocol_20",
+        "logos-protocol": "logos-protocol_19",
         "logos-qt-sdk": "logos-qt-sdk_9",
         "nixpkgs": [
           "logos-liblogos",
@@ -5553,14 +5431,14 @@
         "default-module-loader": "default-module-loader_3",
         "logos-capability-module": "logos-capability-module_4",
         "logos-container": "logos-container_16",
-        "logos-cpp-sdk": "logos-cpp-sdk_20",
-        "logos-module": "logos-module_47",
+        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-module": "logos-module_45",
         "logos-module-loader": "logos-module-loader_7",
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_204",
         "logos-package-manager": "logos-package-manager_7",
-        "logos-plugin-qt": "logos-plugin-qt_28",
-        "logos-protocol": "logos-protocol_36",
-        "logos-qt-sdk": "logos-qt-sdk_16",
+        "logos-plugin-qt": "logos-plugin-qt_26",
+        "logos-protocol": "logos-protocol_32",
+        "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -5591,15 +5469,15 @@
         "default-module-loader": "default-module-loader_4",
         "logos-capability-module": "logos-capability-module_5",
         "logos-container": "logos-container_21",
-        "logos-cpp-sdk": "logos-cpp-sdk_27",
-        "logos-module": "logos-module_64",
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-module": "logos-module_62",
         "logos-module-loader": "logos-module-loader_9",
         "logos-modules-state-module": "logos-modules-state-module_3",
-        "logos-nix": "logos-nix_370",
+        "logos-nix": "logos-nix_364",
         "logos-package-manager": "logos-package-manager_13",
-        "logos-plugin-qt": "logos-plugin-qt_49",
-        "logos-protocol": "logos-protocol_63",
-        "logos-qt-sdk": "logos-qt-sdk_27",
+        "logos-plugin-qt": "logos-plugin-qt_47",
+        "logos-protocol": "logos-protocol_59",
+        "logos-qt-sdk": "logos-qt-sdk_26",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5630,14 +5508,14 @@
         "default-module-loader": "default-module-loader_5",
         "logos-capability-module": "logos-capability-module_6",
         "logos-container": "logos-container_26",
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
-        "logos-module": "logos-module_76",
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-module": "logos-module_74",
         "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_335",
         "logos-package-manager": "logos-package-manager_11",
-        "logos-plugin-qt": "logos-plugin-qt_45",
-        "logos-protocol": "logos-protocol_57",
-        "logos-qt-sdk": "logos-qt-sdk_25",
+        "logos-plugin-qt": "logos-plugin-qt_43",
+        "logos-protocol": "logos-protocol_53",
+        "logos-qt-sdk": "logos-qt-sdk_24",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5672,15 +5550,15 @@
         "default-module-loader": "default-module-loader_6",
         "logos-capability-module": "logos-capability-module_7",
         "logos-container": "logos-container_31",
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
-        "logos-module": "logos-module_98",
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
+        "logos-module": "logos-module_96",
         "logos-module-loader": "logos-module-loader_13",
         "logos-modules-state-module": "logos-modules-state-module_4",
-        "logos-nix": "logos-nix_542",
+        "logos-nix": "logos-nix_536",
         "logos-package-manager": "logos-package-manager_20",
-        "logos-plugin-qt": "logos-plugin-qt_71",
-        "logos-protocol": "logos-protocol_92",
-        "logos-qt-sdk": "logos-qt-sdk_38",
+        "logos-plugin-qt": "logos-plugin-qt_69",
+        "logos-protocol": "logos-protocol_88",
+        "logos-qt-sdk": "logos-qt-sdk_37",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5711,14 +5589,14 @@
         "default-module-loader": "default-module-loader_7",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_36",
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
-        "logos-module": "logos-module_110",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-module": "logos-module_108",
         "logos-module-loader": "logos-module-loader_15",
-        "logos-nix": "logos-nix_513",
+        "logos-nix": "logos-nix_507",
         "logos-package-manager": "logos-package-manager_18",
-        "logos-plugin-qt": "logos-plugin-qt_67",
-        "logos-protocol": "logos-protocol_86",
-        "logos-qt-sdk": "logos-qt-sdk_36",
+        "logos-plugin-qt": "logos-plugin-qt_65",
+        "logos-protocol": "logos-protocol_82",
+        "logos-qt-sdk": "logos-qt-sdk_35",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5753,15 +5631,15 @@
         "default-module-loader": "default-module-loader_8",
         "logos-capability-module": "logos-capability-module_9",
         "logos-container": "logos-container_41",
-        "logos-cpp-sdk": "logos-cpp-sdk_55",
-        "logos-module": "logos-module_131",
+        "logos-cpp-sdk": "logos-cpp-sdk_53",
+        "logos-module": "logos-module_129",
         "logos-module-loader": "logos-module-loader_17",
         "logos-modules-state-module": "logos-modules-state-module_5",
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_702",
         "logos-package-manager": "logos-package-manager_27",
-        "logos-plugin-qt": "logos-plugin-qt_92",
-        "logos-protocol": "logos-protocol_121",
-        "logos-qt-sdk": "logos-qt-sdk_49",
+        "logos-plugin-qt": "logos-plugin-qt_90",
+        "logos-protocol": "logos-protocol_117",
+        "logos-qt-sdk": "logos-qt-sdk_48",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5792,14 +5670,14 @@
         "default-module-loader": "default-module-loader_9",
         "logos-capability-module": "logos-capability-module_10",
         "logos-container": "logos-container_46",
-        "logos-cpp-sdk": "logos-cpp-sdk_60",
-        "logos-module": "logos-module_143",
+        "logos-cpp-sdk": "logos-cpp-sdk_58",
+        "logos-module": "logos-module_141",
         "logos-module-loader": "logos-module-loader_19",
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_673",
         "logos-package-manager": "logos-package-manager_25",
-        "logos-plugin-qt": "logos-plugin-qt_88",
-        "logos-protocol": "logos-protocol_115",
-        "logos-qt-sdk": "logos-qt-sdk_47",
+        "logos-plugin-qt": "logos-plugin-qt_86",
+        "logos-protocol": "logos-protocol_111",
+        "logos-qt-sdk": "logos-qt-sdk_46",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5899,6 +5777,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -5913,6 +5792,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -5946,7 +5826,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5960,18 +5841,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -5993,7 +5875,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6008,7 +5890,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6040,10 +5922,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6055,10 +5934,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6089,10 +5965,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6104,10 +5977,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6138,10 +6008,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6153,10 +6020,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6186,8 +6050,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6198,8 +6061,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6228,8 +6090,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6240,8 +6101,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6271,8 +6131,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -6283,8 +6142,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6314,8 +6172,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6325,8 +6183,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6364,11 +6222,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -6386,7 +6244,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6397,7 +6255,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6425,10 +6283,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6436,21 +6291,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6466,10 +6318,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6477,21 +6326,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6506,10 +6352,6 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6517,10 +6359,6 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6528,11 +6366,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6546,16 +6384,14 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6563,11 +6399,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6581,16 +6417,14 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6598,11 +6432,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6616,14 +6450,47 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_117": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6644,64 +6511,29 @@
         "type": "github"
       }
     },
-    "logos-lidl_117": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_118": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6713,28 +6545,26 @@
     "logos-lidl_119": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6761,11 +6591,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -6777,16 +6607,14 @@
     "logos-lidl_120": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6812,13 +6640,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6843,13 +6671,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6874,13 +6702,15 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6905,13 +6735,19 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6936,13 +6772,19 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6968,6 +6810,9 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -6975,6 +6820,9 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7002,8 +6850,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7011,8 +6860,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7039,8 +6889,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7048,8 +6899,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7078,7 +6930,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7088,7 +6940,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7150,7 +7002,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7160,7 +7012,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7189,6 +7041,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7199,6 +7052,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7206,11 +7060,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7228,6 +7082,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -7238,6 +7093,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7245,11 +7101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7267,7 +7123,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7277,7 +7134,49 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_134": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7297,47 +7196,6 @@
         "type": "github"
       }
     },
-    "logos-lidl_134": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_135": {
       "inputs": {
         "logos-nix": [
@@ -7345,10 +7203,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7356,21 +7211,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -7386,9 +7238,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -7397,9 +7248,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7407,11 +7257,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -7427,10 +7277,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7438,10 +7287,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7468,7 +7316,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7476,7 +7326,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7505,7 +7357,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7515,7 +7367,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7577,7 +7429,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7587,7 +7439,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7616,7 +7468,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7626,18 +7479,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7655,7 +7509,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7665,18 +7523,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7694,7 +7556,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7704,18 +7570,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7734,7 +7604,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7745,7 +7618,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7778,7 +7654,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7792,7 +7668,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7813,147 +7689,6 @@
       }
     },
     "logos-lidl_146": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_147": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_148": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_149": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -7992,6 +7727,153 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_147": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_148": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_149": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8046,7 +7928,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8061,7 +7943,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8093,10 +7975,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8108,10 +7987,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8142,10 +8018,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8157,10 +8030,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8191,10 +8061,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8206,10 +8073,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8239,8 +8103,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8251,8 +8114,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8281,8 +8143,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8293,8 +8154,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8324,8 +8184,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -8336,8 +8195,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8367,8 +8225,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8378,8 +8236,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8408,7 +8266,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8419,7 +8277,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8447,10 +8305,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8458,21 +8313,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8521,10 +8373,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8532,21 +8381,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8561,10 +8407,6 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8572,10 +8414,6 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8583,11 +8421,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8601,16 +8439,14 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8618,11 +8454,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8636,16 +8472,14 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8653,11 +8487,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8671,14 +8505,47 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_165": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8699,64 +8566,29 @@
         "type": "github"
       }
     },
-    "logos-lidl_165": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_166": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8768,28 +8600,26 @@
     "logos-lidl_167": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8801,16 +8631,14 @@
     "logos-lidl_168": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8836,13 +8664,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8900,13 +8728,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8931,13 +8759,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8962,13 +8792,19 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8993,13 +8829,19 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9025,6 +8867,9 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -9032,6 +8877,9 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9059,8 +8907,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9068,8 +8917,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9096,8 +8946,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9105,8 +8956,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9135,7 +8987,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9145,7 +8997,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9174,7 +9026,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9184,7 +9036,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9213,6 +9065,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9223,6 +9076,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9230,11 +9084,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9287,6 +9141,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -9297,6 +9152,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9304,11 +9160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9326,7 +9182,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9336,7 +9193,49 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_182": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9356,47 +9255,6 @@
         "type": "github"
       }
     },
-    "logos-lidl_182": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_183": {
       "inputs": {
         "logos-nix": [
@@ -9404,10 +9262,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9415,21 +9270,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9445,9 +9297,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -9456,9 +9307,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9466,11 +9316,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9486,10 +9336,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9497,10 +9346,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9527,7 +9375,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9535,7 +9385,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9564,7 +9416,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9574,7 +9426,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9603,7 +9455,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9613,7 +9465,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9642,7 +9494,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9652,18 +9505,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9716,7 +9570,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9726,18 +9584,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9755,7 +9617,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9765,18 +9631,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9795,7 +9665,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9806,7 +9679,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9839,7 +9715,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9853,7 +9729,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9874,147 +9750,6 @@
       }
     },
     "logos-lidl_194": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_195": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_196": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_197": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -10061,7 +9796,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_198": {
+    "logos-lidl_195": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -10110,7 +9845,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_199": {
+    "logos-lidl_196": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -10140,6 +9875,147 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_197": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_198": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_199": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10236,10 +10112,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10251,10 +10124,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10285,10 +10155,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10300,10 +10167,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10333,8 +10197,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10345,8 +10208,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10375,8 +10237,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10387,8 +10248,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10418,8 +10278,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -10430,8 +10289,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -10461,8 +10319,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10472,8 +10330,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10502,7 +10360,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10513,7 +10371,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10541,10 +10399,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10552,21 +10407,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10582,10 +10434,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10593,21 +10442,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10622,10 +10468,6 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10633,10 +10475,6 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10644,11 +10482,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10697,16 +10535,14 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10714,11 +10550,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10732,16 +10568,14 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -10749,11 +10583,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10767,26 +10601,26 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10800,14 +10634,14 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10815,11 +10649,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10831,28 +10665,22 @@
     "logos-lidl_214": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10862,99 +10690,6 @@
       }
     },
     "logos-lidl_215": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_216": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_217": {
-      "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_218": {
       "inputs": {
         "logos-nix": [
           "logos-qt-sdk",
@@ -10973,35 +10708,6 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_219": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11014,41 +10720,16 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788811494,
-        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_220": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11074,14 +10755,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11107,14 +10788,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11140,14 +10821,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11173,14 +10854,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11206,25 +10887,27 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11240,6 +10923,9 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -11248,6 +10934,9 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -11278,7 +10967,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11289,7 +10978,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11350,7 +11039,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11361,7 +11050,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11391,7 +11080,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11402,7 +11091,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11423,47 +11112,6 @@
       }
     },
     "logos-lidl_32": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_33": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -11504,7 +11152,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_34": {
+    "logos-lidl_33": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -11547,7 +11195,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_35": {
+    "logos-lidl_34": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -11571,6 +11219,49 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_35": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11601,7 +11292,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11613,7 +11304,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11641,10 +11332,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11653,10 +11341,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11684,7 +11369,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11693,7 +11378,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11721,7 +11406,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11730,7 +11415,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11788,8 +11473,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11797,8 +11481,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11824,7 +11507,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -11832,7 +11515,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -11860,7 +11543,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11868,7 +11551,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11894,16 +11577,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11930,7 +11613,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11938,7 +11621,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11961,30 +11644,24 @@
     "logos-lidl_45": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-module-loader-qt",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-module-loader-qt",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -11996,13 +11673,13 @@
     "logos-lidl_46": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-plugin-qt",
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12025,13 +11702,15 @@
     "logos-lidl_47": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12054,13 +11733,15 @@
     "logos-lidl_48": {
       "inputs": {
         "logos-nix": [
-          "logos-module-loader-qt",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-module-loader-qt",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12083,13 +11764,15 @@
     "logos-lidl_49": {
       "inputs": {
         "logos-nix": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12145,13 +11828,13 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12176,13 +11859,13 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12207,24 +11890,26 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12238,24 +11923,32 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12269,24 +11962,32 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12301,14 +12002,20 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12337,7 +12044,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12347,7 +12054,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12376,7 +12083,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12386,18 +12093,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -12415,6 +12122,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -12425,6 +12133,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12454,6 +12163,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -12464,6 +12174,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12526,7 +12237,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12536,18 +12248,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12565,7 +12278,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -12576,7 +12289,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12604,10 +12317,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12615,10 +12325,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12645,10 +12352,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12656,10 +12360,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12686,10 +12387,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12697,10 +12395,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12726,16 +12421,14 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12760,16 +12453,14 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12795,16 +12486,14 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12830,15 +12519,15 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12863,14 +12552,14 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12927,28 +12616,26 @@
     "logos-lidl_70": {
       "inputs": {
         "logos-nix": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -12960,28 +12647,26 @@
     "logos-lidl_71": {
       "inputs": {
         "logos-nix": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -12993,16 +12678,14 @@
     "logos-lidl_72": {
       "inputs": {
         "logos-nix": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -13010,11 +12693,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -13028,13 +12711,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13059,13 +12742,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13090,13 +12773,15 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13121,13 +12806,19 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13152,13 +12843,19 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13184,6 +12881,9 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -13191,6 +12891,9 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -13218,8 +12921,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13227,8 +12931,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13288,8 +12993,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13297,8 +13003,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13327,7 +13034,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13337,7 +13044,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13366,7 +13073,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13376,7 +13083,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13405,6 +13112,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -13415,6 +13123,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -13422,11 +13131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13444,6 +13153,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -13454,6 +13164,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -13461,11 +13172,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13483,7 +13194,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13493,7 +13205,49 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_86": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13513,47 +13267,6 @@
         "type": "github"
       }
     },
-    "logos-lidl_86": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
     "logos-lidl_87": {
       "inputs": {
         "logos-nix": [
@@ -13561,10 +13274,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13572,21 +13282,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -13602,9 +13309,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -13613,9 +13319,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -13623,11 +13328,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -13643,10 +13348,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13654,10 +13358,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13717,7 +13420,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13725,7 +13430,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13754,7 +13461,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13764,7 +13471,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13793,7 +13500,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13803,7 +13510,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13832,7 +13539,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13842,18 +13550,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13871,7 +13580,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13881,18 +13594,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13910,7 +13627,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13920,18 +13641,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13950,7 +13675,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13961,7 +13689,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13994,7 +13725,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -14008,7 +13739,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -14041,7 +13772,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -14055,18 +13786,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -14088,6 +13819,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -14102,6 +13834,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -14190,14 +13923,14 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-design-system": "logos-design-system_11",
-        "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_313",
+        "logos-module": "logos-module_68",
+        "logos-nix": "logos-nix_307",
         "logos-plugin-core": "logos-plugin-core_10",
-        "logos-plugin-qt": "logos-plugin-qt_41",
-        "logos-protocol": "logos-protocol_53",
-        "logos-qt-sdk": "logos-qt-sdk_23",
+        "logos-plugin-qt": "logos-plugin-qt_39",
+        "logos-protocol": "logos-protocol_49",
+        "logos-qt-sdk": "logos-qt-sdk_22",
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -14247,14 +13980,14 @@
     },
     "logos-module-builder_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-design-system": "logos-design-system_12",
-        "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_416",
+        "logos-module": "logos-module_84",
+        "logos-nix": "logos-nix_410",
         "logos-plugin-core": "logos-plugin-core_11",
-        "logos-plugin-qt": "logos-plugin-qt_54",
-        "logos-protocol": "logos-protocol_70",
-        "logos-qt-sdk": "logos-qt-sdk_29",
+        "logos-plugin-qt": "logos-plugin-qt_52",
+        "logos-protocol": "logos-protocol_66",
+        "logos-qt-sdk": "logos-qt-sdk_28",
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
         "logos-test-framework": "logos-test-framework_14",
@@ -14286,14 +14019,14 @@
     },
     "logos-module-builder_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-design-system": "logos-design-system_13",
-        "logos-module": "logos-module_92",
-        "logos-nix": "logos-nix_437",
+        "logos-module": "logos-module_90",
+        "logos-nix": "logos-nix_431",
         "logos-plugin-core": "logos-plugin-core_12",
-        "logos-plugin-qt": "logos-plugin-qt_57",
-        "logos-protocol": "logos-protocol_74",
-        "logos-qt-sdk": "logos-qt-sdk_31",
+        "logos-plugin-qt": "logos-plugin-qt_55",
+        "logos-protocol": "logos-protocol_70",
+        "logos-qt-sdk": "logos-qt-sdk_30",
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -14335,14 +14068,14 @@
     },
     "logos-module-builder_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-design-system": "logos-design-system_14",
-        "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_468",
+        "logos-module": "logos-module_97",
+        "logos-nix": "logos-nix_462",
         "logos-plugin-core": "logos-plugin-core_13",
-        "logos-plugin-qt": "logos-plugin-qt_61",
-        "logos-protocol": "logos-protocol_79",
-        "logos-qt-sdk": "logos-qt-sdk_33",
+        "logos-plugin-qt": "logos-plugin-qt_59",
+        "logos-protocol": "logos-protocol_75",
+        "logos-qt-sdk": "logos-qt-sdk_32",
         "logos-rust-sdk": "logos-rust-sdk_13",
         "logos-standalone-app": "logos-standalone-app_6",
         "logos-test-framework": "logos-test-framework_13",
@@ -14378,14 +14111,14 @@
     },
     "logos-module-builder_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-design-system": "logos-design-system_15",
-        "logos-module": "logos-module_104",
-        "logos-nix": "logos-nix_485",
+        "logos-module": "logos-module_102",
+        "logos-nix": "logos-nix_479",
         "logos-plugin-core": "logos-plugin-core_14",
-        "logos-plugin-qt": "logos-plugin-qt_63",
-        "logos-protocol": "logos-protocol_82",
-        "logos-qt-sdk": "logos-qt-sdk_34",
+        "logos-plugin-qt": "logos-plugin-qt_61",
+        "logos-protocol": "logos-protocol_78",
+        "logos-qt-sdk": "logos-qt-sdk_33",
         "logos-rust-sdk": "logos-rust-sdk_14",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -14435,14 +14168,14 @@
     },
     "logos-module-builder_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_50",
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-design-system": "logos-design-system_16",
-        "logos-module": "logos-module_120",
-        "logos-nix": "logos-nix_583",
+        "logos-module": "logos-module_118",
+        "logos-nix": "logos-nix_577",
         "logos-plugin-core": "logos-plugin-core_15",
-        "logos-plugin-qt": "logos-plugin-qt_76",
-        "logos-protocol": "logos-protocol_99",
-        "logos-qt-sdk": "logos-qt-sdk_40",
+        "logos-plugin-qt": "logos-plugin-qt_74",
+        "logos-protocol": "logos-protocol_95",
+        "logos-qt-sdk": "logos-qt-sdk_39",
         "logos-rust-sdk": "logos-rust-sdk_15",
         "logos-standalone-app": "logos-standalone-app_7",
         "logos-test-framework": "logos-test-framework_18",
@@ -14474,14 +14207,14 @@
     },
     "logos-module-builder_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_53",
+        "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-design-system": "logos-design-system_17",
-        "logos-module": "logos-module_125",
-        "logos-nix": "logos-nix_603",
+        "logos-module": "logos-module_123",
+        "logos-nix": "logos-nix_597",
         "logos-plugin-core": "logos-plugin-core_16",
-        "logos-plugin-qt": "logos-plugin-qt_78",
-        "logos-protocol": "logos-protocol_103",
-        "logos-qt-sdk": "logos-qt-sdk_42",
+        "logos-plugin-qt": "logos-plugin-qt_76",
+        "logos-protocol": "logos-protocol_99",
+        "logos-qt-sdk": "logos-qt-sdk_41",
         "logos-rust-sdk": "logos-rust-sdk_16",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14523,14 +14256,14 @@
     },
     "logos-module-builder_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-cpp-sdk": "logos-cpp-sdk_54",
         "logos-design-system": "logos-design-system_18",
-        "logos-module": "logos-module_132",
-        "logos-nix": "logos-nix_634",
+        "logos-module": "logos-module_130",
+        "logos-nix": "logos-nix_628",
         "logos-plugin-core": "logos-plugin-core_17",
-        "logos-plugin-qt": "logos-plugin-qt_82",
-        "logos-protocol": "logos-protocol_108",
-        "logos-qt-sdk": "logos-qt-sdk_44",
+        "logos-plugin-qt": "logos-plugin-qt_80",
+        "logos-protocol": "logos-protocol_104",
+        "logos-qt-sdk": "logos-qt-sdk_43",
         "logos-rust-sdk": "logos-rust-sdk_17",
         "logos-standalone-app": "logos-standalone-app_8",
         "logos-test-framework": "logos-test-framework_17",
@@ -14566,14 +14299,14 @@
     },
     "logos-module-builder_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_58",
+        "logos-cpp-sdk": "logos-cpp-sdk_56",
         "logos-design-system": "logos-design-system_19",
-        "logos-module": "logos-module_137",
-        "logos-nix": "logos-nix_651",
+        "logos-module": "logos-module_135",
+        "logos-nix": "logos-nix_645",
         "logos-plugin-core": "logos-plugin-core_18",
-        "logos-plugin-qt": "logos-plugin-qt_84",
-        "logos-protocol": "logos-protocol_111",
-        "logos-qt-sdk": "logos-qt-sdk_45",
+        "logos-plugin-qt": "logos-plugin-qt_82",
+        "logos-protocol": "logos-protocol_107",
+        "logos-qt-sdk": "logos-qt-sdk_44",
         "logos-rust-sdk": "logos-rust-sdk_18",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14629,7 +14362,7 @@
         "logos-nix": "logos-nix_41",
         "logos-plugin-core": "logos-plugin-core_2",
         "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": "logos-protocol_8",
+        "logos-protocol": "logos-protocol_7",
         "logos-qt-sdk": "logos-qt-sdk_4",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": [
@@ -14666,13 +14399,13 @@
     },
     "logos-module-builder_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_8",
+        "logos-cpp-sdk": "logos-cpp-sdk_7",
         "logos-design-system": "logos-design-system_4",
         "logos-module": "logos-module_15",
-        "logos-nix": "logos-nix_72",
+        "logos-nix": "logos-nix_71",
         "logos-plugin-core": "logos-plugin-core_3",
         "logos-plugin-qt": "logos-plugin-qt_9",
-        "logos-protocol": "logos-protocol_13",
+        "logos-protocol": "logos-protocol_12",
         "logos-qt-sdk": "logos-qt-sdk_6",
         "logos-rust-sdk": "logos-rust-sdk_3",
         "logos-standalone-app": "logos-standalone-app",
@@ -14706,13 +14439,13 @@
     },
     "logos-module-builder_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_10",
+        "logos-cpp-sdk": "logos-cpp-sdk_9",
         "logos-design-system": "logos-design-system_5",
         "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_89",
+        "logos-nix": "logos-nix_88",
         "logos-plugin-core": "logos-plugin-core_4",
         "logos-plugin-qt": "logos-plugin-qt_11",
-        "logos-protocol": "logos-protocol_16",
+        "logos-protocol": "logos-protocol_15",
         "logos-qt-sdk": "logos-qt-sdk_7",
         "logos-rust-sdk": "logos-rust-sdk_4",
         "logos-standalone-app": [
@@ -14757,14 +14490,14 @@
     },
     "logos-module-builder_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_16",
+        "logos-cpp-sdk": "logos-cpp-sdk_14",
         "logos-design-system": "logos-design-system_6",
-        "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_165",
+        "logos-module": "logos-module_34",
+        "logos-nix": "logos-nix_159",
         "logos-plugin-core": "logos-plugin-core_5",
-        "logos-plugin-qt": "logos-plugin-qt_22",
-        "logos-protocol": "logos-protocol_29",
-        "logos-qt-sdk": "logos-qt-sdk_13",
+        "logos-plugin-qt": "logos-plugin-qt_20",
+        "logos-protocol": "logos-protocol_25",
+        "logos-qt-sdk": "logos-qt-sdk_12",
         "logos-rust-sdk": "logos-rust-sdk_5",
         "logos-standalone-app": "logos-standalone-app_2",
         "logos-test-framework": "logos-test-framework_6",
@@ -14796,14 +14529,14 @@
     },
     "logos-module-builder_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-cpp-sdk": "logos-cpp-sdk_16",
         "logos-design-system": "logos-design-system_7",
-        "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_182",
+        "logos-module": "logos-module_39",
+        "logos-nix": "logos-nix_176",
         "logos-plugin-core": "logos-plugin-core_6",
-        "logos-plugin-qt": "logos-plugin-qt_24",
-        "logos-protocol": "logos-protocol_32",
-        "logos-qt-sdk": "logos-qt-sdk_14",
+        "logos-plugin-qt": "logos-plugin-qt_22",
+        "logos-protocol": "logos-protocol_28",
+        "logos-qt-sdk": "logos-qt-sdk_13",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": [
           "logos-modules-state-module",
@@ -14845,14 +14578,14 @@
     },
     "logos-module-builder_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_22",
+        "logos-cpp-sdk": "logos-cpp-sdk_20",
         "logos-design-system": "logos-design-system_8",
-        "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_244",
+        "logos-module": "logos-module_50",
+        "logos-nix": "logos-nix_238",
         "logos-plugin-core": "logos-plugin-core_7",
-        "logos-plugin-qt": "logos-plugin-qt_32",
-        "logos-protocol": "logos-protocol_41",
-        "logos-qt-sdk": "logos-qt-sdk_18",
+        "logos-plugin-qt": "logos-plugin-qt_30",
+        "logos-protocol": "logos-protocol_37",
+        "logos-qt-sdk": "logos-qt-sdk_17",
         "logos-rust-sdk": "logos-rust-sdk_7",
         "logos-standalone-app": "logos-standalone-app_3",
         "logos-test-framework": "logos-test-framework_10",
@@ -14884,14 +14617,14 @@
     },
     "logos-module-builder_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-design-system": "logos-design-system_9",
-        "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_265",
+        "logos-module": "logos-module_56",
+        "logos-nix": "logos-nix_259",
         "logos-plugin-core": "logos-plugin-core_8",
-        "logos-plugin-qt": "logos-plugin-qt_35",
-        "logos-protocol": "logos-protocol_45",
-        "logos-qt-sdk": "logos-qt-sdk_20",
+        "logos-plugin-qt": "logos-plugin-qt_33",
+        "logos-protocol": "logos-protocol_41",
+        "logos-qt-sdk": "logos-qt-sdk_19",
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -14933,14 +14666,14 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-design-system": "logos-design-system_10",
-        "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_296",
+        "logos-module": "logos-module_63",
+        "logos-nix": "logos-nix_290",
         "logos-plugin-core": "logos-plugin-core_9",
-        "logos-plugin-qt": "logos-plugin-qt_39",
-        "logos-protocol": "logos-protocol_50",
-        "logos-qt-sdk": "logos-qt-sdk_22",
+        "logos-plugin-qt": "logos-plugin-qt_37",
+        "logos-protocol": "logos-protocol_46",
+        "logos-qt-sdk": "logos-qt-sdk_21",
         "logos-rust-sdk": "logos-rust-sdk_9",
         "logos-standalone-app": "logos-standalone-app_4",
         "logos-test-framework": "logos-test-framework_9",
@@ -15003,12 +14736,12 @@
     "logos-module-loader-qt": {
       "inputs": {
         "logos-container": "logos-container_11",
-        "logos-cpp-sdk": "logos-cpp-sdk_15",
-        "logos-module": "logos-module_34",
+        "logos-cpp-sdk": "logos-cpp-sdk_13",
+        "logos-module": "logos-module_32",
         "logos-module-loader": "logos-module-loader_5",
-        "logos-nix": "logos-nix_158",
-        "logos-protocol": "logos-protocol_28",
-        "logos-qt-sdk": "logos-qt-sdk_12",
+        "logos-nix": "logos-nix_152",
+        "logos-protocol": "logos-protocol_24",
+        "logos-qt-sdk": "logos-qt-sdk_11",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-nix",
@@ -15032,7 +14765,7 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
-        "logos-nix": "logos-nix_308",
+        "logos-nix": "logos-nix_302",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15065,7 +14798,7 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_334",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15097,7 +14830,7 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15126,7 +14859,7 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
-        "logos-nix": "logos-nix_464",
+        "logos-nix": "logos-nix_458",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15154,7 +14887,7 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15187,7 +14920,7 @@
     "logos-module-loader_15": {
       "inputs": {
         "logos-container": "logos-container_37",
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_506",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15219,7 +14952,7 @@
     "logos-module-loader_16": {
       "inputs": {
         "logos-container": "logos-container_40",
-        "logos-nix": "logos-nix_595",
+        "logos-nix": "logos-nix_589",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15248,7 +14981,7 @@
     "logos-module-loader_17": {
       "inputs": {
         "logos-container": "logos-container_42",
-        "logos-nix": "logos-nix_630",
+        "logos-nix": "logos-nix_624",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15276,7 +15009,7 @@
     "logos-module-loader_18": {
       "inputs": {
         "logos-container": "logos-container_45",
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15309,7 +15042,7 @@
     "logos-module-loader_19": {
       "inputs": {
         "logos-container": "logos-container_47",
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_672",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15341,7 +15074,7 @@
     "logos-module-loader_2": {
       "inputs": {
         "logos-container": "logos-container_5",
-        "logos-nix": "logos-nix_68",
+        "logos-nix": "logos-nix_67",
         "nixpkgs": [
           "logos-liblogos",
           "logos-module-loader",
@@ -15366,7 +15099,7 @@
     "logos-module-loader_3": {
       "inputs": {
         "logos-container": "logos-container_8",
-        "logos-nix": "logos-nix_84",
+        "logos-nix": "logos-nix_83",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -15396,7 +15129,7 @@
     "logos-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_10",
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_115",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -15425,7 +15158,7 @@
     "logos-module-loader_5": {
       "inputs": {
         "logos-container": "logos-container_12",
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_151",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-module-loader",
@@ -15450,7 +15183,7 @@
     "logos-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_15",
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_171",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -15479,7 +15212,7 @@
     "logos-module-loader_7": {
       "inputs": {
         "logos-container": "logos-container_17",
-        "logos-nix": "logos-nix_209",
+        "logos-nix": "logos-nix_203",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -15507,7 +15240,7 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
-        "logos-nix": "logos-nix_257",
+        "logos-nix": "logos-nix_251",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15536,7 +15269,7 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
-        "logos-nix": "logos-nix_292",
+        "logos-nix": "logos-nix_286",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15598,66 +15331,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_101": {
-      "inputs": {
-        "logos-nix": "logos-nix_471",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_102": {
-      "inputs": {
-        "logos-nix": "logos-nix_475",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -15679,9 +15352,9 @@
         "type": "github"
       }
     },
-    "logos-module_103": {
+    "logos-module_101": {
       "inputs": {
-        "logos-nix": "logos-nix_479",
+        "logos-nix": "logos-nix_473",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15711,9 +15384,9 @@
         "type": "github"
       }
     },
-    "logos-module_104": {
+    "logos-module_102": {
       "inputs": {
-        "logos-nix": "logos-nix_484",
+        "logos-nix": "logos-nix_478",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15725,6 +15398,74 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_103": {
+      "inputs": {
+        "logos-nix": "logos-nix_480",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_104": {
+      "inputs": {
+        "logos-nix": "logos-nix_482",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15758,7 +15499,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15792,6 +15534,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15814,7 +15557,7 @@
     },
     "logos-module_107": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_490",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15826,7 +15569,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15849,7 +15592,7 @@
     },
     "logos-module_108": {
       "inputs": {
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_505",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15859,10 +15602,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15884,7 +15623,7 @@
     },
     "logos-module_109": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_513",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15894,9 +15633,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15947,7 +15683,7 @@
     },
     "logos-module_110": {
       "inputs": {
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_518",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15956,7 +15692,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15978,70 +15714,7 @@
     },
     "logos-module_111": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_112": {
-      "inputs": {
-        "logos-nix": "logos-nix_524",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_113": {
-      "inputs": {
-        "logos-nix": "logos-nix_527",
+        "logos-nix": "logos-nix_521",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16070,9 +15743,9 @@
         "type": "github"
       }
     },
-    "logos-module_114": {
+    "logos-module_112": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_523",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16101,9 +15774,9 @@
         "type": "github"
       }
     },
-    "logos-module_115": {
+    "logos-module_113": {
       "inputs": {
-        "logos-nix": "logos-nix_548",
+        "logos-nix": "logos-nix_542",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16129,9 +15802,9 @@
         "type": "github"
       }
     },
-    "logos-module_116": {
+    "logos-module_114": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_546",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16158,9 +15831,9 @@
         "type": "github"
       }
     },
-    "logos-module_117": {
+    "logos-module_115": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
+        "logos-nix": "logos-nix_549",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16185,9 +15858,9 @@
         "type": "github"
       }
     },
-    "logos-module_118": {
+    "logos-module_116": {
       "inputs": {
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -16212,14 +15885,65 @@
         "type": "github"
       }
     },
-    "logos-module_119": {
+    "logos-module_117": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_556",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_118": {
+      "inputs": {
+        "logos-nix": "logos-nix_576",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_119": {
+      "inputs": {
+        "logos-nix": "logos-nix_578",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16269,58 +15993,7 @@
     },
     "logos-module_120": {
       "inputs": {
-        "logos-nix": "logos-nix_582",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_121": {
-      "inputs": {
-        "logos-nix": "logos-nix_584",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_122": {
-      "inputs": {
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_580",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16344,9 +16017,9 @@
         "type": "github"
       }
     },
-    "logos-module_123": {
+    "logos-module_121": {
       "inputs": {
-        "logos-nix": "logos-nix_594",
+        "logos-nix": "logos-nix_588",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16372,9 +16045,9 @@
         "type": "github"
       }
     },
-    "logos-module_124": {
+    "logos-module_122": {
       "inputs": {
-        "logos-nix": "logos-nix_599",
+        "logos-nix": "logos-nix_593",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16402,9 +16075,9 @@
         "type": "github"
       }
     },
-    "logos-module_125": {
+    "logos-module_123": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_596",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16412,6 +16085,66 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_124": {
+      "inputs": {
+        "logos-nix": "logos-nix_598",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_125": {
+      "inputs": {
+        "logos-nix": "logos-nix_600",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16441,7 +16174,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16471,6 +16205,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16493,7 +16228,7 @@
     },
     "logos-module_128": {
       "inputs": {
-        "logos-nix": "logos-nix_610",
+        "logos-nix": "logos-nix_608",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16501,7 +16236,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16524,16 +16259,12 @@
     },
     "logos-module_129": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
+        "logos-nix": "logos-nix_623",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16583,16 +16314,14 @@
     },
     "logos-module_130": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_627",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16620,6 +16349,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16641,7 +16373,7 @@
     },
     "logos-module_132": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_631",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16649,6 +16381,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16678,66 +16411,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_134": {
-      "inputs": {
-        "logos-nix": "logos-nix_637",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_135": {
-      "inputs": {
-        "logos-nix": "logos-nix_641",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -16759,9 +16432,9 @@
         "type": "github"
       }
     },
-    "logos-module_136": {
+    "logos-module_134": {
       "inputs": {
-        "logos-nix": "logos-nix_645",
+        "logos-nix": "logos-nix_639",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16791,9 +16464,9 @@
         "type": "github"
       }
     },
-    "logos-module_137": {
+    "logos-module_135": {
       "inputs": {
-        "logos-nix": "logos-nix_650",
+        "logos-nix": "logos-nix_644",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16805,6 +16478,74 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_136": {
+      "inputs": {
+        "logos-nix": "logos-nix_646",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_137": {
+      "inputs": {
+        "logos-nix": "logos-nix_648",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16838,7 +16579,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16872,6 +16614,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16894,7 +16637,7 @@
     },
     "logos-module_14": {
       "inputs": {
-        "logos-nix": "logos-nix_67",
+        "logos-nix": "logos-nix_66",
         "logos-package": "logos-package_7",
         "nixpkgs": [
           "logos-liblogos",
@@ -16919,7 +16662,7 @@
     },
     "logos-module_140": {
       "inputs": {
-        "logos-nix": "logos-nix_658",
+        "logos-nix": "logos-nix_656",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16931,7 +16674,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16954,7 +16697,7 @@
     },
     "logos-module_141": {
       "inputs": {
-        "logos-nix": "logos-nix_660",
+        "logos-nix": "logos-nix_671",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16964,10 +16707,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16989,7 +16728,7 @@
     },
     "logos-module_142": {
       "inputs": {
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_679",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16999,9 +16738,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17024,7 +16760,7 @@
     },
     "logos-module_143": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_684",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17033,7 +16769,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17055,70 +16791,7 @@
     },
     "logos-module_144": {
       "inputs": {
-        "logos-nix": "logos-nix_685",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_145": {
-      "inputs": {
-        "logos-nix": "logos-nix_690",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_146": {
-      "inputs": {
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_687",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17147,9 +16820,9 @@
         "type": "github"
       }
     },
-    "logos-module_147": {
+    "logos-module_145": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_689",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17178,9 +16851,9 @@
         "type": "github"
       }
     },
-    "logos-module_148": {
+    "logos-module_146": {
       "inputs": {
-        "logos-nix": "logos-nix_714",
+        "logos-nix": "logos-nix_708",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17206,9 +16879,9 @@
         "type": "github"
       }
     },
-    "logos-module_149": {
+    "logos-module_147": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_712",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17235,9 +16908,63 @@
         "type": "github"
       }
     },
+    "logos-module_148": {
+      "inputs": {
+        "logos-nix": "logos-nix_715",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_149": {
+      "inputs": {
+        "logos-nix": "logos-nix_720",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_15": {
       "inputs": {
-        "logos-nix": "logos-nix_71",
+        "logos-nix": "logos-nix_70",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17263,11 +16990,11 @@
     },
     "logos-module_150": {
       "inputs": {
-        "logos-nix": "logos-nix_721",
+        "logos-nix": "logos-nix_722",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17290,112 +17017,8 @@
     },
     "logos-module_151": {
       "inputs": {
-        "logos-nix": "logos-nix_726",
+        "logos-nix": "logos-nix_736",
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_152": {
-      "inputs": {
-        "logos-nix": "logos-nix_728",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_153": {
-      "inputs": {
-        "logos-nix": "logos-nix_742",
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_154": {
-      "inputs": {
-        "logos-nix": "logos-nix_747",
-        "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_155": {
-      "inputs": {
-        "logos-nix": "logos-nix_749",
-        "nixpkgs": [
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17418,7 +17041,7 @@
     },
     "logos-module_16": {
       "inputs": {
-        "logos-nix": "logos-nix_73",
+        "logos-nix": "logos-nix_72",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17445,7 +17068,7 @@
     },
     "logos-module_17": {
       "inputs": {
-        "logos-nix": "logos-nix_75",
+        "logos-nix": "logos-nix_74",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17472,7 +17095,7 @@
     },
     "logos-module_18": {
       "inputs": {
-        "logos-nix": "logos-nix_79",
+        "logos-nix": "logos-nix_78",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17500,7 +17123,7 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_83",
+        "logos-nix": "logos-nix_82",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17555,7 +17178,7 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_88",
+        "logos-nix": "logos-nix_87",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17585,7 +17208,7 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_90",
+        "logos-nix": "logos-nix_89",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17616,7 +17239,7 @@
     },
     "logos-module_22": {
       "inputs": {
-        "logos-nix": "logos-nix_92",
+        "logos-nix": "logos-nix_91",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17647,7 +17270,7 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_96",
+        "logos-nix": "logos-nix_95",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17679,7 +17302,7 @@
     },
     "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_98",
+        "logos-nix": "logos-nix_97",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17711,7 +17334,7 @@
     },
     "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_100",
+        "logos-nix": "logos-nix_99",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17743,7 +17366,7 @@
     },
     "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_114",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17771,7 +17394,7 @@
     },
     "logos-module_27": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_122",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17800,7 +17423,7 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_127",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17828,7 +17451,7 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_131",
+        "logos-nix": "logos-nix_130",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17882,7 +17505,7 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_133",
+        "logos-nix": "logos-nix_132",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17911,57 +17534,6 @@
     "logos-module_31": {
       "inputs": {
         "logos-nix": "logos-nix_147",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_32": {
-      "inputs": {
-        "logos-nix": "logos-nix_151",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_33": {
-      "inputs": {
-        "logos-nix": "logos-nix_153",
         "logos-package": "logos-package_15",
         "nixpkgs": [
           "logos-module",
@@ -17983,9 +17555,9 @@
         "type": "github"
       }
     },
-    "logos-module_34": {
+    "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_156",
+        "logos-nix": "logos-nix_150",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-module",
@@ -18007,9 +17579,9 @@
         "type": "github"
       }
     },
-    "logos-module_35": {
+    "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_161",
+        "logos-nix": "logos-nix_155",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-qt-sdk",
@@ -18033,12 +17605,64 @@
         "type": "github"
       }
     },
-    "logos-module_36": {
+    "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_164",
+        "logos-nix": "logos-nix_158",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_35": {
+      "inputs": {
+        "logos-nix": "logos-nix_160",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_36": {
+      "inputs": {
+        "logos-nix": "logos-nix_162",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18064,7 +17688,8 @@
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18086,11 +17711,13 @@
     },
     "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_170",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18112,12 +17739,14 @@
     },
     "logos-module_39": {
       "inputs": {
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_175",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18166,13 +17795,15 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_176",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18194,7 +17825,7 @@
     },
     "logos-module_41": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_179",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -18202,6 +17833,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18231,7 +17863,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18261,6 +17894,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18283,69 +17917,7 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_189",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_45": {
-      "inputs": {
-        "logos-nix": "logos-nix_191",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_46": {
-      "inputs": {
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_187",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -18374,9 +17946,9 @@
         "type": "github"
       }
     },
-    "logos-module_47": {
+    "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_202",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -18401,9 +17973,9 @@
         "type": "github"
       }
     },
-    "logos-module_48": {
+    "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_210",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -18429,13 +18001,67 @@
         "type": "github"
       }
     },
-    "logos-module_49": {
+    "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_215",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_48": {
+      "inputs": {
+        "logos-nix": "logos-nix_218",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_220",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18485,12 +18111,10 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_237",
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18512,12 +18136,11 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18539,10 +18162,11 @@
     },
     "logos-module_52": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_241",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18568,7 +18192,8 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18590,11 +18215,13 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_250",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18616,10 +18243,13 @@
     },
     "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_251",
+        "logos-nix": "logos-nix_255",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -18643,13 +18273,14 @@
     },
     "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_256",
+        "logos-nix": "logos-nix_258",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18671,15 +18302,15 @@
     },
     "logos-module_57": {
       "inputs": {
-        "logos-nix": "logos-nix_261",
+        "logos-nix": "logos-nix_260",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18701,7 +18332,7 @@
     },
     "logos-module_58": {
       "inputs": {
-        "logos-nix": "logos-nix_264",
+        "logos-nix": "logos-nix_262",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18709,6 +18340,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18738,7 +18370,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18793,6 +18426,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18815,69 +18449,7 @@
     },
     "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_272",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_274",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_63": {
-      "inputs": {
-        "logos-nix": "logos-nix_276",
+        "logos-nix": "logos-nix_270",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18906,9 +18478,9 @@
         "type": "github"
       }
     },
-    "logos-module_64": {
+    "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
+        "logos-nix": "logos-nix_285",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18933,9 +18505,9 @@
         "type": "github"
       }
     },
-    "logos-module_65": {
+    "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
+        "logos-nix": "logos-nix_289",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18943,6 +18515,66 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_64": {
+      "inputs": {
+        "logos-nix": "logos-nix_291",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_65": {
+      "inputs": {
+        "logos-nix": "logos-nix_293",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18972,66 +18604,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_299",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_68": {
-      "inputs": {
-        "logos-nix": "logos-nix_303",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -19053,9 +18625,9 @@
         "type": "github"
       }
     },
-    "logos-module_69": {
+    "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_307",
+        "logos-nix": "logos-nix_301",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19066,6 +18638,73 @@
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_68": {
+      "inputs": {
+        "logos-nix": "logos-nix_306",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_308",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19114,7 +18753,7 @@
     },
     "logos-module_70": {
       "inputs": {
-        "logos-nix": "logos-nix_312",
+        "logos-nix": "logos-nix_310",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19126,6 +18765,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19159,7 +18799,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19193,6 +18834,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19215,77 +18857,7 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_320",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_74": {
-      "inputs": {
-        "logos-nix": "logos-nix_322",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_75": {
-      "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_318",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19318,9 +18890,9 @@
         "type": "github"
       }
     },
-    "logos-module_76": {
+    "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19349,9 +18921,9 @@
         "type": "github"
       }
     },
-    "logos-module_77": {
+    "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_341",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19361,6 +18933,68 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_76": {
+      "inputs": {
+        "logos-nix": "logos-nix_346",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_349",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19383,7 +19017,7 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_351",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19391,7 +19025,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19414,15 +19048,12 @@
     },
     "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_370",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19471,66 +19102,7 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_81": {
-      "inputs": {
-        "logos-nix": "logos-nix_376",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_82": {
-      "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_374",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19557,9 +19129,9 @@
         "type": "github"
       }
     },
-    "logos-module_83": {
+    "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_383",
+        "logos-nix": "logos-nix_377",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19584,9 +19156,9 @@
         "type": "github"
       }
     },
-    "logos-module_84": {
+    "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_382",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19611,9 +19183,9 @@
         "type": "github"
       }
     },
-    "logos-module_85": {
+    "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_384",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19638,12 +19210,64 @@
         "type": "github"
       }
     },
-    "logos-module_86": {
+    "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_409",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_85": {
+      "inputs": {
+        "logos-nix": "logos-nix_411",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_86": {
+      "inputs": {
+        "logos-nix": "logos-nix_413",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19669,7 +19293,8 @@
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19691,11 +19316,13 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_422",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19717,10 +19344,13 @@
     },
     "logos-module_89": {
       "inputs": {
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_427",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -19771,13 +19401,14 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_428",
+        "logos-nix": "logos-nix_430",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19799,15 +19430,15 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_433",
+        "logos-nix": "logos-nix_432",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19829,7 +19460,7 @@
     },
     "logos-module_92": {
       "inputs": {
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_434",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19837,6 +19468,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19866,7 +19498,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19896,6 +19529,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19918,69 +19552,7 @@
     },
     "logos-module_95": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_96": {
-      "inputs": {
-        "logos-nix": "logos-nix_446",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_97": {
-      "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_442",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -20009,9 +19581,9 @@
         "type": "github"
       }
     },
-    "logos-module_98": {
+    "logos-module_96": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_457",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -20036,9 +19608,9 @@
         "type": "github"
       }
     },
-    "logos-module_99": {
+    "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_461",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -20046,6 +19618,66 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_463",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_465",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -20309,15 +19941,14 @@
     },
     "logos-nix_106": {
       "inputs": {
-        "nixpkgs": "nixpkgs_106",
-        "nixpkgs-windows": "nixpkgs-windows_102"
+        "nixpkgs": "nixpkgs_106"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20346,14 +19977,15 @@
     },
     "logos-nix_108": {
       "inputs": {
-        "nixpkgs": "nixpkgs_108"
+        "nixpkgs": "nixpkgs_108",
+        "nixpkgs-windows": "nixpkgs-windows_102"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20573,15 +20205,14 @@
     },
     "logos-nix_119": {
       "inputs": {
-        "nixpkgs": "nixpkgs_119",
-        "nixpkgs-windows": "nixpkgs-windows_113"
+        "nixpkgs": "nixpkgs_119"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20629,14 +20260,15 @@
     },
     "logos-nix_121": {
       "inputs": {
-        "nixpkgs": "nixpkgs_121"
+        "nixpkgs": "nixpkgs_121",
+        "nixpkgs-windows": "nixpkgs-windows_113"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20727,11 +20359,11 @@
         "nixpkgs-windows": "nixpkgs-windows_118"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -20746,25 +20378,6 @@
         "nixpkgs-windows": "nixpkgs-windows_119"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_128": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_128",
-        "nixpkgs-windows": "nixpkgs-windows_120"
-      },
-      "locked": {
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
@@ -20778,9 +20391,9 @@
         "type": "github"
       }
     },
-    "logos-nix_129": {
+    "logos-nix_128": {
       "inputs": {
-        "nixpkgs": "nixpkgs_129"
+        "nixpkgs": "nixpkgs_128"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -20788,6 +20401,25 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_129": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_129",
+        "nixpkgs-windows": "nixpkgs-windows_120"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20988,15 +20620,14 @@
     },
     "logos-nix_139": {
       "inputs": {
-        "nixpkgs": "nixpkgs_139",
-        "nixpkgs-windows": "nixpkgs-windows_130"
+        "nixpkgs": "nixpkgs_139"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21044,14 +20675,15 @@
     },
     "logos-nix_141": {
       "inputs": {
-        "nixpkgs": "nixpkgs_141"
+        "nixpkgs": "nixpkgs_141",
+        "nixpkgs-windows": "nixpkgs-windows_130"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21123,11 +20755,11 @@
         "nixpkgs-windows": "nixpkgs-windows_134"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21142,11 +20774,11 @@
         "nixpkgs-windows": "nixpkgs-windows_135"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21275,11 +20907,11 @@
         "nixpkgs-windows": "nixpkgs-windows_141"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21389,11 +21021,11 @@
         "nixpkgs-windows": "nixpkgs-windows_147"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21693,11 +21325,11 @@
         "nixpkgs-windows": "nixpkgs-windows_161"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21807,11 +21439,11 @@
         "nixpkgs-windows": "nixpkgs-windows_167"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22145,15 +21777,14 @@
     },
     "logos-nix_194": {
       "inputs": {
-        "nixpkgs": "nixpkgs_194",
-        "nixpkgs-windows": "nixpkgs-windows_183"
+        "nixpkgs": "nixpkgs_194"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22164,15 +21795,14 @@
     },
     "logos-nix_195": {
       "inputs": {
-        "nixpkgs": "nixpkgs_195",
-        "nixpkgs-windows": "nixpkgs-windows_184"
+        "nixpkgs": "nixpkgs_195"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22184,7 +21814,7 @@
     "logos-nix_196": {
       "inputs": {
         "nixpkgs": "nixpkgs_196",
-        "nixpkgs-windows": "nixpkgs-windows_185"
+        "nixpkgs-windows": "nixpkgs-windows_183"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22203,7 +21833,7 @@
     "logos-nix_197": {
       "inputs": {
         "nixpkgs": "nixpkgs_197",
-        "nixpkgs-windows": "nixpkgs-windows_186"
+        "nixpkgs-windows": "nixpkgs-windows_184"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22222,7 +21852,7 @@
     "logos-nix_198": {
       "inputs": {
         "nixpkgs": "nixpkgs_198",
-        "nixpkgs-windows": "nixpkgs-windows_187"
+        "nixpkgs-windows": "nixpkgs-windows_185"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22241,7 +21871,7 @@
     "logos-nix_199": {
       "inputs": {
         "nixpkgs": "nixpkgs_199",
-        "nixpkgs-windows": "nixpkgs-windows_188"
+        "nixpkgs-windows": "nixpkgs-windows_186"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22297,14 +21927,15 @@
     },
     "logos-nix_200": {
       "inputs": {
-        "nixpkgs": "nixpkgs_200"
+        "nixpkgs": "nixpkgs_200",
+        "nixpkgs-windows": "nixpkgs-windows_187"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22315,14 +21946,15 @@
     },
     "logos-nix_201": {
       "inputs": {
-        "nixpkgs": "nixpkgs_201"
+        "nixpkgs": "nixpkgs_201",
+        "nixpkgs-windows": "nixpkgs-windows_188"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22428,15 +22060,14 @@
     },
     "logos-nix_207": {
       "inputs": {
-        "nixpkgs": "nixpkgs_207",
-        "nixpkgs-windows": "nixpkgs-windows_194"
+        "nixpkgs": "nixpkgs_207"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22447,15 +22078,14 @@
     },
     "logos-nix_208": {
       "inputs": {
-        "nixpkgs": "nixpkgs_208",
-        "nixpkgs-windows": "nixpkgs-windows_195"
+        "nixpkgs": "nixpkgs_208"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22467,7 +22097,7 @@
     "logos-nix_209": {
       "inputs": {
         "nixpkgs": "nixpkgs_209",
-        "nixpkgs-windows": "nixpkgs-windows_196"
+        "nixpkgs-windows": "nixpkgs-windows_194"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22504,7 +22134,7 @@
     "logos-nix_210": {
       "inputs": {
         "nixpkgs": "nixpkgs_210",
-        "nixpkgs-windows": "nixpkgs-windows_197"
+        "nixpkgs-windows": "nixpkgs-windows_195"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22523,7 +22153,7 @@
     "logos-nix_211": {
       "inputs": {
         "nixpkgs": "nixpkgs_211",
-        "nixpkgs-windows": "nixpkgs-windows_198"
+        "nixpkgs-windows": "nixpkgs-windows_196"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22542,7 +22172,7 @@
     "logos-nix_212": {
       "inputs": {
         "nixpkgs": "nixpkgs_212",
-        "nixpkgs-windows": "nixpkgs-windows_199"
+        "nixpkgs-windows": "nixpkgs-windows_197"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22560,14 +22190,15 @@
     },
     "logos-nix_213": {
       "inputs": {
-        "nixpkgs": "nixpkgs_213"
+        "nixpkgs": "nixpkgs_213",
+        "nixpkgs-windows": "nixpkgs-windows_198"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22578,14 +22209,15 @@
     },
     "logos-nix_214": {
       "inputs": {
-        "nixpkgs": "nixpkgs_214"
+        "nixpkgs": "nixpkgs_214",
+        "nixpkgs-windows": "nixpkgs-windows_199"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -22615,15 +22247,14 @@
     },
     "logos-nix_216": {
       "inputs": {
-        "nixpkgs": "nixpkgs_216",
-        "nixpkgs-windows": "nixpkgs-windows_201"
+        "nixpkgs": "nixpkgs_216"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22635,7 +22266,7 @@
     "logos-nix_217": {
       "inputs": {
         "nixpkgs": "nixpkgs_217",
-        "nixpkgs-windows": "nixpkgs-windows_202"
+        "nixpkgs-windows": "nixpkgs-windows_201"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22654,7 +22285,7 @@
     "logos-nix_218": {
       "inputs": {
         "nixpkgs": "nixpkgs_218",
-        "nixpkgs-windows": "nixpkgs-windows_203"
+        "nixpkgs-windows": "nixpkgs-windows_202"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22673,7 +22304,7 @@
     "logos-nix_219": {
       "inputs": {
         "nixpkgs": "nixpkgs_219",
-        "nixpkgs-windows": "nixpkgs-windows_204"
+        "nixpkgs-windows": "nixpkgs-windows_203"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22710,14 +22341,14 @@
     "logos-nix_220": {
       "inputs": {
         "nixpkgs": "nixpkgs_220",
-        "nixpkgs-windows": "nixpkgs-windows_205"
+        "nixpkgs-windows": "nixpkgs-windows_204"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22729,7 +22360,7 @@
     "logos-nix_221": {
       "inputs": {
         "nixpkgs": "nixpkgs_221",
-        "nixpkgs-windows": "nixpkgs-windows_206"
+        "nixpkgs-windows": "nixpkgs-windows_205"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22747,14 +22378,15 @@
     },
     "logos-nix_222": {
       "inputs": {
-        "nixpkgs": "nixpkgs_222"
+        "nixpkgs": "nixpkgs_222",
+        "nixpkgs-windows": "nixpkgs-windows_206"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22841,15 +22473,14 @@
     },
     "logos-nix_227": {
       "inputs": {
-        "nixpkgs": "nixpkgs_227",
-        "nixpkgs-windows": "nixpkgs-windows_211"
+        "nixpkgs": "nixpkgs_227"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22860,15 +22491,14 @@
     },
     "logos-nix_228": {
       "inputs": {
-        "nixpkgs": "nixpkgs_228",
-        "nixpkgs-windows": "nixpkgs-windows_212"
+        "nixpkgs": "nixpkgs_228"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22880,7 +22510,7 @@
     "logos-nix_229": {
       "inputs": {
         "nixpkgs": "nixpkgs_229",
-        "nixpkgs-windows": "nixpkgs-windows_213"
+        "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22918,7 +22548,7 @@
     "logos-nix_230": {
       "inputs": {
         "nixpkgs": "nixpkgs_230",
-        "nixpkgs-windows": "nixpkgs-windows_214"
+        "nixpkgs-windows": "nixpkgs-windows_212"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22937,7 +22567,7 @@
     "logos-nix_231": {
       "inputs": {
         "nixpkgs": "nixpkgs_231",
-        "nixpkgs-windows": "nixpkgs-windows_215"
+        "nixpkgs-windows": "nixpkgs-windows_213"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22956,7 +22586,7 @@
     "logos-nix_232": {
       "inputs": {
         "nixpkgs": "nixpkgs_232",
-        "nixpkgs-windows": "nixpkgs-windows_216"
+        "nixpkgs-windows": "nixpkgs-windows_214"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22974,14 +22604,15 @@
     },
     "logos-nix_233": {
       "inputs": {
-        "nixpkgs": "nixpkgs_233"
+        "nixpkgs": "nixpkgs_233",
+        "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1788439860,
+        "narHash": "sha256-RlR4iAlgB3V20/ZwpLGp3uXPqqFKk+ILVsswtwSxJpc=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "cae28e2cda88cb34fc74bd4f2ecc32d3c1bcd03e",
         "type": "github"
       },
       "original": {
@@ -22992,14 +22623,15 @@
     },
     "logos-nix_234": {
       "inputs": {
-        "nixpkgs": "nixpkgs_234"
+        "nixpkgs": "nixpkgs_234",
+        "nixpkgs-windows": "nixpkgs-windows_216"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23071,11 +22703,11 @@
         "nixpkgs-windows": "nixpkgs-windows_220"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23090,11 +22722,11 @@
         "nixpkgs-windows": "nixpkgs-windows_221"
       },
       "locked": {
-        "lastModified": 1788439860,
-        "narHash": "sha256-RlR4iAlgB3V20/ZwpLGp3uXPqqFKk+ILVsswtwSxJpc=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "cae28e2cda88cb34fc74bd4f2ecc32d3c1bcd03e",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23204,11 +22836,11 @@
         "nixpkgs-windows": "nixpkgs-windows_226"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23375,11 +23007,11 @@
         "nixpkgs-windows": "nixpkgs-windows_234"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23489,11 +23121,11 @@
         "nixpkgs-windows": "nixpkgs-windows_240"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23508,11 +23140,11 @@
         "nixpkgs-windows": "nixpkgs-windows_241"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23641,11 +23273,11 @@
         "nixpkgs-windows": "nixpkgs-windows_247"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23831,11 +23463,11 @@
         "nixpkgs-windows": "nixpkgs-windows_256"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23850,11 +23482,11 @@
         "nixpkgs-windows": "nixpkgs-windows_257"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23884,15 +23516,14 @@
     },
     "logos-nix_277": {
       "inputs": {
-        "nixpkgs": "nixpkgs_277",
-        "nixpkgs-windows": "nixpkgs-windows_259"
+        "nixpkgs": "nixpkgs_277"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23903,15 +23534,14 @@
     },
     "logos-nix_278": {
       "inputs": {
-        "nixpkgs": "nixpkgs_278",
-        "nixpkgs-windows": "nixpkgs-windows_260"
+        "nixpkgs": "nixpkgs_278"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23923,7 +23553,7 @@
     "logos-nix_279": {
       "inputs": {
         "nixpkgs": "nixpkgs_279",
-        "nixpkgs-windows": "nixpkgs-windows_261"
+        "nixpkgs-windows": "nixpkgs-windows_259"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23961,14 +23591,14 @@
     "logos-nix_280": {
       "inputs": {
         "nixpkgs": "nixpkgs_280",
-        "nixpkgs-windows": "nixpkgs-windows_262"
+        "nixpkgs-windows": "nixpkgs-windows_260"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23980,14 +23610,14 @@
     "logos-nix_281": {
       "inputs": {
         "nixpkgs": "nixpkgs_281",
-        "nixpkgs-windows": "nixpkgs-windows_263"
+        "nixpkgs-windows": "nixpkgs-windows_261"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23999,7 +23629,7 @@
     "logos-nix_282": {
       "inputs": {
         "nixpkgs": "nixpkgs_282",
-        "nixpkgs-windows": "nixpkgs-windows_264"
+        "nixpkgs-windows": "nixpkgs-windows_262"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24017,14 +23647,15 @@
     },
     "logos-nix_283": {
       "inputs": {
-        "nixpkgs": "nixpkgs_283"
+        "nixpkgs": "nixpkgs_283",
+        "nixpkgs-windows": "nixpkgs-windows_263"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24035,14 +23666,15 @@
     },
     "logos-nix_284": {
       "inputs": {
-        "nixpkgs": "nixpkgs_284"
+        "nixpkgs": "nixpkgs_284",
+        "nixpkgs-windows": "nixpkgs-windows_264"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24456,11 +24088,11 @@
         "nixpkgs-windows": "nixpkgs-windows_283"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24570,11 +24202,11 @@
         "nixpkgs-windows": "nixpkgs-windows_289"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24908,15 +24540,14 @@
     },
     "logos-nix_325": {
       "inputs": {
-        "nixpkgs": "nixpkgs_325",
-        "nixpkgs-windows": "nixpkgs-windows_305"
+        "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24927,15 +24558,14 @@
     },
     "logos-nix_326": {
       "inputs": {
-        "nixpkgs": "nixpkgs_326",
-        "nixpkgs-windows": "nixpkgs-windows_306"
+        "nixpkgs": "nixpkgs_326"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24947,7 +24577,7 @@
     "logos-nix_327": {
       "inputs": {
         "nixpkgs": "nixpkgs_327",
-        "nixpkgs-windows": "nixpkgs-windows_307"
+        "nixpkgs-windows": "nixpkgs-windows_305"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24966,7 +24596,7 @@
     "logos-nix_328": {
       "inputs": {
         "nixpkgs": "nixpkgs_328",
-        "nixpkgs-windows": "nixpkgs-windows_308"
+        "nixpkgs-windows": "nixpkgs-windows_306"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24985,7 +24615,7 @@
     "logos-nix_329": {
       "inputs": {
         "nixpkgs": "nixpkgs_329",
-        "nixpkgs-windows": "nixpkgs-windows_309"
+        "nixpkgs-windows": "nixpkgs-windows_307"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25023,7 +24653,7 @@
     "logos-nix_330": {
       "inputs": {
         "nixpkgs": "nixpkgs_330",
-        "nixpkgs-windows": "nixpkgs-windows_310"
+        "nixpkgs-windows": "nixpkgs-windows_308"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25041,14 +24671,15 @@
     },
     "logos-nix_331": {
       "inputs": {
-        "nixpkgs": "nixpkgs_331"
+        "nixpkgs": "nixpkgs_331",
+        "nixpkgs-windows": "nixpkgs-windows_309"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25059,14 +24690,15 @@
     },
     "logos-nix_332": {
       "inputs": {
-        "nixpkgs": "nixpkgs_332"
+        "nixpkgs": "nixpkgs_332",
+        "nixpkgs-windows": "nixpkgs-windows_310"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25172,15 +24804,14 @@
     },
     "logos-nix_338": {
       "inputs": {
-        "nixpkgs": "nixpkgs_338",
-        "nixpkgs-windows": "nixpkgs-windows_316"
+        "nixpkgs": "nixpkgs_338"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25191,15 +24822,14 @@
     },
     "logos-nix_339": {
       "inputs": {
-        "nixpkgs": "nixpkgs_339",
-        "nixpkgs-windows": "nixpkgs-windows_317"
+        "nixpkgs": "nixpkgs_339"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25230,7 +24860,7 @@
     "logos-nix_340": {
       "inputs": {
         "nixpkgs": "nixpkgs_340",
-        "nixpkgs-windows": "nixpkgs-windows_318"
+        "nixpkgs-windows": "nixpkgs-windows_316"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25249,7 +24879,7 @@
     "logos-nix_341": {
       "inputs": {
         "nixpkgs": "nixpkgs_341",
-        "nixpkgs-windows": "nixpkgs-windows_319"
+        "nixpkgs-windows": "nixpkgs-windows_317"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25268,7 +24898,7 @@
     "logos-nix_342": {
       "inputs": {
         "nixpkgs": "nixpkgs_342",
-        "nixpkgs-windows": "nixpkgs-windows_320"
+        "nixpkgs-windows": "nixpkgs-windows_318"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25287,7 +24917,7 @@
     "logos-nix_343": {
       "inputs": {
         "nixpkgs": "nixpkgs_343",
-        "nixpkgs-windows": "nixpkgs-windows_321"
+        "nixpkgs-windows": "nixpkgs-windows_319"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25305,14 +24935,15 @@
     },
     "logos-nix_344": {
       "inputs": {
-        "nixpkgs": "nixpkgs_344"
+        "nixpkgs": "nixpkgs_344",
+        "nixpkgs-windows": "nixpkgs-windows_320"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25323,14 +24954,15 @@
     },
     "logos-nix_345": {
       "inputs": {
-        "nixpkgs": "nixpkgs_345"
+        "nixpkgs": "nixpkgs_345",
+        "nixpkgs-windows": "nixpkgs-windows_321"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25360,15 +24992,14 @@
     },
     "logos-nix_347": {
       "inputs": {
-        "nixpkgs": "nixpkgs_347",
-        "nixpkgs-windows": "nixpkgs-windows_323"
+        "nixpkgs": "nixpkgs_347"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25380,7 +25011,7 @@
     "logos-nix_348": {
       "inputs": {
         "nixpkgs": "nixpkgs_348",
-        "nixpkgs-windows": "nixpkgs-windows_324"
+        "nixpkgs-windows": "nixpkgs-windows_323"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25399,7 +25030,7 @@
     "logos-nix_349": {
       "inputs": {
         "nixpkgs": "nixpkgs_349",
-        "nixpkgs-windows": "nixpkgs-windows_325"
+        "nixpkgs-windows": "nixpkgs-windows_324"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25437,7 +25068,7 @@
     "logos-nix_350": {
       "inputs": {
         "nixpkgs": "nixpkgs_350",
-        "nixpkgs-windows": "nixpkgs-windows_326"
+        "nixpkgs-windows": "nixpkgs-windows_325"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25456,14 +25087,14 @@
     "logos-nix_351": {
       "inputs": {
         "nixpkgs": "nixpkgs_351",
-        "nixpkgs-windows": "nixpkgs-windows_327"
+        "nixpkgs-windows": "nixpkgs-windows_326"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25475,7 +25106,7 @@
     "logos-nix_352": {
       "inputs": {
         "nixpkgs": "nixpkgs_352",
-        "nixpkgs-windows": "nixpkgs-windows_328"
+        "nixpkgs-windows": "nixpkgs-windows_327"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25493,14 +25124,15 @@
     },
     "logos-nix_353": {
       "inputs": {
-        "nixpkgs": "nixpkgs_353"
+        "nixpkgs": "nixpkgs_353",
+        "nixpkgs-windows": "nixpkgs-windows_328"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25587,15 +25219,14 @@
     },
     "logos-nix_358": {
       "inputs": {
-        "nixpkgs": "nixpkgs_358",
-        "nixpkgs-windows": "nixpkgs-windows_333"
+        "nixpkgs": "nixpkgs_358"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25606,15 +25237,14 @@
     },
     "logos-nix_359": {
       "inputs": {
-        "nixpkgs": "nixpkgs_359",
-        "nixpkgs-windows": "nixpkgs-windows_334"
+        "nixpkgs": "nixpkgs_359"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25645,7 +25275,7 @@
     "logos-nix_360": {
       "inputs": {
         "nixpkgs": "nixpkgs_360",
-        "nixpkgs-windows": "nixpkgs-windows_335"
+        "nixpkgs-windows": "nixpkgs-windows_333"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25664,7 +25294,7 @@
     "logos-nix_361": {
       "inputs": {
         "nixpkgs": "nixpkgs_361",
-        "nixpkgs-windows": "nixpkgs-windows_336"
+        "nixpkgs-windows": "nixpkgs-windows_334"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25683,7 +25313,7 @@
     "logos-nix_362": {
       "inputs": {
         "nixpkgs": "nixpkgs_362",
-        "nixpkgs-windows": "nixpkgs-windows_337"
+        "nixpkgs-windows": "nixpkgs-windows_335"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25702,7 +25332,7 @@
     "logos-nix_363": {
       "inputs": {
         "nixpkgs": "nixpkgs_363",
-        "nixpkgs-windows": "nixpkgs-windows_338"
+        "nixpkgs-windows": "nixpkgs-windows_336"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25720,14 +25350,15 @@
     },
     "logos-nix_364": {
       "inputs": {
-        "nixpkgs": "nixpkgs_364"
+        "nixpkgs": "nixpkgs_364",
+        "nixpkgs-windows": "nixpkgs-windows_337"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25738,14 +25369,15 @@
     },
     "logos-nix_365": {
       "inputs": {
-        "nixpkgs": "nixpkgs_365"
+        "nixpkgs": "nixpkgs_365",
+        "nixpkgs-windows": "nixpkgs-windows_338"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25775,15 +25407,14 @@
     },
     "logos-nix_367": {
       "inputs": {
-        "nixpkgs": "nixpkgs_367",
-        "nixpkgs-windows": "nixpkgs-windows_340"
+        "nixpkgs": "nixpkgs_367"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25794,15 +25425,14 @@
     },
     "logos-nix_368": {
       "inputs": {
-        "nixpkgs": "nixpkgs_368",
-        "nixpkgs-windows": "nixpkgs-windows_341"
+        "nixpkgs": "nixpkgs_368"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25814,7 +25444,7 @@
     "logos-nix_369": {
       "inputs": {
         "nixpkgs": "nixpkgs_369",
-        "nixpkgs-windows": "nixpkgs-windows_342"
+        "nixpkgs-windows": "nixpkgs-windows_340"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25852,14 +25482,14 @@
     "logos-nix_370": {
       "inputs": {
         "nixpkgs": "nixpkgs_370",
-        "nixpkgs-windows": "nixpkgs-windows_343"
+        "nixpkgs-windows": "nixpkgs-windows_341"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25871,14 +25501,14 @@
     "logos-nix_371": {
       "inputs": {
         "nixpkgs": "nixpkgs_371",
-        "nixpkgs-windows": "nixpkgs-windows_344"
+        "nixpkgs-windows": "nixpkgs-windows_342"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25890,7 +25520,7 @@
     "logos-nix_372": {
       "inputs": {
         "nixpkgs": "nixpkgs_372",
-        "nixpkgs-windows": "nixpkgs-windows_345"
+        "nixpkgs-windows": "nixpkgs-windows_343"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25908,14 +25538,15 @@
     },
     "logos-nix_373": {
       "inputs": {
-        "nixpkgs": "nixpkgs_373"
+        "nixpkgs": "nixpkgs_373",
+        "nixpkgs-windows": "nixpkgs-windows_344"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25926,14 +25557,15 @@
     },
     "logos-nix_374": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374"
+        "nixpkgs": "nixpkgs_374",
+        "nixpkgs-windows": "nixpkgs-windows_345"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25967,11 +25599,11 @@
         "nixpkgs-windows": "nixpkgs-windows_347"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26058,15 +25690,14 @@
     },
     "logos-nix_380": {
       "inputs": {
-        "nixpkgs": "nixpkgs_380",
-        "nixpkgs-windows": "nixpkgs-windows_351"
+        "nixpkgs": "nixpkgs_380"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26078,7 +25709,7 @@
     "logos-nix_381": {
       "inputs": {
         "nixpkgs": "nixpkgs_381",
-        "nixpkgs-windows": "nixpkgs-windows_352"
+        "nixpkgs-windows": "nixpkgs-windows_351"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26097,14 +25728,14 @@
     "logos-nix_382": {
       "inputs": {
         "nixpkgs": "nixpkgs_382",
-        "nixpkgs-windows": "nixpkgs-windows_353"
+        "nixpkgs-windows": "nixpkgs-windows_352"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26116,7 +25747,7 @@
     "logos-nix_383": {
       "inputs": {
         "nixpkgs": "nixpkgs_383",
-        "nixpkgs-windows": "nixpkgs-windows_354"
+        "nixpkgs-windows": "nixpkgs-windows_353"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26135,7 +25766,7 @@
     "logos-nix_384": {
       "inputs": {
         "nixpkgs": "nixpkgs_384",
-        "nixpkgs-windows": "nixpkgs-windows_355"
+        "nixpkgs-windows": "nixpkgs-windows_354"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26154,7 +25785,7 @@
     "logos-nix_385": {
       "inputs": {
         "nixpkgs": "nixpkgs_385",
-        "nixpkgs-windows": "nixpkgs-windows_356"
+        "nixpkgs-windows": "nixpkgs-windows_355"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26172,14 +25803,15 @@
     },
     "logos-nix_386": {
       "inputs": {
-        "nixpkgs": "nixpkgs_386"
+        "nixpkgs": "nixpkgs_386",
+        "nixpkgs-windows": "nixpkgs-windows_356"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26213,11 +25845,11 @@
         "nixpkgs-windows": "nixpkgs-windows_358"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26232,11 +25864,11 @@
         "nixpkgs-windows": "nixpkgs-windows_359"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26285,15 +25917,14 @@
     },
     "logos-nix_391": {
       "inputs": {
-        "nixpkgs": "nixpkgs_391",
-        "nixpkgs-windows": "nixpkgs-windows_361"
+        "nixpkgs": "nixpkgs_391"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26304,15 +25935,14 @@
     },
     "logos-nix_392": {
       "inputs": {
-        "nixpkgs": "nixpkgs_392",
-        "nixpkgs-windows": "nixpkgs-windows_362"
+        "nixpkgs": "nixpkgs_392"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26324,7 +25954,7 @@
     "logos-nix_393": {
       "inputs": {
         "nixpkgs": "nixpkgs_393",
-        "nixpkgs-windows": "nixpkgs-windows_363"
+        "nixpkgs-windows": "nixpkgs-windows_361"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26343,14 +25973,14 @@
     "logos-nix_394": {
       "inputs": {
         "nixpkgs": "nixpkgs_394",
-        "nixpkgs-windows": "nixpkgs-windows_364"
+        "nixpkgs-windows": "nixpkgs-windows_362"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26362,14 +25992,14 @@
     "logos-nix_395": {
       "inputs": {
         "nixpkgs": "nixpkgs_395",
-        "nixpkgs-windows": "nixpkgs-windows_365"
+        "nixpkgs-windows": "nixpkgs-windows_363"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26381,7 +26011,7 @@
     "logos-nix_396": {
       "inputs": {
         "nixpkgs": "nixpkgs_396",
-        "nixpkgs-windows": "nixpkgs-windows_366"
+        "nixpkgs-windows": "nixpkgs-windows_364"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26399,14 +26029,15 @@
     },
     "logos-nix_397": {
       "inputs": {
-        "nixpkgs": "nixpkgs_397"
+        "nixpkgs": "nixpkgs_397",
+        "nixpkgs-windows": "nixpkgs-windows_365"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26417,14 +26048,15 @@
     },
     "logos-nix_398": {
       "inputs": {
-        "nixpkgs": "nixpkgs_398"
+        "nixpkgs": "nixpkgs_398",
+        "nixpkgs-windows": "nixpkgs-windows_366"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26435,15 +26067,14 @@
     },
     "logos-nix_399": {
       "inputs": {
-        "nixpkgs": "nixpkgs_399",
-        "nixpkgs-windows": "nixpkgs-windows_367"
+        "nixpkgs": "nixpkgs_399"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26492,15 +26123,14 @@
     },
     "logos-nix_400": {
       "inputs": {
-        "nixpkgs": "nixpkgs_400",
-        "nixpkgs-windows": "nixpkgs-windows_368"
+        "nixpkgs": "nixpkgs_400"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26512,7 +26142,7 @@
     "logos-nix_401": {
       "inputs": {
         "nixpkgs": "nixpkgs_401",
-        "nixpkgs-windows": "nixpkgs-windows_369"
+        "nixpkgs-windows": "nixpkgs-windows_367"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26531,6 +26161,80 @@
     "logos-nix_402": {
       "inputs": {
         "nixpkgs": "nixpkgs_402",
+        "nixpkgs-windows": "nixpkgs-windows_368"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_403": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_403",
+        "nixpkgs-windows": "nixpkgs-windows_369"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_404": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_404"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_405": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_405"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_406": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_406",
         "nixpkgs-windows": "nixpkgs-windows_370"
       },
       "locked": {
@@ -26547,84 +26251,10 @@
         "type": "github"
       }
     },
-    "logos-nix_403": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_403",
-        "nixpkgs-windows": "nixpkgs-windows_371"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_404": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_404",
-        "nixpkgs-windows": "nixpkgs-windows_372"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_405": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_405"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_406": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_406"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_407": {
       "inputs": {
         "nixpkgs": "nixpkgs_407",
-        "nixpkgs-windows": "nixpkgs-windows_373"
+        "nixpkgs-windows": "nixpkgs-windows_371"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26643,14 +26273,14 @@
     "logos-nix_408": {
       "inputs": {
         "nixpkgs": "nixpkgs_408",
-        "nixpkgs-windows": "nixpkgs-windows_374"
+        "nixpkgs-windows": "nixpkgs-windows_372"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26662,7 +26292,7 @@
     "logos-nix_409": {
       "inputs": {
         "nixpkgs": "nixpkgs_409",
-        "nixpkgs-windows": "nixpkgs-windows_375"
+        "nixpkgs-windows": "nixpkgs-windows_373"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26699,14 +26329,15 @@
     },
     "logos-nix_410": {
       "inputs": {
-        "nixpkgs": "nixpkgs_410"
+        "nixpkgs": "nixpkgs_410",
+        "nixpkgs-windows": "nixpkgs-windows_374"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26717,14 +26348,15 @@
     },
     "logos-nix_411": {
       "inputs": {
-        "nixpkgs": "nixpkgs_411"
+        "nixpkgs": "nixpkgs_411",
+        "nixpkgs-windows": "nixpkgs-windows_375"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26815,11 +26447,11 @@
         "nixpkgs-windows": "nixpkgs-windows_380"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26986,11 +26618,11 @@
         "nixpkgs-windows": "nixpkgs-windows_388"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27119,11 +26751,11 @@
         "nixpkgs-windows": "nixpkgs-windows_394"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27138,11 +26770,11 @@
         "nixpkgs-windows": "nixpkgs-windows_395"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27252,11 +26884,11 @@
         "nixpkgs-windows": "nixpkgs-windows_401"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27442,11 +27074,11 @@
         "nixpkgs-windows": "nixpkgs-windows_410"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27461,11 +27093,11 @@
         "nixpkgs-windows": "nixpkgs-windows_411"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27495,15 +27127,14 @@
     },
     "logos-nix_449": {
       "inputs": {
-        "nixpkgs": "nixpkgs_449",
-        "nixpkgs-windows": "nixpkgs-windows_413"
+        "nixpkgs": "nixpkgs_449"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -27533,15 +27164,14 @@
     },
     "logos-nix_450": {
       "inputs": {
-        "nixpkgs": "nixpkgs_450",
-        "nixpkgs-windows": "nixpkgs-windows_414"
+        "nixpkgs": "nixpkgs_450"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27553,7 +27183,7 @@
     "logos-nix_451": {
       "inputs": {
         "nixpkgs": "nixpkgs_451",
-        "nixpkgs-windows": "nixpkgs-windows_415"
+        "nixpkgs-windows": "nixpkgs-windows_413"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27572,14 +27202,14 @@
     "logos-nix_452": {
       "inputs": {
         "nixpkgs": "nixpkgs_452",
-        "nixpkgs-windows": "nixpkgs-windows_416"
+        "nixpkgs-windows": "nixpkgs-windows_414"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27591,14 +27221,14 @@
     "logos-nix_453": {
       "inputs": {
         "nixpkgs": "nixpkgs_453",
-        "nixpkgs-windows": "nixpkgs-windows_417"
+        "nixpkgs-windows": "nixpkgs-windows_415"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27610,7 +27240,7 @@
     "logos-nix_454": {
       "inputs": {
         "nixpkgs": "nixpkgs_454",
-        "nixpkgs-windows": "nixpkgs-windows_418"
+        "nixpkgs-windows": "nixpkgs-windows_416"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27628,14 +27258,15 @@
     },
     "logos-nix_455": {
       "inputs": {
-        "nixpkgs": "nixpkgs_455"
+        "nixpkgs": "nixpkgs_455",
+        "nixpkgs-windows": "nixpkgs-windows_417"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27646,14 +27277,15 @@
     },
     "logos-nix_456": {
       "inputs": {
-        "nixpkgs": "nixpkgs_456"
+        "nixpkgs": "nixpkgs_456",
+        "nixpkgs-windows": "nixpkgs-windows_418"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28048,11 +27680,11 @@
         "nixpkgs-windows": "nixpkgs-windows_437"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28181,11 +27813,11 @@
         "nixpkgs-windows": "nixpkgs-windows_443"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28500,15 +28132,14 @@
     },
     "logos-nix_497": {
       "inputs": {
-        "nixpkgs": "nixpkgs_497",
-        "nixpkgs-windows": "nixpkgs-windows_459"
+        "nixpkgs": "nixpkgs_497"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28519,15 +28150,14 @@
     },
     "logos-nix_498": {
       "inputs": {
-        "nixpkgs": "nixpkgs_498",
-        "nixpkgs-windows": "nixpkgs-windows_460"
+        "nixpkgs": "nixpkgs_498"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28539,7 +28169,7 @@
     "logos-nix_499": {
       "inputs": {
         "nixpkgs": "nixpkgs_499",
-        "nixpkgs-windows": "nixpkgs-windows_461"
+        "nixpkgs-windows": "nixpkgs-windows_459"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28596,7 +28226,7 @@
     "logos-nix_500": {
       "inputs": {
         "nixpkgs": "nixpkgs_500",
-        "nixpkgs-windows": "nixpkgs-windows_462"
+        "nixpkgs-windows": "nixpkgs-windows_460"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28615,7 +28245,7 @@
     "logos-nix_501": {
       "inputs": {
         "nixpkgs": "nixpkgs_501",
-        "nixpkgs-windows": "nixpkgs-windows_463"
+        "nixpkgs-windows": "nixpkgs-windows_461"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28634,7 +28264,7 @@
     "logos-nix_502": {
       "inputs": {
         "nixpkgs": "nixpkgs_502",
-        "nixpkgs-windows": "nixpkgs-windows_464"
+        "nixpkgs-windows": "nixpkgs-windows_462"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28652,14 +28282,15 @@
     },
     "logos-nix_503": {
       "inputs": {
-        "nixpkgs": "nixpkgs_503"
+        "nixpkgs": "nixpkgs_503",
+        "nixpkgs-windows": "nixpkgs-windows_463"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28670,14 +28301,15 @@
     },
     "logos-nix_504": {
       "inputs": {
-        "nixpkgs": "nixpkgs_504"
+        "nixpkgs": "nixpkgs_504",
+        "nixpkgs-windows": "nixpkgs-windows_464"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28802,15 +28434,14 @@
     },
     "logos-nix_510": {
       "inputs": {
-        "nixpkgs": "nixpkgs_510",
-        "nixpkgs-windows": "nixpkgs-windows_470"
+        "nixpkgs": "nixpkgs_510"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28821,15 +28452,14 @@
     },
     "logos-nix_511": {
       "inputs": {
-        "nixpkgs": "nixpkgs_511",
-        "nixpkgs-windows": "nixpkgs-windows_471"
+        "nixpkgs": "nixpkgs_511"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28841,7 +28471,7 @@
     "logos-nix_512": {
       "inputs": {
         "nixpkgs": "nixpkgs_512",
-        "nixpkgs-windows": "nixpkgs-windows_472"
+        "nixpkgs-windows": "nixpkgs-windows_470"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28860,7 +28490,7 @@
     "logos-nix_513": {
       "inputs": {
         "nixpkgs": "nixpkgs_513",
-        "nixpkgs-windows": "nixpkgs-windows_473"
+        "nixpkgs-windows": "nixpkgs-windows_471"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28879,7 +28509,7 @@
     "logos-nix_514": {
       "inputs": {
         "nixpkgs": "nixpkgs_514",
-        "nixpkgs-windows": "nixpkgs-windows_474"
+        "nixpkgs-windows": "nixpkgs-windows_472"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28898,7 +28528,7 @@
     "logos-nix_515": {
       "inputs": {
         "nixpkgs": "nixpkgs_515",
-        "nixpkgs-windows": "nixpkgs-windows_475"
+        "nixpkgs-windows": "nixpkgs-windows_473"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28916,14 +28546,15 @@
     },
     "logos-nix_516": {
       "inputs": {
-        "nixpkgs": "nixpkgs_516"
+        "nixpkgs": "nixpkgs_516",
+        "nixpkgs-windows": "nixpkgs-windows_474"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28934,14 +28565,15 @@
     },
     "logos-nix_517": {
       "inputs": {
-        "nixpkgs": "nixpkgs_517"
+        "nixpkgs": "nixpkgs_517",
+        "nixpkgs-windows": "nixpkgs-windows_475"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28971,15 +28603,14 @@
     },
     "logos-nix_519": {
       "inputs": {
-        "nixpkgs": "nixpkgs_519",
-        "nixpkgs-windows": "nixpkgs-windows_477"
+        "nixpkgs": "nixpkgs_519"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29010,7 +28641,7 @@
     "logos-nix_520": {
       "inputs": {
         "nixpkgs": "nixpkgs_520",
-        "nixpkgs-windows": "nixpkgs-windows_478"
+        "nixpkgs-windows": "nixpkgs-windows_477"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29029,7 +28660,7 @@
     "logos-nix_521": {
       "inputs": {
         "nixpkgs": "nixpkgs_521",
-        "nixpkgs-windows": "nixpkgs-windows_479"
+        "nixpkgs-windows": "nixpkgs-windows_478"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29048,7 +28679,7 @@
     "logos-nix_522": {
       "inputs": {
         "nixpkgs": "nixpkgs_522",
-        "nixpkgs-windows": "nixpkgs-windows_480"
+        "nixpkgs-windows": "nixpkgs-windows_479"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29067,14 +28698,14 @@
     "logos-nix_523": {
       "inputs": {
         "nixpkgs": "nixpkgs_523",
-        "nixpkgs-windows": "nixpkgs-windows_481"
+        "nixpkgs-windows": "nixpkgs-windows_480"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29086,7 +28717,7 @@
     "logos-nix_524": {
       "inputs": {
         "nixpkgs": "nixpkgs_524",
-        "nixpkgs-windows": "nixpkgs-windows_482"
+        "nixpkgs-windows": "nixpkgs-windows_481"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29104,14 +28735,15 @@
     },
     "logos-nix_525": {
       "inputs": {
-        "nixpkgs": "nixpkgs_525"
+        "nixpkgs": "nixpkgs_525",
+        "nixpkgs-windows": "nixpkgs-windows_482"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29217,15 +28849,14 @@
     },
     "logos-nix_530": {
       "inputs": {
-        "nixpkgs": "nixpkgs_530",
-        "nixpkgs-windows": "nixpkgs-windows_487"
+        "nixpkgs": "nixpkgs_530"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29236,15 +28867,14 @@
     },
     "logos-nix_531": {
       "inputs": {
-        "nixpkgs": "nixpkgs_531",
-        "nixpkgs-windows": "nixpkgs-windows_488"
+        "nixpkgs": "nixpkgs_531"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29256,7 +28886,7 @@
     "logos-nix_532": {
       "inputs": {
         "nixpkgs": "nixpkgs_532",
-        "nixpkgs-windows": "nixpkgs-windows_489"
+        "nixpkgs-windows": "nixpkgs-windows_487"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29275,7 +28905,7 @@
     "logos-nix_533": {
       "inputs": {
         "nixpkgs": "nixpkgs_533",
-        "nixpkgs-windows": "nixpkgs-windows_490"
+        "nixpkgs-windows": "nixpkgs-windows_488"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29294,7 +28924,7 @@
     "logos-nix_534": {
       "inputs": {
         "nixpkgs": "nixpkgs_534",
-        "nixpkgs-windows": "nixpkgs-windows_491"
+        "nixpkgs-windows": "nixpkgs-windows_489"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29313,7 +28943,7 @@
     "logos-nix_535": {
       "inputs": {
         "nixpkgs": "nixpkgs_535",
-        "nixpkgs-windows": "nixpkgs-windows_492"
+        "nixpkgs-windows": "nixpkgs-windows_490"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29331,14 +28961,15 @@
     },
     "logos-nix_536": {
       "inputs": {
-        "nixpkgs": "nixpkgs_536"
+        "nixpkgs": "nixpkgs_536",
+        "nixpkgs-windows": "nixpkgs-windows_491"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29349,14 +28980,15 @@
     },
     "logos-nix_537": {
       "inputs": {
-        "nixpkgs": "nixpkgs_537"
+        "nixpkgs": "nixpkgs_537",
+        "nixpkgs-windows": "nixpkgs-windows_492"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29386,15 +29018,14 @@
     },
     "logos-nix_539": {
       "inputs": {
-        "nixpkgs": "nixpkgs_539",
-        "nixpkgs-windows": "nixpkgs-windows_494"
+        "nixpkgs": "nixpkgs_539"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -29424,15 +29055,14 @@
     },
     "logos-nix_540": {
       "inputs": {
-        "nixpkgs": "nixpkgs_540",
-        "nixpkgs-windows": "nixpkgs-windows_495"
+        "nixpkgs": "nixpkgs_540"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29444,7 +29074,7 @@
     "logos-nix_541": {
       "inputs": {
         "nixpkgs": "nixpkgs_541",
-        "nixpkgs-windows": "nixpkgs-windows_496"
+        "nixpkgs-windows": "nixpkgs-windows_494"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29463,14 +29093,14 @@
     "logos-nix_542": {
       "inputs": {
         "nixpkgs": "nixpkgs_542",
-        "nixpkgs-windows": "nixpkgs-windows_497"
+        "nixpkgs-windows": "nixpkgs-windows_495"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29482,14 +29112,14 @@
     "logos-nix_543": {
       "inputs": {
         "nixpkgs": "nixpkgs_543",
-        "nixpkgs-windows": "nixpkgs-windows_498"
+        "nixpkgs-windows": "nixpkgs-windows_496"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29501,7 +29131,7 @@
     "logos-nix_544": {
       "inputs": {
         "nixpkgs": "nixpkgs_544",
-        "nixpkgs-windows": "nixpkgs-windows_499"
+        "nixpkgs-windows": "nixpkgs-windows_497"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29519,14 +29149,15 @@
     },
     "logos-nix_545": {
       "inputs": {
-        "nixpkgs": "nixpkgs_545"
+        "nixpkgs": "nixpkgs_545",
+        "nixpkgs-windows": "nixpkgs-windows_498"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29537,14 +29168,15 @@
     },
     "logos-nix_546": {
       "inputs": {
-        "nixpkgs": "nixpkgs_546"
+        "nixpkgs": "nixpkgs_546",
+        "nixpkgs-windows": "nixpkgs-windows_499"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29578,11 +29210,11 @@
         "nixpkgs-windows": "nixpkgs-windows_501"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29669,15 +29301,14 @@
     },
     "logos-nix_552": {
       "inputs": {
-        "nixpkgs": "nixpkgs_552",
-        "nixpkgs-windows": "nixpkgs-windows_505"
+        "nixpkgs": "nixpkgs_552"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29689,7 +29320,7 @@
     "logos-nix_553": {
       "inputs": {
         "nixpkgs": "nixpkgs_553",
-        "nixpkgs-windows": "nixpkgs-windows_506"
+        "nixpkgs-windows": "nixpkgs-windows_505"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29708,14 +29339,14 @@
     "logos-nix_554": {
       "inputs": {
         "nixpkgs": "nixpkgs_554",
-        "nixpkgs-windows": "nixpkgs-windows_507"
+        "nixpkgs-windows": "nixpkgs-windows_506"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29727,7 +29358,7 @@
     "logos-nix_555": {
       "inputs": {
         "nixpkgs": "nixpkgs_555",
-        "nixpkgs-windows": "nixpkgs-windows_508"
+        "nixpkgs-windows": "nixpkgs-windows_507"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29746,7 +29377,7 @@
     "logos-nix_556": {
       "inputs": {
         "nixpkgs": "nixpkgs_556",
-        "nixpkgs-windows": "nixpkgs-windows_509"
+        "nixpkgs-windows": "nixpkgs-windows_508"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29765,7 +29396,7 @@
     "logos-nix_557": {
       "inputs": {
         "nixpkgs": "nixpkgs_557",
-        "nixpkgs-windows": "nixpkgs-windows_510"
+        "nixpkgs-windows": "nixpkgs-windows_509"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29783,14 +29414,15 @@
     },
     "logos-nix_558": {
       "inputs": {
-        "nixpkgs": "nixpkgs_558"
+        "nixpkgs": "nixpkgs_558",
+        "nixpkgs-windows": "nixpkgs-windows_510"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29843,11 +29475,11 @@
         "nixpkgs-windows": "nixpkgs-windows_512"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29862,11 +29494,11 @@
         "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29896,15 +29528,14 @@
     },
     "logos-nix_563": {
       "inputs": {
-        "nixpkgs": "nixpkgs_563",
-        "nixpkgs-windows": "nixpkgs-windows_515"
+        "nixpkgs": "nixpkgs_563"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -29915,15 +29546,14 @@
     },
     "logos-nix_564": {
       "inputs": {
-        "nixpkgs": "nixpkgs_564",
-        "nixpkgs-windows": "nixpkgs-windows_516"
+        "nixpkgs": "nixpkgs_564"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29935,7 +29565,7 @@
     "logos-nix_565": {
       "inputs": {
         "nixpkgs": "nixpkgs_565",
-        "nixpkgs-windows": "nixpkgs-windows_517"
+        "nixpkgs-windows": "nixpkgs-windows_515"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29954,14 +29584,14 @@
     "logos-nix_566": {
       "inputs": {
         "nixpkgs": "nixpkgs_566",
-        "nixpkgs-windows": "nixpkgs-windows_518"
+        "nixpkgs-windows": "nixpkgs-windows_516"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29973,14 +29603,14 @@
     "logos-nix_567": {
       "inputs": {
         "nixpkgs": "nixpkgs_567",
-        "nixpkgs-windows": "nixpkgs-windows_519"
+        "nixpkgs-windows": "nixpkgs-windows_517"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29992,7 +29622,7 @@
     "logos-nix_568": {
       "inputs": {
         "nixpkgs": "nixpkgs_568",
-        "nixpkgs-windows": "nixpkgs-windows_520"
+        "nixpkgs-windows": "nixpkgs-windows_518"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30010,14 +29640,15 @@
     },
     "logos-nix_569": {
       "inputs": {
-        "nixpkgs": "nixpkgs_569"
+        "nixpkgs": "nixpkgs_569",
+        "nixpkgs-windows": "nixpkgs-windows_519"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30047,7 +29678,44 @@
     },
     "logos-nix_570": {
       "inputs": {
-        "nixpkgs": "nixpkgs_570"
+        "nixpkgs": "nixpkgs_570",
+        "nixpkgs-windows": "nixpkgs-windows_520"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_571": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_571"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_572": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_572"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -30063,48 +29731,10 @@
         "type": "github"
       }
     },
-    "logos-nix_571": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_571",
-        "nixpkgs-windows": "nixpkgs-windows_521"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_572": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_572",
-        "nixpkgs-windows": "nixpkgs-windows_522"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_573": {
       "inputs": {
         "nixpkgs": "nixpkgs_573",
-        "nixpkgs-windows": "nixpkgs-windows_523"
+        "nixpkgs-windows": "nixpkgs-windows_521"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30123,7 +29753,7 @@
     "logos-nix_574": {
       "inputs": {
         "nixpkgs": "nixpkgs_574",
-        "nixpkgs-windows": "nixpkgs-windows_524"
+        "nixpkgs-windows": "nixpkgs-windows_522"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30142,14 +29772,14 @@
     "logos-nix_575": {
       "inputs": {
         "nixpkgs": "nixpkgs_575",
-        "nixpkgs-windows": "nixpkgs-windows_525"
+        "nixpkgs-windows": "nixpkgs-windows_523"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30161,7 +29791,7 @@
     "logos-nix_576": {
       "inputs": {
         "nixpkgs": "nixpkgs_576",
-        "nixpkgs-windows": "nixpkgs-windows_526"
+        "nixpkgs-windows": "nixpkgs-windows_524"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30179,14 +29809,15 @@
     },
     "logos-nix_577": {
       "inputs": {
-        "nixpkgs": "nixpkgs_577"
+        "nixpkgs": "nixpkgs_577",
+        "nixpkgs-windows": "nixpkgs-windows_525"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30197,14 +29828,15 @@
     },
     "logos-nix_578": {
       "inputs": {
-        "nixpkgs": "nixpkgs_578"
+        "nixpkgs": "nixpkgs_578",
+        "nixpkgs-windows": "nixpkgs-windows_526"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30314,11 +29946,11 @@
         "nixpkgs-windows": "nixpkgs-windows_531"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30465,11 +30097,11 @@
         "nixpkgs-windows": "nixpkgs-windows_538"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30579,11 +30211,11 @@
         "nixpkgs-windows": "nixpkgs-windows_544"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30598,11 +30230,11 @@
         "nixpkgs-windows": "nixpkgs-windows_545"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30749,11 +30381,11 @@
         "nixpkgs-windows": "nixpkgs-windows_551"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30939,11 +30571,11 @@
         "nixpkgs-windows": "nixpkgs-windows_560"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30958,11 +30590,11 @@
         "nixpkgs-windows": "nixpkgs-windows_561"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30992,15 +30624,14 @@
     },
     "logos-nix_615": {
       "inputs": {
-        "nixpkgs": "nixpkgs_615",
-        "nixpkgs-windows": "nixpkgs-windows_563"
+        "nixpkgs": "nixpkgs_615"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -31011,15 +30642,14 @@
     },
     "logos-nix_616": {
       "inputs": {
-        "nixpkgs": "nixpkgs_616",
-        "nixpkgs-windows": "nixpkgs-windows_564"
+        "nixpkgs": "nixpkgs_616"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31031,7 +30661,7 @@
     "logos-nix_617": {
       "inputs": {
         "nixpkgs": "nixpkgs_617",
-        "nixpkgs-windows": "nixpkgs-windows_565"
+        "nixpkgs-windows": "nixpkgs-windows_563"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31050,14 +30680,14 @@
     "logos-nix_618": {
       "inputs": {
         "nixpkgs": "nixpkgs_618",
-        "nixpkgs-windows": "nixpkgs-windows_566"
+        "nixpkgs-windows": "nixpkgs-windows_564"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31069,14 +30699,14 @@
     "logos-nix_619": {
       "inputs": {
         "nixpkgs": "nixpkgs_619",
-        "nixpkgs-windows": "nixpkgs-windows_567"
+        "nixpkgs-windows": "nixpkgs-windows_565"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31107,7 +30737,7 @@
     "logos-nix_620": {
       "inputs": {
         "nixpkgs": "nixpkgs_620",
-        "nixpkgs-windows": "nixpkgs-windows_568"
+        "nixpkgs-windows": "nixpkgs-windows_566"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31125,14 +30755,15 @@
     },
     "logos-nix_621": {
       "inputs": {
-        "nixpkgs": "nixpkgs_621"
+        "nixpkgs": "nixpkgs_621",
+        "nixpkgs-windows": "nixpkgs-windows_567"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31143,14 +30774,15 @@
     },
     "logos-nix_622": {
       "inputs": {
-        "nixpkgs": "nixpkgs_622"
+        "nixpkgs": "nixpkgs_622",
+        "nixpkgs-windows": "nixpkgs-windows_568"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31545,11 +31177,11 @@
         "nixpkgs-windows": "nixpkgs-windows_587"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31659,11 +31291,11 @@
         "nixpkgs-windows": "nixpkgs-windows_593"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31997,15 +31629,14 @@
     },
     "logos-nix_663": {
       "inputs": {
-        "nixpkgs": "nixpkgs_663",
-        "nixpkgs-windows": "nixpkgs-windows_609"
+        "nixpkgs": "nixpkgs_663"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32016,15 +31647,14 @@
     },
     "logos-nix_664": {
       "inputs": {
-        "nixpkgs": "nixpkgs_664",
-        "nixpkgs-windows": "nixpkgs-windows_610"
+        "nixpkgs": "nixpkgs_664"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32036,7 +31666,7 @@
     "logos-nix_665": {
       "inputs": {
         "nixpkgs": "nixpkgs_665",
-        "nixpkgs-windows": "nixpkgs-windows_611"
+        "nixpkgs-windows": "nixpkgs-windows_609"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32055,7 +31685,7 @@
     "logos-nix_666": {
       "inputs": {
         "nixpkgs": "nixpkgs_666",
-        "nixpkgs-windows": "nixpkgs-windows_612"
+        "nixpkgs-windows": "nixpkgs-windows_610"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32074,7 +31704,7 @@
     "logos-nix_667": {
       "inputs": {
         "nixpkgs": "nixpkgs_667",
-        "nixpkgs-windows": "nixpkgs-windows_613"
+        "nixpkgs-windows": "nixpkgs-windows_611"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32093,7 +31723,7 @@
     "logos-nix_668": {
       "inputs": {
         "nixpkgs": "nixpkgs_668",
-        "nixpkgs-windows": "nixpkgs-windows_614"
+        "nixpkgs-windows": "nixpkgs-windows_612"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32111,14 +31741,15 @@
     },
     "logos-nix_669": {
       "inputs": {
-        "nixpkgs": "nixpkgs_669"
+        "nixpkgs": "nixpkgs_669",
+        "nixpkgs-windows": "nixpkgs-windows_613"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32148,14 +31779,15 @@
     },
     "logos-nix_670": {
       "inputs": {
-        "nixpkgs": "nixpkgs_670"
+        "nixpkgs": "nixpkgs_670",
+        "nixpkgs-windows": "nixpkgs-windows_614"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32261,15 +31893,14 @@
     },
     "logos-nix_676": {
       "inputs": {
-        "nixpkgs": "nixpkgs_676",
-        "nixpkgs-windows": "nixpkgs-windows_620"
+        "nixpkgs": "nixpkgs_676"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32280,15 +31911,14 @@
     },
     "logos-nix_677": {
       "inputs": {
-        "nixpkgs": "nixpkgs_677",
-        "nixpkgs-windows": "nixpkgs-windows_621"
+        "nixpkgs": "nixpkgs_677"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32300,7 +31930,7 @@
     "logos-nix_678": {
       "inputs": {
         "nixpkgs": "nixpkgs_678",
-        "nixpkgs-windows": "nixpkgs-windows_622"
+        "nixpkgs-windows": "nixpkgs-windows_620"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32319,7 +31949,7 @@
     "logos-nix_679": {
       "inputs": {
         "nixpkgs": "nixpkgs_679",
-        "nixpkgs-windows": "nixpkgs-windows_623"
+        "nixpkgs-windows": "nixpkgs-windows_621"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32357,7 +31987,7 @@
     "logos-nix_680": {
       "inputs": {
         "nixpkgs": "nixpkgs_680",
-        "nixpkgs-windows": "nixpkgs-windows_624"
+        "nixpkgs-windows": "nixpkgs-windows_622"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32376,7 +32006,7 @@
     "logos-nix_681": {
       "inputs": {
         "nixpkgs": "nixpkgs_681",
-        "nixpkgs-windows": "nixpkgs-windows_625"
+        "nixpkgs-windows": "nixpkgs-windows_623"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32394,14 +32024,15 @@
     },
     "logos-nix_682": {
       "inputs": {
-        "nixpkgs": "nixpkgs_682"
+        "nixpkgs": "nixpkgs_682",
+        "nixpkgs-windows": "nixpkgs-windows_624"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32412,14 +32043,15 @@
     },
     "logos-nix_683": {
       "inputs": {
-        "nixpkgs": "nixpkgs_683"
+        "nixpkgs": "nixpkgs_683",
+        "nixpkgs-windows": "nixpkgs-windows_625"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32449,15 +32081,14 @@
     },
     "logos-nix_685": {
       "inputs": {
-        "nixpkgs": "nixpkgs_685",
-        "nixpkgs-windows": "nixpkgs-windows_627"
+        "nixpkgs": "nixpkgs_685"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32469,7 +32100,7 @@
     "logos-nix_686": {
       "inputs": {
         "nixpkgs": "nixpkgs_686",
-        "nixpkgs-windows": "nixpkgs-windows_628"
+        "nixpkgs-windows": "nixpkgs-windows_627"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32488,7 +32119,7 @@
     "logos-nix_687": {
       "inputs": {
         "nixpkgs": "nixpkgs_687",
-        "nixpkgs-windows": "nixpkgs-windows_629"
+        "nixpkgs-windows": "nixpkgs-windows_628"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32507,7 +32138,7 @@
     "logos-nix_688": {
       "inputs": {
         "nixpkgs": "nixpkgs_688",
-        "nixpkgs-windows": "nixpkgs-windows_630"
+        "nixpkgs-windows": "nixpkgs-windows_629"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32526,14 +32157,14 @@
     "logos-nix_689": {
       "inputs": {
         "nixpkgs": "nixpkgs_689",
-        "nixpkgs-windows": "nixpkgs-windows_631"
+        "nixpkgs-windows": "nixpkgs-windows_630"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32564,7 +32195,7 @@
     "logos-nix_690": {
       "inputs": {
         "nixpkgs": "nixpkgs_690",
-        "nixpkgs-windows": "nixpkgs-windows_632"
+        "nixpkgs-windows": "nixpkgs-windows_631"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32582,14 +32213,15 @@
     },
     "logos-nix_691": {
       "inputs": {
-        "nixpkgs": "nixpkgs_691"
+        "nixpkgs": "nixpkgs_691",
+        "nixpkgs-windows": "nixpkgs-windows_632"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32676,15 +32308,14 @@
     },
     "logos-nix_696": {
       "inputs": {
-        "nixpkgs": "nixpkgs_696",
-        "nixpkgs-windows": "nixpkgs-windows_637"
+        "nixpkgs": "nixpkgs_696"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32695,15 +32326,14 @@
     },
     "logos-nix_697": {
       "inputs": {
-        "nixpkgs": "nixpkgs_697",
-        "nixpkgs-windows": "nixpkgs-windows_638"
+        "nixpkgs": "nixpkgs_697"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32715,7 +32345,7 @@
     "logos-nix_698": {
       "inputs": {
         "nixpkgs": "nixpkgs_698",
-        "nixpkgs-windows": "nixpkgs-windows_639"
+        "nixpkgs-windows": "nixpkgs-windows_637"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32734,7 +32364,7 @@
     "logos-nix_699": {
       "inputs": {
         "nixpkgs": "nixpkgs_699",
-        "nixpkgs-windows": "nixpkgs-windows_640"
+        "nixpkgs-windows": "nixpkgs-windows_638"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32791,7 +32421,7 @@
     "logos-nix_700": {
       "inputs": {
         "nixpkgs": "nixpkgs_700",
-        "nixpkgs-windows": "nixpkgs-windows_641"
+        "nixpkgs-windows": "nixpkgs-windows_639"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32810,7 +32440,7 @@
     "logos-nix_701": {
       "inputs": {
         "nixpkgs": "nixpkgs_701",
-        "nixpkgs-windows": "nixpkgs-windows_642"
+        "nixpkgs-windows": "nixpkgs-windows_640"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32828,14 +32458,15 @@
     },
     "logos-nix_702": {
       "inputs": {
-        "nixpkgs": "nixpkgs_702"
+        "nixpkgs": "nixpkgs_702",
+        "nixpkgs-windows": "nixpkgs-windows_641"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32846,14 +32477,15 @@
     },
     "logos-nix_703": {
       "inputs": {
-        "nixpkgs": "nixpkgs_703"
+        "nixpkgs": "nixpkgs_703",
+        "nixpkgs-windows": "nixpkgs-windows_642"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32883,15 +32515,14 @@
     },
     "logos-nix_705": {
       "inputs": {
-        "nixpkgs": "nixpkgs_705",
-        "nixpkgs-windows": "nixpkgs-windows_644"
+        "nixpkgs": "nixpkgs_705"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -32902,15 +32533,14 @@
     },
     "logos-nix_706": {
       "inputs": {
-        "nixpkgs": "nixpkgs_706",
-        "nixpkgs-windows": "nixpkgs-windows_645"
+        "nixpkgs": "nixpkgs_706"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32922,7 +32552,7 @@
     "logos-nix_707": {
       "inputs": {
         "nixpkgs": "nixpkgs_707",
-        "nixpkgs-windows": "nixpkgs-windows_646"
+        "nixpkgs-windows": "nixpkgs-windows_644"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32941,14 +32571,14 @@
     "logos-nix_708": {
       "inputs": {
         "nixpkgs": "nixpkgs_708",
-        "nixpkgs-windows": "nixpkgs-windows_647"
+        "nixpkgs-windows": "nixpkgs-windows_645"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32960,14 +32590,14 @@
     "logos-nix_709": {
       "inputs": {
         "nixpkgs": "nixpkgs_709",
-        "nixpkgs-windows": "nixpkgs-windows_648"
+        "nixpkgs-windows": "nixpkgs-windows_646"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32998,7 +32628,7 @@
     "logos-nix_710": {
       "inputs": {
         "nixpkgs": "nixpkgs_710",
-        "nixpkgs-windows": "nixpkgs-windows_649"
+        "nixpkgs-windows": "nixpkgs-windows_647"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33016,14 +32646,15 @@
     },
     "logos-nix_711": {
       "inputs": {
-        "nixpkgs": "nixpkgs_711"
+        "nixpkgs": "nixpkgs_711",
+        "nixpkgs-windows": "nixpkgs-windows_648"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33034,14 +32665,15 @@
     },
     "logos-nix_712": {
       "inputs": {
-        "nixpkgs": "nixpkgs_712"
+        "nixpkgs": "nixpkgs_712",
+        "nixpkgs-windows": "nixpkgs-windows_649"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33075,11 +32707,11 @@
         "nixpkgs-windows": "nixpkgs-windows_651"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33147,15 +32779,14 @@
     },
     "logos-nix_718": {
       "inputs": {
-        "nixpkgs": "nixpkgs_718",
-        "nixpkgs-windows": "nixpkgs-windows_655"
+        "nixpkgs": "nixpkgs_718"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33167,7 +32798,7 @@
     "logos-nix_719": {
       "inputs": {
         "nixpkgs": "nixpkgs_719",
-        "nixpkgs-windows": "nixpkgs-windows_656"
+        "nixpkgs-windows": "nixpkgs-windows_655"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33205,14 +32836,14 @@
     "logos-nix_720": {
       "inputs": {
         "nixpkgs": "nixpkgs_720",
-        "nixpkgs-windows": "nixpkgs-windows_657"
+        "nixpkgs-windows": "nixpkgs-windows_656"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33224,7 +32855,7 @@
     "logos-nix_721": {
       "inputs": {
         "nixpkgs": "nixpkgs_721",
-        "nixpkgs-windows": "nixpkgs-windows_658"
+        "nixpkgs-windows": "nixpkgs-windows_657"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33243,7 +32874,7 @@
     "logos-nix_722": {
       "inputs": {
         "nixpkgs": "nixpkgs_722",
-        "nixpkgs-windows": "nixpkgs-windows_659"
+        "nixpkgs-windows": "nixpkgs-windows_658"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33262,7 +32893,7 @@
     "logos-nix_723": {
       "inputs": {
         "nixpkgs": "nixpkgs_723",
-        "nixpkgs-windows": "nixpkgs-windows_660"
+        "nixpkgs-windows": "nixpkgs-windows_659"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33280,14 +32911,15 @@
     },
     "logos-nix_724": {
       "inputs": {
-        "nixpkgs": "nixpkgs_724"
+        "nixpkgs": "nixpkgs_724",
+        "nixpkgs-windows": "nixpkgs-windows_660"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33321,11 +32953,11 @@
         "nixpkgs-windows": "nixpkgs-windows_662"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33340,11 +32972,11 @@
         "nixpkgs-windows": "nixpkgs-windows_663"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33374,15 +33006,14 @@
     },
     "logos-nix_729": {
       "inputs": {
-        "nixpkgs": "nixpkgs_729",
-        "nixpkgs-windows": "nixpkgs-windows_665"
+        "nixpkgs": "nixpkgs_729"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33412,15 +33043,14 @@
     },
     "logos-nix_730": {
       "inputs": {
-        "nixpkgs": "nixpkgs_730",
-        "nixpkgs-windows": "nixpkgs-windows_666"
+        "nixpkgs": "nixpkgs_730"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33432,7 +33062,7 @@
     "logos-nix_731": {
       "inputs": {
         "nixpkgs": "nixpkgs_731",
-        "nixpkgs-windows": "nixpkgs-windows_667"
+        "nixpkgs-windows": "nixpkgs-windows_665"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33451,14 +33081,14 @@
     "logos-nix_732": {
       "inputs": {
         "nixpkgs": "nixpkgs_732",
-        "nixpkgs-windows": "nixpkgs-windows_668"
+        "nixpkgs-windows": "nixpkgs-windows_666"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33470,14 +33100,14 @@
     "logos-nix_733": {
       "inputs": {
         "nixpkgs": "nixpkgs_733",
-        "nixpkgs-windows": "nixpkgs-windows_669"
+        "nixpkgs-windows": "nixpkgs-windows_667"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33489,7 +33119,7 @@
     "logos-nix_734": {
       "inputs": {
         "nixpkgs": "nixpkgs_734",
-        "nixpkgs-windows": "nixpkgs-windows_670"
+        "nixpkgs-windows": "nixpkgs-windows_668"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33507,14 +33137,15 @@
     },
     "logos-nix_735": {
       "inputs": {
-        "nixpkgs": "nixpkgs_735"
+        "nixpkgs": "nixpkgs_735",
+        "nixpkgs-windows": "nixpkgs-windows_669"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33525,14 +33156,15 @@
     },
     "logos-nix_736": {
       "inputs": {
-        "nixpkgs": "nixpkgs_736"
+        "nixpkgs": "nixpkgs_736",
+        "nixpkgs-windows": "nixpkgs-windows_670"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33581,15 +33213,14 @@
     },
     "logos-nix_739": {
       "inputs": {
-        "nixpkgs": "nixpkgs_739",
-        "nixpkgs-windows": "nixpkgs-windows_673"
+        "nixpkgs": "nixpkgs_739"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33620,7 +33251,7 @@
     "logos-nix_740": {
       "inputs": {
         "nixpkgs": "nixpkgs_740",
-        "nixpkgs-windows": "nixpkgs-windows_674"
+        "nixpkgs-windows": "nixpkgs-windows_673"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33639,7 +33270,7 @@
     "logos-nix_741": {
       "inputs": {
         "nixpkgs": "nixpkgs_741",
-        "nixpkgs-windows": "nixpkgs-windows_675"
+        "nixpkgs-windows": "nixpkgs-windows_674"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33657,15 +33288,14 @@
     },
     "logos-nix_742": {
       "inputs": {
-        "nixpkgs": "nixpkgs_742",
-        "nixpkgs-windows": "nixpkgs-windows_676"
+        "nixpkgs": "nixpkgs_742"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33676,15 +33306,14 @@
     },
     "logos-nix_743": {
       "inputs": {
-        "nixpkgs": "nixpkgs_743",
-        "nixpkgs-windows": "nixpkgs-windows_677"
+        "nixpkgs": "nixpkgs_743"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33696,7 +33325,7 @@
     "logos-nix_744": {
       "inputs": {
         "nixpkgs": "nixpkgs_744",
-        "nixpkgs-windows": "nixpkgs-windows_678"
+        "nixpkgs-windows": "nixpkgs-windows_675"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33714,14 +33343,15 @@
     },
     "logos-nix_745": {
       "inputs": {
-        "nixpkgs": "nixpkgs_745"
+        "nixpkgs": "nixpkgs_745",
+        "nixpkgs-windows": "nixpkgs-windows_676"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33733,14 +33363,14 @@
     "logos-nix_746": {
       "inputs": {
         "nixpkgs": "nixpkgs_746",
-        "nixpkgs-windows": "nixpkgs-windows_679"
+        "nixpkgs-windows": "nixpkgs-windows_677"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33752,7 +33382,7 @@
     "logos-nix_747": {
       "inputs": {
         "nixpkgs": "nixpkgs_747",
-        "nixpkgs-windows": "nixpkgs-windows_680"
+        "nixpkgs-windows": "nixpkgs-windows_678"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33770,15 +33400,14 @@
     },
     "logos-nix_748": {
       "inputs": {
-        "nixpkgs": "nixpkgs_748",
-        "nixpkgs-windows": "nixpkgs-windows_681"
+        "nixpkgs": "nixpkgs_748"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33789,15 +33418,14 @@
     },
     "logos-nix_749": {
       "inputs": {
-        "nixpkgs": "nixpkgs_749",
-        "nixpkgs-windows": "nixpkgs-windows_682"
+        "nixpkgs": "nixpkgs_749"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33827,14 +33455,15 @@
     },
     "logos-nix_750": {
       "inputs": {
-        "nixpkgs": "nixpkgs_750"
+        "nixpkgs": "nixpkgs_750",
+        "nixpkgs-windows": "nixpkgs-windows_679"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33845,14 +33474,15 @@
     },
     "logos-nix_751": {
       "inputs": {
-        "nixpkgs": "nixpkgs_751"
+        "nixpkgs": "nixpkgs_751",
+        "nixpkgs-windows": "nixpkgs-windows_680"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33864,7 +33494,7 @@
     "logos-nix_752": {
       "inputs": {
         "nixpkgs": "nixpkgs_752",
-        "nixpkgs-windows": "nixpkgs-windows_683"
+        "nixpkgs-windows": "nixpkgs-windows_681"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33883,14 +33513,14 @@
     "logos-nix_753": {
       "inputs": {
         "nixpkgs": "nixpkgs_753",
-        "nixpkgs-windows": "nixpkgs-windows_684"
+        "nixpkgs-windows": "nixpkgs-windows_682"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33901,45 +33531,7 @@
     },
     "logos-nix_754": {
       "inputs": {
-        "nixpkgs": "nixpkgs_754",
-        "nixpkgs-windows": "nixpkgs-windows_685"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_755": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_755",
-        "nixpkgs-windows": "nixpkgs-windows_686"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_756": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_756"
+        "nixpkgs": "nixpkgs_754"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33947,62 +33539,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_757": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_757"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_758": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_758",
-        "nixpkgs-windows": "nixpkgs-windows_687"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_759": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_759",
-        "nixpkgs-windows": "nixpkgs-windows_688"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34022,62 +33558,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_760": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_760",
-        "nixpkgs-windows": "nixpkgs-windows_689"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_761": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_761",
-        "nixpkgs-windows": "nixpkgs-windows_690"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_762": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_762"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34244,11 +33724,11 @@
         "nixpkgs-windows": "nixpkgs-windows_80"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -34263,11 +33743,11 @@
         "nixpkgs-windows": "nixpkgs-windows_81"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34589,7 +34069,7 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
+        "logos-nix": "logos-nix_397",
         "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_61",
@@ -34708,7 +34188,7 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_323",
         "logos-package": "logos-package_28",
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_46",
@@ -34745,7 +34225,7 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_336",
         "logos-package": "logos-package_30",
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_49",
@@ -34779,7 +34259,7 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_356",
         "logos-package": "logos-package_32",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_52",
@@ -34812,7 +34292,7 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_371",
+        "logos-nix": "logos-nix_365",
         "logos-package": "logos-package_34",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_55",
@@ -34842,7 +34322,7 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_389",
         "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_58",
@@ -34871,7 +34351,7 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_402",
         "logos-package": "logos-package_39",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_63",
@@ -34897,7 +34377,7 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_447",
         "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_68",
@@ -34930,7 +34410,7 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_495",
         "logos-package": "logos-package_44",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_74",
@@ -34967,7 +34447,7 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_508",
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_77",
@@ -35001,7 +34481,7 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_528",
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_80",
@@ -35064,7 +34544,7 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_543",
+        "logos-nix": "logos-nix_537",
         "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_83",
@@ -35094,7 +34574,7 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_561",
         "logos-package": "logos-package_52",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_86",
@@ -35123,7 +34603,7 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_569",
         "logos-package": "logos-package_54",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_89",
@@ -35150,7 +34630,7 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_619",
+        "logos-nix": "logos-nix_613",
         "logos-package": "logos-package_56",
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_94",
@@ -35183,7 +34663,7 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_667",
+        "logos-nix": "logos-nix_661",
         "logos-package": "logos-package_59",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_100",
@@ -35220,7 +34700,7 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_674",
         "logos-package": "logos-package_61",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
         "nix-bundle-dir": "nix-bundle-dir_103",
@@ -35254,7 +34734,7 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_694",
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
         "nix-bundle-dir": "nix-bundle-dir_106",
@@ -35287,7 +34767,7 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_709",
+        "logos-nix": "logos-nix_703",
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_47",
         "nix-bundle-dir": "nix-bundle-dir_109",
@@ -35317,7 +34797,7 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_733",
+        "logos-nix": "logos-nix_727",
         "logos-package": "logos-package_67",
         "nix-bundle-appimage": "nix-bundle-appimage_48",
         "nix-bundle-dir": "nix-bundle-dir_112",
@@ -35346,7 +34826,7 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_754",
+        "logos-nix": "logos-nix_746",
         "logos-package": "logos-package_70",
         "nix-bundle-appimage": "nix-bundle-appimage_50",
         "nix-bundle-dir": "nix-bundle-dir_117",
@@ -35373,7 +34853,7 @@
     },
     "logos-package-manager_3": {
       "inputs": {
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_104",
         "logos-package": "logos-package_9",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_16",
@@ -35407,7 +34887,7 @@
     },
     "logos-package-manager_4": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_117",
         "logos-package": "logos-package_11",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_19",
@@ -35438,7 +34918,7 @@
     },
     "logos-package-manager_5": {
       "inputs": {
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_137",
         "logos-package": "logos-package_13",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_22",
@@ -35468,7 +34948,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_192",
         "logos-package": "logos-package_17",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
         "nix-bundle-dir": "nix-bundle-dir_28",
@@ -35501,7 +34981,7 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_211",
+        "logos-nix": "logos-nix_205",
         "logos-package": "logos-package_19",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
         "nix-bundle-dir": "nix-bundle-dir_31",
@@ -35531,7 +35011,7 @@
     },
     "logos-package-manager_8": {
       "inputs": {
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_225",
         "logos-package": "logos-package_21",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
         "nix-bundle-dir": "nix-bundle-dir_34",
@@ -35560,7 +35040,7 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_275",
         "logos-package": "logos-package_25",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_40",
@@ -35593,7 +35073,7 @@
     },
     "logos-package_10": {
       "inputs": {
-        "logos-nix": "logos-nix_111",
+        "logos-nix": "logos-nix_110",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35625,7 +35105,7 @@
     },
     "logos-package_11": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_118",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35654,7 +35134,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_135",
+        "logos-nix": "logos-nix_134",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35681,7 +35161,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_139",
+        "logos-nix": "logos-nix_138",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35709,7 +35189,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_143",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35764,7 +35244,7 @@
     },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_195",
+        "logos-nix": "logos-nix_189",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35794,7 +35274,7 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_193",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35825,7 +35305,7 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35856,7 +35336,7 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_212",
+        "logos-nix": "logos-nix_206",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35911,7 +35391,7 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
+        "logos-nix": "logos-nix_222",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35937,7 +35417,7 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_226",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35964,7 +35444,7 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_231",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35991,7 +35471,7 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_240",
+        "logos-nix": "logos-nix_234",
         "nixpkgs": [
           "logos-package",
           "logos-nix",
@@ -36014,7 +35494,7 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_278",
+        "logos-nix": "logos-nix_272",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36044,7 +35524,7 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_282",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36075,7 +35555,7 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_281",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36106,7 +35586,7 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36140,7 +35620,7 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_324",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36175,7 +35655,7 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_335",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36237,7 +35717,7 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_343",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36269,7 +35749,7 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_353",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36299,7 +35779,7 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_357",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36330,7 +35810,7 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_362",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36361,7 +35841,7 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": "logos-nix_366",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36389,7 +35869,7 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36415,7 +35895,7 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_390",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36442,7 +35922,7 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_395",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -36469,7 +35949,7 @@
     },
     "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_398",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -36494,7 +35974,7 @@
     },
     "logos-package_39": {
       "inputs": {
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_403",
         "nixpkgs": [
           "logos-package-manager",
           "logos-package",
@@ -36545,7 +36025,7 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_444",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36575,7 +36055,7 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_448",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36606,7 +36086,7 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_459",
+        "logos-nix": "logos-nix_453",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36637,7 +36117,7 @@
     },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36671,7 +36151,7 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": "logos-nix_496",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36706,7 +36186,7 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_501",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36741,7 +36221,7 @@
     },
     "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_515",
+        "logos-nix": "logos-nix_509",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36773,7 +36253,7 @@
     },
     "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_525",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36803,7 +36283,7 @@
     },
     "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_535",
+        "logos-nix": "logos-nix_529",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36834,7 +36314,7 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_534",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36893,7 +36373,7 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_538",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36921,7 +36401,7 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36947,7 +36427,7 @@
     },
     "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_562",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36974,7 +36454,7 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_573",
+        "logos-nix": "logos-nix_567",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37001,7 +36481,7 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_570",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -37026,7 +36506,7 @@
     },
     "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_616",
+        "logos-nix": "logos-nix_610",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37056,7 +36536,7 @@
     },
     "logos-package_56": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_614",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37087,7 +36567,7 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_625",
+        "logos-nix": "logos-nix_619",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37118,7 +36598,7 @@
     },
     "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_664",
+        "logos-nix": "logos-nix_658",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37152,7 +36632,7 @@
     },
     "logos-package_59": {
       "inputs": {
-        "logos-nix": "logos-nix_668",
+        "logos-nix": "logos-nix_662",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37215,7 +36695,7 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37250,7 +36730,7 @@
     },
     "logos-package_61": {
       "inputs": {
-        "logos-nix": "logos-nix_681",
+        "logos-nix": "logos-nix_675",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37282,7 +36762,7 @@
     },
     "logos-package_62": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
+        "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37312,7 +36792,7 @@
     },
     "logos-package_63": {
       "inputs": {
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_695",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37343,7 +36823,7 @@
     },
     "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_700",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37374,7 +36854,7 @@
     },
     "logos-package_65": {
       "inputs": {
-        "logos-nix": "logos-nix_710",
+        "logos-nix": "logos-nix_704",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37402,7 +36882,7 @@
     },
     "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
+        "logos-nix": "logos-nix_724",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37428,7 +36908,7 @@
     },
     "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_728",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37455,7 +36935,7 @@
     },
     "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_739",
+        "logos-nix": "logos-nix_733",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37482,7 +36962,7 @@
     },
     "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_741",
+        "logos-nix": "logos-nix_735",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-package",
@@ -37535,7 +37015,7 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_755",
+        "logos-nix": "logos-nix_747",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -37560,7 +37040,7 @@
     },
     "logos-package_71": {
       "inputs": {
-        "logos-nix": "logos-nix_760",
+        "logos-nix": "logos-nix_752",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37585,7 +37065,7 @@
     },
     "logos-package_8": {
       "inputs": {
-        "logos-nix": "logos-nix_102",
+        "logos-nix": "logos-nix_101",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37616,7 +37096,7 @@
     },
     "logos-package_9": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_105",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37680,9 +37160,9 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_98",
-        "logos-module": "logos-module_71",
-        "logos-nix": "logos-nix_315",
+        "logos-lidl": "logos-lidl_95",
+        "logos-module": "logos-module_69",
+        "logos-nix": "logos-nix_309",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37728,9 +37208,9 @@
     },
     "logos-plugin-core_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_122",
-        "logos-module": "logos-module_87",
-        "logos-nix": "logos-nix_418",
+        "logos-lidl": "logos-lidl_119",
+        "logos-module": "logos-module_85",
+        "logos-nix": "logos-nix_412",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37760,9 +37240,9 @@
     },
     "logos-plugin-core_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_130",
-        "logos-module": "logos-module_93",
-        "logos-nix": "logos-nix_439",
+        "logos-lidl": "logos-lidl_127",
+        "logos-module": "logos-module_91",
+        "logos-nix": "logos-nix_433",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37800,9 +37280,9 @@
     },
     "logos-plugin-core_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_140",
-        "logos-module": "logos-module_100",
-        "logos-nix": "logos-nix_470",
+        "logos-lidl": "logos-lidl_137",
+        "logos-module": "logos-module_98",
+        "logos-nix": "logos-nix_464",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37840,9 +37320,9 @@
     },
     "logos-plugin-core_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_146",
-        "logos-module": "logos-module_105",
-        "logos-nix": "logos-nix_487",
+        "logos-lidl": "logos-lidl_143",
+        "logos-module": "logos-module_103",
+        "logos-nix": "logos-nix_481",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37888,9 +37368,9 @@
     },
     "logos-plugin-core_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_170",
-        "logos-module": "logos-module_121",
-        "logos-nix": "logos-nix_585",
+        "logos-lidl": "logos-lidl_167",
+        "logos-module": "logos-module_119",
+        "logos-nix": "logos-nix_579",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37920,9 +37400,9 @@
     },
     "logos-plugin-core_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_178",
-        "logos-module": "logos-module_126",
-        "logos-nix": "logos-nix_605",
+        "logos-lidl": "logos-lidl_175",
+        "logos-module": "logos-module_124",
+        "logos-nix": "logos-nix_599",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37960,9 +37440,9 @@
     },
     "logos-plugin-core_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_188",
-        "logos-module": "logos-module_133",
-        "logos-nix": "logos-nix_636",
+        "logos-lidl": "logos-lidl_185",
+        "logos-module": "logos-module_131",
+        "logos-nix": "logos-nix_630",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -38000,9 +37480,9 @@
     },
     "logos-plugin-core_18": {
       "inputs": {
-        "logos-lidl": "logos-lidl_194",
-        "logos-module": "logos-module_138",
-        "logos-nix": "logos-nix_653",
+        "logos-lidl": "logos-lidl_191",
+        "logos-module": "logos-module_136",
+        "logos-nix": "logos-nix_647",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -38082,9 +37562,9 @@
     },
     "logos-plugin-core_3": {
       "inputs": {
-        "logos-lidl": "logos-lidl_24",
+        "logos-lidl": "logos-lidl_23",
         "logos-module": "logos-module_16",
-        "logos-nix": "logos-nix_74",
+        "logos-nix": "logos-nix_73",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -38116,9 +37596,9 @@
     },
     "logos-plugin-core_4": {
       "inputs": {
-        "logos-lidl": "logos-lidl_30",
+        "logos-lidl": "logos-lidl_29",
         "logos-module": "logos-module_21",
-        "logos-nix": "logos-nix_91",
+        "logos-nix": "logos-nix_90",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -38158,9 +37638,9 @@
     },
     "logos-plugin-core_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_51",
-        "logos-module": "logos-module_37",
-        "logos-nix": "logos-nix_167",
+        "logos-lidl": "logos-lidl_48",
+        "logos-module": "logos-module_35",
+        "logos-nix": "logos-nix_161",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38190,9 +37670,9 @@
     },
     "logos-plugin-core_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_57",
-        "logos-module": "logos-module_42",
-        "logos-nix": "logos-nix_184",
+        "logos-lidl": "logos-lidl_54",
+        "logos-module": "logos-module_40",
+        "logos-nix": "logos-nix_178",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38230,9 +37710,9 @@
     },
     "logos-plugin-core_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_74",
-        "logos-module": "logos-module_53",
-        "logos-nix": "logos-nix_246",
+        "logos-lidl": "logos-lidl_71",
+        "logos-module": "logos-module_51",
+        "logos-nix": "logos-nix_240",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38262,9 +37742,9 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_82",
-        "logos-module": "logos-module_59",
-        "logos-nix": "logos-nix_267",
+        "logos-lidl": "logos-lidl_79",
+        "logos-module": "logos-module_57",
+        "logos-nix": "logos-nix_261",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38302,9 +37782,9 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_92",
-        "logos-module": "logos-module_66",
-        "logos-nix": "logos-nix_298",
+        "logos-lidl": "logos-lidl_89",
+        "logos-module": "logos-module_64",
+        "logos-nix": "logos-nix_292",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38422,9 +37902,9 @@
     },
     "logos-plugin-qt_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_31",
+        "logos-lidl": "logos-lidl_30",
         "logos-module": "logos-module_22",
-        "logos-nix": "logos-nix_93",
+        "logos-nix": "logos-nix_92",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -38528,7 +38008,7 @@
     },
     "logos-plugin-qt_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_34",
+        "logos-lidl": "logos-lidl_33",
         "logos-module": "logos-module_24",
         "logos-nix": [
           "logos-liblogos",
@@ -38580,7 +38060,7 @@
     },
     "logos-plugin-qt_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_37",
+        "logos-lidl": "logos-lidl_36",
         "logos-module": "logos-module_25",
         "logos-nix": [
           "logos-liblogos",
@@ -38632,7 +38112,7 @@
     },
     "logos-plugin-qt_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_39",
+        "logos-lidl": "logos-lidl_38",
         "logos-module": "logos-module_27",
         "logos-nix": [
           "logos-liblogos",
@@ -38675,7 +38155,7 @@
     },
     "logos-plugin-qt_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_41",
+        "logos-lidl": "logos-lidl_40",
         "logos-module": "logos-module_28",
         "logos-nix": [
           "logos-liblogos",
@@ -38715,7 +38195,7 @@
     },
     "logos-plugin-qt_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_42",
+        "logos-lidl": "logos-lidl_41",
         "logos-module": "logos-module_29",
         "logos-nix": [
           "logos-liblogos",
@@ -38755,7 +38235,7 @@
     },
     "logos-plugin-qt_18": {
       "inputs": {
-        "logos-lidl": "logos-lidl_45",
+        "logos-lidl": "logos-lidl_44",
         "logos-module": "logos-module_30",
         "logos-nix": [
           "logos-liblogos",
@@ -38795,23 +38275,36 @@
     },
     "logos-plugin-qt_19": {
       "inputs": {
-        "logos-lidl": "logos-lidl_46",
-        "logos-module": "logos-module_31",
-        "logos-nix": "logos-nix_148",
-        "logos-protocol": "logos-protocol_25",
+        "logos-lidl": [
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_33",
+        "logos-nix": [
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
         "nixpkgs": [
-          "logos-liblogos",
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -38859,89 +38352,9 @@
     },
     "logos-plugin-qt_20": {
       "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_32",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_21": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_35",
-        "logos-nix": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_22": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_52",
-        "logos-module": "logos-module_38",
-        "logos-nix": "logos-nix_169",
+        "logos-lidl": "logos-lidl_49",
+        "logos-module": "logos-module_36",
+        "logos-nix": "logos-nix_163",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38969,7 +38382,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_23": {
+    "logos-plugin-qt_21": {
       "inputs": {
         "logos-lidl": [
           "logos-modules-state-module",
@@ -38977,7 +38390,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_39",
+        "logos-module": "logos-module_37",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38992,6 +38405,106 @@
         ],
         "nixpkgs": [
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_22": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_55",
+        "logos-module": "logos-module_41",
+        "logos-nix": "logos-nix_180",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_23": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_42",
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -39017,7 +38530,16 @@
       "inputs": {
         "logos-lidl": "logos-lidl_58",
         "logos-module": "logos-module_43",
-        "logos-nix": "logos-nix_186",
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -39025,6 +38547,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39034,8 +38557,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -39055,16 +38577,7 @@
     },
     "logos-plugin-qt_25": {
       "inputs": {
-        "logos-lidl": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_61",
         "logos-module": "logos-module_44",
         "logos-nix": [
           "logos-modules-state-module",
@@ -39073,7 +38586,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39083,7 +38596,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39093,9 +38606,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -39115,16 +38626,13 @@
     },
     "logos-plugin-qt_26": {
       "inputs": {
-        "logos-lidl": "logos-lidl_61",
-        "logos-module": "logos-module_45",
+        "logos-lidl": "logos-lidl_63",
+        "logos-module": "logos-module_46",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39132,9 +38640,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39142,18 +38647,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -39164,45 +38666,33 @@
     },
     "logos-plugin-qt_27": {
       "inputs": {
-        "logos-lidl": "logos-lidl_64",
-        "logos-module": "logos-module_46",
+        "logos-lidl": "logos-lidl_65",
+        "logos-module": "logos-module_47",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -39218,31 +38708,28 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -39253,33 +38740,33 @@
     },
     "logos-plugin-qt_29": {
       "inputs": {
-        "logos-lidl": "logos-lidl_68",
+        "logos-lidl": "logos-lidl_69",
         "logos-module": "logos-module_49",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
         "type": "github"
       },
       "original": {
@@ -39327,83 +38814,9 @@
     },
     "logos-plugin-qt_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_69",
-        "logos-module": "logos-module_50",
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_31": {
-      "inputs": {
         "logos-lidl": "logos-lidl_72",
-        "logos-module": "logos-module_51",
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787346530,
-        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_32": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_75",
-        "logos-module": "logos-module_54",
-        "logos-nix": "logos-nix_248",
+        "logos-module": "logos-module_52",
+        "logos-nix": "logos-nix_242",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39431,7 +38844,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_33": {
+    "logos-plugin-qt_31": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -39439,7 +38852,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_55",
+        "logos-module": "logos-module_53",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39475,7 +38888,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_34": {
+    "logos-plugin-qt_32": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -39486,7 +38899,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_57",
+        "logos-module": "logos-module_55",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39511,6 +38924,106 @@
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_33": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_80",
+        "logos-module": "logos-module_58",
+        "logos-nix": "logos-nix_263",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_34": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_59",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -39535,106 +39048,6 @@
       "inputs": {
         "logos-lidl": "logos-lidl_83",
         "logos-module": "logos-module_60",
-        "logos-nix": "logos-nix_269",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_36": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_61",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_37": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_86",
-        "logos-module": "logos-module_62",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39680,10 +39093,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_38": {
+    "logos-plugin-qt_36": {
       "inputs": {
-        "logos-lidl": "logos-lidl_89",
-        "logos-module": "logos-module_63",
+        "logos-lidl": "logos-lidl_86",
+        "logos-module": "logos-module_61",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39729,11 +39142,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_39": {
+    "logos-plugin-qt_37": {
       "inputs": {
-        "logos-lidl": "logos-lidl_93",
-        "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_300",
+        "logos-lidl": "logos-lidl_90",
+        "logos-module": "logos-module_65",
+        "logos-nix": "logos-nix_294",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39761,6 +39174,114 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_38": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_66",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_39": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_96",
+        "logos-module": "logos-module_70",
+        "logos-nix": "logos-nix_311",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -39800,11 +39321,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1788890168,
+        "narHash": "sha256-gx8vxNsAU591M11YA5NFbhmCgE6FVaFsVWVvC57/Rk4=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "1a0e399ef238ef3dbed367249f13a87029ca7fc1",
         "type": "github"
       },
       "original": {
@@ -39822,16 +39343,24 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_68",
+        "logos-module": "logos-module_71",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
@@ -39843,6 +39372,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
@@ -39852,6 +39385,10 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -39877,7 +39414,20 @@
       "inputs": {
         "logos-lidl": "logos-lidl_99",
         "logos-module": "logos-module_72",
-        "logos-nix": "logos-nix_317",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39889,6 +39439,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39902,8 +39453,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -39923,20 +39473,7 @@
     },
     "logos-plugin-qt_42": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_102",
         "logos-module": "logos-module_73",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39949,7 +39486,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39963,7 +39500,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39977,9 +39514,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -39999,68 +39534,7 @@
     },
     "logos-plugin-qt_43": {
       "inputs": {
-        "logos-lidl": "logos-lidl_102",
-        "logos-module": "logos-module_74",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_44": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_105",
+        "logos-lidl": "logos-lidl_104",
         "logos-module": "logos-module_75",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -40071,9 +39545,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40085,9 +39556,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40099,18 +39567,64 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_44": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_106",
+        "logos-module": "logos-module_76",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -40130,107 +39644,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_46": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_109",
-        "logos-module": "logos-module_78",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_47": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_110",
-        "logos-module": "logos-module_79",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
@@ -40269,10 +39682,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_48": {
+    "logos-plugin-qt_46": {
       "inputs": {
-        "logos-lidl": "logos-lidl_113",
-        "logos-module": "logos-module_80",
+        "logos-lidl": "logos-lidl_110",
+        "logos-module": "logos-module_78",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40318,17 +39731,98 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_49": {
+    "logos-plugin-qt_47": {
       "inputs": {
-        "logos-lidl": "logos-lidl_114",
-        "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_377",
-        "logos-protocol": "logos-protocol_62",
+        "logos-lidl": "logos-lidl_111",
+        "logos-module": "logos-module_79",
+        "logos-nix": "logos-nix_371",
+        "logos-protocol": "logos-protocol_58",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_48": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_80",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_49": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_113",
+        "logos-module": "logos-module_81",
+        "logos-nix": "logos-nix_378",
+        "logos-protocol": "logos-protocol_61",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -40384,89 +39878,8 @@
     },
     "logos-plugin-qt_50": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_114",
         "logos-module": "logos-module_82",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_51": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_116",
-        "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_384",
-        "logos-protocol": "logos-protocol_65",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_52": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_117",
-        "logos-module": "logos-module_84",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40500,10 +39913,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_53": {
+    "logos-plugin-qt_51": {
       "inputs": {
-        "logos-lidl": "logos-lidl_120",
-        "logos-module": "logos-module_85",
+        "logos-lidl": "logos-lidl_117",
+        "logos-module": "logos-module_83",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -40537,11 +39950,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_54": {
+    "logos-plugin-qt_52": {
       "inputs": {
-        "logos-lidl": "logos-lidl_123",
-        "logos-module": "logos-module_88",
-        "logos-nix": "logos-nix_420",
+        "logos-lidl": "logos-lidl_120",
+        "logos-module": "logos-module_86",
+        "logos-nix": "logos-nix_414",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40569,7 +39982,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_55": {
+    "logos-plugin-qt_53": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -40577,7 +39990,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_89",
+        "logos-module": "logos-module_87",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40613,7 +40026,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_56": {
+    "logos-plugin-qt_54": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -40624,7 +40037,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_91",
+        "logos-module": "logos-module_89",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40649,6 +40062,106 @@
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_55": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_128",
+        "logos-module": "logos-module_92",
+        "logos-nix": "logos-nix_435",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_56": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_93",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -40673,106 +40186,6 @@
       "inputs": {
         "logos-lidl": "logos-lidl_131",
         "logos-module": "logos-module_94",
-        "logos-nix": "logos-nix_441",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_58": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_95",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_59": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_134",
-        "logos-module": "logos-module_96",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40810,6 +40223,95 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_58": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_134",
+        "logos-module": "logos-module_95",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_59": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_138",
+        "logos-module": "logos-module_99",
+        "logos-nix": "logos-nix_466",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {
@@ -40868,16 +40370,25 @@
     },
     "logos-plugin-qt_60": {
       "inputs": {
-        "logos-lidl": "logos-lidl_137",
-        "logos-module": "logos-module_97",
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_100",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40885,9 +40396,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40895,18 +40406,20 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -40917,15 +40430,19 @@
     },
     "logos-plugin-qt_61": {
       "inputs": {
-        "logos-lidl": "logos-lidl_141",
-        "logos-module": "logos-module_101",
-        "logos-nix": "logos-nix_472",
+        "logos-lidl": "logos-lidl_144",
+        "logos-module": "logos-module_104",
+        "logos-nix": "logos-nix_483",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
@@ -40936,17 +40453,21 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -40964,16 +40485,24 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_102",
+        "logos-module": "logos-module_105",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
@@ -40985,6 +40514,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
@@ -40994,6 +40527,10 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -41019,7 +40556,20 @@
       "inputs": {
         "logos-lidl": "logos-lidl_147",
         "logos-module": "logos-module_106",
-        "logos-nix": "logos-nix_489",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41031,6 +40581,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41044,8 +40595,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -41065,20 +40615,7 @@
     },
     "logos-plugin-qt_64": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_150",
         "logos-module": "logos-module_107",
         "logos-nix": [
           "logos-package-manager-module",
@@ -41091,7 +40628,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41105,7 +40642,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41119,9 +40656,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -41141,68 +40676,7 @@
     },
     "logos-plugin-qt_65": {
       "inputs": {
-        "logos-lidl": "logos-lidl_150",
-        "logos-module": "logos-module_108",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_66": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_153",
+        "logos-lidl": "logos-lidl_152",
         "logos-module": "logos-module_109",
         "logos-nix": [
           "logos-package-manager-module",
@@ -41213,9 +40687,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41227,9 +40698,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41241,18 +40709,64 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_66": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_154",
+        "logos-module": "logos-module_110",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -41272,107 +40786,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_68": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_157",
-        "logos-module": "logos-module_112",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_69": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_158",
-        "logos-module": "logos-module_113",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
@@ -41403,6 +40816,85 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_68": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_158",
+        "logos-module": "logos-module_112",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787346530,
+        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_69": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_159",
+        "logos-module": "logos-module_113",
+        "logos-nix": "logos-nix_543",
+        "logos-protocol": "logos-protocol_87",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -41453,85 +40945,6 @@
     },
     "logos-plugin-qt_70": {
       "inputs": {
-        "logos-lidl": "logos-lidl_161",
-        "logos-module": "logos-module_114",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787346530,
-        "narHash": "sha256-ZN699QDeXZq3rUHP5GafqU3a6lPyx3UFHgqnBm71kMk=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_71": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_162",
-        "logos-module": "logos-module_115",
-        "logos-nix": "logos-nix_549",
-        "logos-protocol": "logos-protocol_91",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_72": {
-      "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41540,7 +40953,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_116",
+        "logos-module": "logos-module_114",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41582,12 +40995,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_73": {
+    "logos-plugin-qt_71": {
       "inputs": {
-        "logos-lidl": "logos-lidl_164",
-        "logos-module": "logos-module_117",
-        "logos-nix": "logos-nix_556",
-        "logos-protocol": "logos-protocol_94",
+        "logos-lidl": "logos-lidl_161",
+        "logos-module": "logos-module_115",
+        "logos-nix": "logos-nix_550",
+        "logos-protocol": "logos-protocol_90",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41611,10 +41024,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_74": {
+    "logos-plugin-qt_72": {
       "inputs": {
-        "logos-lidl": "logos-lidl_165",
-        "logos-module": "logos-module_118",
+        "logos-lidl": "logos-lidl_162",
+        "logos-module": "logos-module_116",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41648,10 +41061,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_75": {
+    "logos-plugin-qt_73": {
       "inputs": {
-        "logos-lidl": "logos-lidl_168",
-        "logos-module": "logos-module_119",
+        "logos-lidl": "logos-lidl_165",
+        "logos-module": "logos-module_117",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41685,11 +41098,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_76": {
+    "logos-plugin-qt_74": {
       "inputs": {
-        "logos-lidl": "logos-lidl_171",
-        "logos-module": "logos-module_122",
-        "logos-nix": "logos-nix_587",
+        "logos-lidl": "logos-lidl_168",
+        "logos-module": "logos-module_120",
+        "logos-nix": "logos-nix_581",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41717,7 +41130,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_77": {
+    "logos-plugin-qt_75": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41728,7 +41141,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_124",
+        "logos-module": "logos-module_122",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41773,11 +41186,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_78": {
+    "logos-plugin-qt_76": {
       "inputs": {
-        "logos-lidl": "logos-lidl_179",
-        "logos-module": "logos-module_127",
-        "logos-nix": "logos-nix_607",
+        "logos-lidl": "logos-lidl_176",
+        "logos-module": "logos-module_125",
+        "logos-nix": "logos-nix_601",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41813,7 +41226,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_79": {
+    "logos-plugin-qt_77": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41825,7 +41238,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_128",
+        "logos-module": "logos-module_126",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41856,6 +41269,104 @@
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_78": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_179",
+        "logos-module": "logos-module_127",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_79": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_182",
+        "logos-module": "logos-module_128",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -41915,107 +41426,9 @@
     },
     "logos-plugin-qt_80": {
       "inputs": {
-        "logos-lidl": "logos-lidl_182",
-        "logos-module": "logos-module_129",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_81": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_185",
-        "logos-module": "logos-module_130",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_82": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_189",
-        "logos-module": "logos-module_134",
-        "logos-nix": "logos-nix_638",
+        "logos-lidl": "logos-lidl_186",
+        "logos-module": "logos-module_132",
+        "logos-nix": "logos-nix_632",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42051,7 +41464,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_83": {
+    "logos-plugin-qt_81": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -42063,7 +41476,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_135",
+        "logos-module": "logos-module_133",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42090,6 +41503,130 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_82": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_192",
+        "logos-module": "logos-module_137",
+        "logos-nix": "logos-nix_649",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_83": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_138",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -42115,7 +41652,20 @@
       "inputs": {
         "logos-lidl": "logos-lidl_195",
         "logos-module": "logos-module_139",
-        "logos-nix": "logos-nix_655",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42127,6 +41677,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -42140,8 +41691,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -42161,20 +41711,7 @@
     },
     "logos-plugin-qt_85": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_198",
         "logos-module": "logos-module_140",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42187,7 +41724,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -42201,7 +41738,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -42215,9 +41752,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -42237,68 +41772,7 @@
     },
     "logos-plugin-qt_86": {
       "inputs": {
-        "logos-lidl": "logos-lidl_198",
-        "logos-module": "logos-module_141",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_87": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_201",
+        "logos-lidl": "logos-lidl_200",
         "logos-module": "logos-module_142",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42309,9 +41783,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -42323,9 +41794,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -42337,18 +41805,64 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_87": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_202",
+        "logos-module": "logos-module_143",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -42368,141 +41882,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_89": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_205",
-        "logos-module": "logos-module_145",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_9": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_25",
-        "logos-module": "logos-module_17",
-        "logos-nix": "logos-nix_76",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_90": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_206",
-        "logos-module": "logos-module_146",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
@@ -42541,10 +41920,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_91": {
+    "logos-plugin-qt_89": {
       "inputs": {
-        "logos-lidl": "logos-lidl_209",
-        "logos-module": "logos-module_147",
+        "logos-lidl": "logos-lidl_206",
+        "logos-module": "logos-module_145",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42590,12 +41969,46 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_92": {
+    "logos-plugin-qt_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_210",
-        "logos-module": "logos-module_148",
-        "logos-nix": "logos-nix_715",
-        "logos-protocol": "logos-protocol_120",
+        "logos-lidl": "logos-lidl_24",
+        "logos-module": "logos-module_17",
+        "logos-nix": "logos-nix_75",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_90": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_207",
+        "logos-module": "logos-module_146",
+        "logos-nix": "logos-nix_709",
+        "logos-protocol": "logos-protocol_116",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42620,7 +42033,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_93": {
+    "logos-plugin-qt_91": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -42630,7 +42043,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_149",
+        "logos-module": "logos-module_147",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42672,12 +42085,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_94": {
+    "logos-plugin-qt_92": {
       "inputs": {
-        "logos-lidl": "logos-lidl_212",
-        "logos-module": "logos-module_150",
-        "logos-nix": "logos-nix_722",
-        "logos-protocol": "logos-protocol_123",
+        "logos-lidl": "logos-lidl_209",
+        "logos-module": "logos-module_148",
+        "logos-nix": "logos-nix_716",
+        "logos-protocol": "logos-protocol_119",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42701,10 +42114,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_95": {
+    "logos-plugin-qt_93": {
       "inputs": {
-        "logos-lidl": "logos-lidl_213",
-        "logos-module": "logos-module_151",
+        "logos-lidl": "logos-lidl_210",
+        "logos-module": "logos-module_149",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42738,10 +42151,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_96": {
+    "logos-plugin-qt_94": {
       "inputs": {
-        "logos-lidl": "logos-lidl_216",
-        "logos-module": "logos-module_152",
+        "logos-lidl": "logos-lidl_213",
+        "logos-module": "logos-module_150",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42775,12 +42188,14 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_97": {
+    "logos-plugin-qt_95": {
       "inputs": {
-        "logos-lidl": "logos-lidl_217",
-        "logos-module": "logos-module_153",
-        "logos-nix": "logos-nix_743",
-        "logos-protocol": "logos-protocol_128",
+        "logos-lidl": "logos-lidl_214",
+        "logos-module": "logos-module_151",
+        "logos-nix": "logos-nix_737",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-nix",
@@ -42788,78 +42203,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788377387,
-        "narHash": "sha256-C7qFhnU1glCE1hgrgKkZEjvJwUqcaAfvgY46gZBjuoA=",
+        "lastModified": 1788890168,
+        "narHash": "sha256-gx8vxNsAU591M11YA5NFbhmCgE6FVaFsVWVvC57/Rk4=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "6990e588c4ef127c7ed1810814fd0c2f6fad880b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_98": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_154",
-        "logos-nix": [
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788366702,
-        "narHash": "sha256-R/N68xBqxIPvkgv/X0ZVDzkMHUHJoe+YRHzJF/ZswUg=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "8625db8b8de12b2528248fe66858c91d2c9de444",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_99": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_220",
-        "logos-module": "logos-module_155",
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "1a0e399ef238ef3dbed367249f13a87029ca7fc1",
         "type": "github"
       },
       "original": {
@@ -42899,10 +42247,90 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_100": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_101": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -42924,90 +42352,39 @@
         "type": "github"
       }
     },
-    "logos-protocol_100": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788377511,
-        "narHash": "sha256-ausAm190Qj1ZtcZcMhxT10h+m/hGgFkHB6FB7SUWDyU=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "677c660692c8f9a9aace8596ee6abbeb86ff2fb8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_101": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_102": {
       "inputs": {
-        "logos-nix": "logos-nix_597",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
         "type": "github"
       },
       "original": {
@@ -43018,7 +42395,16 @@
     },
     "logos-protocol_103": {
       "inputs": {
-        "logos-nix": "logos-nix_608",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43026,17 +42412,16 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -43047,24 +42432,14 @@
     },
     "logos-protocol_104": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_633",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43091,6 +42466,123 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_106": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_107": {
+      "inputs": {
+        "logos-nix": "logos-nix_650",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_108": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -43098,6 +42590,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43121,10 +42617,14 @@
         "type": "github"
       }
     },
-    "logos-protocol_106": {
+    "logos-protocol_109": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43136,6 +42636,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -43154,111 +42658,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_107": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_108": {
-      "inputs": {
-        "logos-nix": "logos-nix_639",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_109": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -43274,7 +42673,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -43282,18 +42680,15 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -43312,7 +42707,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -43323,9 +42721,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -43345,179 +42744,7 @@
     },
     "logos-protocol_111": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_112": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_113": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_114": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_115": {
-      "inputs": {
-        "logos-nix": "logos-nix_686",
+        "logos-nix": "logos-nix_680",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43546,7 +42773,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_116": {
+    "logos-protocol_112": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43583,7 +42810,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_117": {
+    "logos-protocol_113": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43620,7 +42847,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_118": {
+    "logos-protocol_114": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43661,7 +42888,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_119": {
+    "logos-protocol_115": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43698,20 +42925,145 @@
         "type": "github"
       }
     },
-    "logos-protocol_12": {
+    "logos-protocol_116": {
       "inputs": {
         "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_117": {
+      "inputs": {
+        "logos-nix": "logos-nix_710",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_118": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_119": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_12": {
+      "inputs": {
+        "logos-nix": "logos-nix_76",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -43731,20 +43083,11 @@
     },
     "logos-protocol_120": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_717",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43766,127 +43109,6 @@
     },
     "logos-protocol_121": {
       "inputs": {
-        "logos-nix": "logos-nix_716",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_122": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_123": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_124": {
-      "inputs": {
-        "logos-nix": "logos-nix_723",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_125": {
-      "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43914,7 +43136,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_126": {
+    "logos-protocol_122": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43947,7 +43169,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_127": {
+    "logos-protocol_123": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43976,36 +43198,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_128": {
+    "logos-protocol_124": {
       "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788367777,
-        "narHash": "sha256-80DDvYUPLNSB914movtntx30Dy4lqf54ViSWTH6KhMo=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "3d132f4bc8f1d73078a41682dc68221ff5b516e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_129": {
-      "inputs": {
-        "logos-nix": "logos-nix_744",
+        "logos-nix": "logos-nix_738",
         "nixpkgs": [
           "logos-protocol",
           "logos-nix",
@@ -44013,11 +43208,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788405494,
-        "narHash": "sha256-FQ+qXZBt7akDKXOmim0ST+jEOPK6oGnD9UhqXuZYFVA=",
+        "lastModified": 1788891513,
+        "narHash": "sha256-C362bESdD153asRK+1T9bl/hu+Y2isvpCjv2iFzCY5c=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "cac0642a4f230818b9891e71d38a815bafe6c2b2",
+        "rev": "9ba2f5a7e254a68f05d7dbfb87272334bb96679d",
         "type": "github"
       },
       "original": {
@@ -44028,11 +43223,18 @@
     },
     "logos-protocol_13": {
       "inputs": {
-        "logos-nix": "logos-nix_77",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44044,87 +43246,6 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_130": {
-      "inputs": {
-        "logos-nix": [
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788367777,
-        "narHash": "sha256-80DDvYUPLNSB914movtntx30Dy4lqf54ViSWTH6KhMo=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "3d132f4bc8f1d73078a41682dc68221ff5b516e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_131": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_132": {
-      "inputs": {
-        "logos-nix": [
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788188235,
-        "narHash": "sha256-gI7JYUqaGR9jLk1s1Y3zZw+4ykailDxTTh3CBmwQY4U=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "2da8eab43c238064306ff08be1b75c060c603ce9",
         "type": "github"
       },
       "original": {
@@ -44139,25 +43260,27 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -44168,20 +43291,15 @@
     },
     "logos-protocol_15": {
       "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_93",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44203,7 +43321,17 @@
     },
     "logos-protocol_16": {
       "inputs": {
-        "logos-nix": "logos-nix_94",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -44212,8 +43340,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -44241,45 +43368,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_18": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
@@ -44313,7 +43401,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_19": {
+    "logos-protocol_18": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -44344,6 +43432,34 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_19": {
+      "inputs": {
+        "logos-nix": "logos-nix_123",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275122,
+        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
         "type": "github"
       },
       "original": {
@@ -44385,34 +43501,6 @@
     },
     "logos-protocol_20": {
       "inputs": {
-        "logos-nix": "logos-nix_124",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275122,
-        "narHash": "sha256-VfnbFZO7cF+pTuFlw+VIagB1JBbXYH+VjgDVF0f2UG4=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_21": {
-      "inputs": {
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -44442,7 +43530,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_22": {
+    "logos-protocol_21": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -44473,7 +43561,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_23": {
+    "logos-protocol_22": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -44508,7 +43596,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_24": {
+    "logos-protocol_23": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -44539,91 +43627,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_25": {
+    "logos-protocol_24": {
       "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_26": {
-      "inputs": {
-        "logos-nix": "logos-nix_149",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788188235,
-        "narHash": "sha256-gI7JYUqaGR9jLk1s1Y3zZw+4ykailDxTTh3CBmwQY4U=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "2da8eab43c238064306ff08be1b75c060c603ce9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_27": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_28": {
-      "inputs": {
-        "logos-nix": "logos-nix_159",
+        "logos-nix": "logos-nix_153",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-protocol",
@@ -44645,9 +43651,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_29": {
+    "logos-protocol_25": {
       "inputs": {
-        "logos-nix": "logos-nix_170",
+        "logos-nix": "logos-nix_164",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -44662,6 +43668,136 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_26": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_27": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_28": {
+      "inputs": {
+        "logos-nix": "logos-nix_181",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_29": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -44704,136 +43840,6 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_31": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_32": {
-      "inputs": {
-        "logos-nix": "logos-nix_187",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_33": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_34": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -44870,7 +43876,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_35": {
+    "logos-protocol_31": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -44907,9 +43913,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_36": {
+    "logos-protocol_32": {
       "inputs": {
-        "logos-nix": "logos-nix_217",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -44934,7 +43940,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_37": {
+    "logos-protocol_33": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -44963,7 +43969,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_38": {
+    "logos-protocol_34": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -44992,7 +43998,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_39": {
+    "logos-protocol_35": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -45017,6 +44023,124 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_36": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_37": {
+      "inputs": {
+        "logos-nix": "logos-nix_243",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_38": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_39": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
         "type": "github"
       },
       "original": {
@@ -45060,125 +44184,7 @@
     },
     "logos-protocol_40": {
       "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_41": {
-      "inputs": {
-        "logos-nix": "logos-nix_249",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_42": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_43": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_44": {
-      "inputs": {
-        "logos-nix": "logos-nix_259",
+        "logos-nix": "logos-nix_253",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45204,9 +44210,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_45": {
+    "logos-protocol_41": {
       "inputs": {
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_264",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45233,7 +44239,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_46": {
+    "logos-protocol_42": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45272,7 +44278,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_47": {
+    "logos-protocol_43": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45309,7 +44315,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_48": {
+    "logos-protocol_44": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45350,7 +44356,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_49": {
+    "logos-protocol_45": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45379,6 +44385,148 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_295",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_47": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_48": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_312",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -45418,7 +44566,20 @@
     },
     "logos-protocol_50": {
       "inputs": {
-        "logos-nix": "logos-nix_301",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45426,17 +44587,20 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -45446,164 +44610,6 @@
       }
     },
     "logos-protocol_51": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_52": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_53": {
-      "inputs": {
-        "logos-nix": "logos-nix_318",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_54": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_55": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45652,7 +44658,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_56": {
+    "logos-protocol_52": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45697,9 +44703,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_57": {
+    "logos-protocol_53": {
       "inputs": {
-        "logos-nix": "logos-nix_348",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45728,7 +44734,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_58": {
+    "logos-protocol_54": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45765,7 +44771,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_59": {
+    "logos-protocol_55": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45802,34 +44808,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_6": {
-      "inputs": {
-        "logos-nix": [
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788359020,
-        "narHash": "sha256-HIWeEJN9ezl6cRIOS3i8rt0yLTDYb6fR9lSKkrE2nGM=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "47d287cddc6c827057fdbf35aa30793e212560af",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_60": {
+    "logos-protocol_56": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45870,7 +44849,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_61": {
+    "logos-protocol_57": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45907,7 +44886,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_62": {
+    "logos-protocol_58": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45923,6 +44902,152 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_59": {
+      "inputs": {
+        "logos-nix": "logos-nix_372",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_6": {
+      "inputs": {
+        "logos-nix": "logos-nix_35",
+        "nixpkgs": [
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788891513,
+        "narHash": "sha256-C362bESdD153asRK+1T9bl/hu+Y2isvpCjv2iFzCY5c=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "9ba2f5a7e254a68f05d7dbfb87272334bb96679d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_60": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_61": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_62": {
+      "inputs": {
+        "logos-nix": "logos-nix_379",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -45943,127 +45068,6 @@
       }
     },
     "logos-protocol_63": {
-      "inputs": {
-        "logos-nix": "logos-nix_378",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_64": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_65": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_66": {
-      "inputs": {
-        "logos-nix": "logos-nix_385",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_67": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -46092,7 +45096,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_68": {
+    "logos-protocol_64": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -46125,7 +45129,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_69": {
+    "logos-protocol_65": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -46154,10 +45158,102 @@
         "type": "github"
       }
     },
-    "logos-protocol_7": {
+    "logos-protocol_66": {
       "inputs": {
-        "logos-nix": "logos-nix_35",
+        "logos-nix": "logos-nix_415",
         "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_67": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_68": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_425",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-protocol",
@@ -46179,11 +45275,41 @@
         "type": "github"
       }
     },
+    "logos-protocol_7": {
+      "inputs": {
+        "logos-nix": "logos-nix_46",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_70": {
       "inputs": {
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -46209,11 +45335,19 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
           "logos-protocol",
@@ -46241,25 +45375,29 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -46270,15 +45408,65 @@
     },
     "logos-protocol_73": {
       "inputs": {
-        "logos-nix": "logos-nix_431",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_74": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -46296,55 +45484,16 @@
         "type": "github"
       }
     },
-    "logos-protocol_74": {
-      "inputs": {
-        "logos-nix": "logos-nix_442",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_75": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_467",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -46371,6 +45520,123 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_77": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_484",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_79": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -46378,6 +45644,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -46401,10 +45671,47 @@
         "type": "github"
       }
     },
-    "logos-protocol_77": {
+    "logos-protocol_8": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_80": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -46416,6 +45723,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -46442,137 +45753,6 @@
         "type": "github"
       }
     },
-    "logos-protocol_78": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_79": {
-      "inputs": {
-        "logos-nix": "logos-nix_473",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_8": {
-      "inputs": {
-        "logos-nix": "logos-nix_46",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_80": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_81": {
       "inputs": {
         "logos-nix": [
@@ -46583,7 +45763,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -46594,9 +45777,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -46616,179 +45800,7 @@
     },
     "logos-protocol_82": {
       "inputs": {
-        "logos-nix": "logos-nix_490",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_83": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_84": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_85": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_520",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46817,7 +45829,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_87": {
+    "logos-protocol_83": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46854,7 +45866,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_88": {
+    "logos-protocol_84": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46891,7 +45903,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_89": {
+    "logos-protocol_85": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46932,40 +45944,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_9": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_90": {
+    "logos-protocol_86": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -47002,7 +45981,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_91": {
+    "logos-protocol_87": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -47018,6 +45997,158 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_88": {
+      "inputs": {
+        "logos-nix": "logos-nix_544",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_89": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_9": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_90": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_91": {
+      "inputs": {
+        "logos-nix": "logos-nix_551",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -47038,127 +46169,6 @@
       }
     },
     "logos-protocol_92": {
-      "inputs": {
-        "logos-nix": "logos-nix_550",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_93": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_94": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_95": {
-      "inputs": {
-        "logos-nix": "logos-nix_557",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_96": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -47187,7 +46197,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_97": {
+    "logos-protocol_93": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -47220,7 +46230,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_98": {
+    "logos-protocol_94": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -47249,9 +46259,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_99": {
+    "logos-protocol_95": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
+        "logos-nix": "logos-nix_582",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -47274,9 +46284,130 @@
         "type": "github"
       }
     },
+    "logos-protocol_96": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788377511,
+        "narHash": "sha256-ausAm190Qj1ZtcZcMhxT10h+m/hGgFkHB6FB7SUWDyU=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "677c660692c8f9a9aace8596ee6abbeb86ff2fb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_97": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_591",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_602",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-qt-mcp": {
       "inputs": {
-        "logos-nix": "logos-nix_129",
+        "logos-nix": "logos-nix_128",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -47303,7 +46434,7 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_216",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47329,7 +46460,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
+        "logos-nix": "logos-nix_347",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47359,7 +46490,7 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47385,7 +46516,7 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47415,7 +46546,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47441,7 +46572,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_685",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -47471,7 +46602,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_718",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -47497,7 +46628,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_745",
+        "logos-nix": "logos-nix_739",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -47568,7 +46699,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_43",
+        "logos-lidl": "logos-lidl_42",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -47614,41 +46745,13 @@
     },
     "logos-qt-sdk_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_14",
-        "logos-lidl": "logos-lidl_47",
-        "logos-nix": "logos-nix_150",
-        "logos-plugin-qt": "logos-plugin-qt_20",
-        "logos-protocol": "logos-protocol_27",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_12": {
-      "inputs": {
         "logos-cpp-sdk": [
           "logos-module-loader-qt",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_49",
-        "logos-nix": "logos-nix_160",
-        "logos-plugin-qt": "logos-plugin-qt_21",
+        "logos-lidl": "logos-lidl_46",
+        "logos-nix": "logos-nix_154",
+        "logos-plugin-qt": "logos-plugin-qt_19",
         "logos-protocol": [
           "logos-module-loader-qt",
           "logos-protocol"
@@ -47674,16 +46777,16 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_13": {
+    "logos-qt-sdk_12": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_53",
-        "logos-nix": "logos-nix_171",
-        "logos-plugin-qt": "logos-plugin-qt_23",
+        "logos-lidl": "logos-lidl_50",
+        "logos-nix": "logos-nix_165",
+        "logos-plugin-qt": "logos-plugin-qt_21",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47711,7 +46814,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_14": {
+    "logos-qt-sdk_13": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -47722,9 +46825,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_59",
-        "logos-nix": "logos-nix_188",
-        "logos-plugin-qt": "logos-plugin-qt_25",
+        "logos-lidl": "logos-lidl_56",
+        "logos-nix": "logos-nix_182",
+        "logos-plugin-qt": "logos-plugin-qt_23",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47760,7 +46863,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_15": {
+    "logos-qt-sdk_14": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -47772,7 +46875,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_62",
+        "logos-lidl": "logos-lidl_59",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47828,7 +46931,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_16": {
+    "logos-qt-sdk_15": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -47837,8 +46940,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_67",
-        "logos-nix": "logos-nix_218",
+        "logos-lidl": "logos-lidl_64",
+        "logos-nix": "logos-nix_212",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47870,7 +46973,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_17": {
+    "logos-qt-sdk_16": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -47878,7 +46981,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_70",
+        "logos-lidl": "logos-lidl_67",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47918,16 +47021,16 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_18": {
+    "logos-qt-sdk_17": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_76",
-        "logos-nix": "logos-nix_250",
-        "logos-plugin-qt": "logos-plugin-qt_33",
+        "logos-lidl": "logos-lidl_73",
+        "logos-nix": "logos-nix_244",
+        "logos-plugin-qt": "logos-plugin-qt_31",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47955,7 +47058,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_19": {
+    "logos-qt-sdk_18": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47965,9 +47068,9 @@
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_80",
-        "logos-nix": "logos-nix_260",
-        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-lidl": "logos-lidl_77",
+        "logos-nix": "logos-nix_254",
+        "logos-plugin-qt": "logos-plugin-qt_32",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47993,6 +47096,55 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_19": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_81",
+        "logos-nix": "logos-nix_265",
+        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -48058,59 +47210,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_84",
-        "logos-nix": "logos-nix_271",
-        "logos-plugin-qt": "logos-plugin-qt_36",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_21": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_87",
+        "logos-lidl": "logos-lidl_84",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48166,7 +47269,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_22": {
+    "logos-qt-sdk_21": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48177,9 +47280,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_94",
-        "logos-nix": "logos-nix_302",
-        "logos-plugin-qt": "logos-plugin-qt_40",
+        "logos-lidl": "logos-lidl_91",
+        "logos-nix": "logos-nix_296",
+        "logos-plugin-qt": "logos-plugin-qt_38",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48215,7 +47318,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_23": {
+    "logos-qt-sdk_22": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48230,9 +47333,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_100",
-        "logos-nix": "logos-nix_319",
-        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-lidl": "logos-lidl_97",
+        "logos-nix": "logos-nix_313",
+        "logos-plugin-qt": "logos-plugin-qt_40",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48276,7 +47379,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_24": {
+    "logos-qt-sdk_23": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48292,7 +47395,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_103",
+        "logos-lidl": "logos-lidl_100",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48364,7 +47467,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_25": {
+    "logos-qt-sdk_24": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48377,8 +47480,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_108",
-        "logos-nix": "logos-nix_349",
+        "logos-lidl": "logos-lidl_105",
+        "logos-nix": "logos-nix_343",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48418,7 +47521,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_26": {
+    "logos-qt-sdk_25": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48430,7 +47533,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_111",
+        "logos-lidl": "logos-lidl_108",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48486,13 +47589,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_27": {
+    "logos-qt-sdk_26": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
-        "logos-lidl": "logos-lidl_115",
-        "logos-nix": "logos-nix_379",
-        "logos-plugin-qt": "logos-plugin-qt_50",
-        "logos-protocol": "logos-protocol_64",
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
+        "logos-lidl": "logos-lidl_112",
+        "logos-nix": "logos-nix_373",
+        "logos-plugin-qt": "logos-plugin-qt_48",
+        "logos-protocol": "logos-protocol_60",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48517,7 +47620,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_28": {
+    "logos-qt-sdk_27": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -48525,7 +47628,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_118",
+        "logos-lidl": "logos-lidl_115",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -48557,6 +47660,43 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_28": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_121",
+        "logos-nix": "logos-nix_416",
+        "logos-plugin-qt": "logos-plugin-qt_53",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -48570,30 +47710,39 @@
         "logos-cpp-sdk": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_124",
-        "logos-nix": "logos-nix_422",
-        "logos-plugin-qt": "logos-plugin-qt_55",
+        "logos-lidl": "logos-lidl_125",
+        "logos-nix": "logos-nix_426",
+        "logos-plugin-qt": "logos-plugin-qt_54",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "lastModified": 1787668712,
+        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
         "type": "github"
       },
       "original": {
@@ -48626,11 +47775,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
+        "lastModified": 1788891524,
+        "narHash": "sha256-qIf/0a0lVYgiRK/QqsjhOgC9viEOy10UHdSj3PDnKeI=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
+        "rev": "012d090568a8452972cc3b7e007cb3ecd03b7000",
         "type": "github"
       },
       "original": {
@@ -48646,59 +47795,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_128",
-        "logos-nix": "logos-nix_432",
-        "logos-plugin-qt": "logos-plugin-qt_56",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_31": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_132",
-        "logos-nix": "logos-nix_443",
-        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-lidl": "logos-lidl_129",
+        "logos-nix": "logos-nix_437",
+        "logos-plugin-qt": "logos-plugin-qt_56",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48734,7 +47837,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_32": {
+    "logos-qt-sdk_31": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48746,7 +47849,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_135",
+        "logos-lidl": "logos-lidl_132",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48802,7 +47905,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_33": {
+    "logos-qt-sdk_32": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48813,9 +47916,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_142",
-        "logos-nix": "logos-nix_474",
-        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-lidl": "logos-lidl_139",
+        "logos-nix": "logos-nix_468",
+        "logos-plugin-qt": "logos-plugin-qt_60",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48851,7 +47954,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_34": {
+    "logos-qt-sdk_33": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48866,9 +47969,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_148",
-        "logos-nix": "logos-nix_491",
-        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-lidl": "logos-lidl_145",
+        "logos-nix": "logos-nix_485",
+        "logos-plugin-qt": "logos-plugin-qt_62",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48912,7 +48015,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_35": {
+    "logos-qt-sdk_34": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48928,7 +48031,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_151",
+        "logos-lidl": "logos-lidl_148",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49000,7 +48103,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_36": {
+    "logos-qt-sdk_35": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -49013,8 +48116,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_156",
-        "logos-nix": "logos-nix_521",
+        "logos-lidl": "logos-lidl_153",
+        "logos-nix": "logos-nix_515",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49054,7 +48157,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_37": {
+    "logos-qt-sdk_36": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -49066,7 +48169,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_159",
+        "logos-lidl": "logos-lidl_156",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49122,13 +48225,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_38": {
+    "logos-qt-sdk_37": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_48",
-        "logos-lidl": "logos-lidl_163",
-        "logos-nix": "logos-nix_551",
-        "logos-plugin-qt": "logos-plugin-qt_72",
-        "logos-protocol": "logos-protocol_93",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-lidl": "logos-lidl_160",
+        "logos-nix": "logos-nix_545",
+        "logos-plugin-qt": "logos-plugin-qt_70",
+        "logos-protocol": "logos-protocol_89",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49153,7 +48256,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_39": {
+    "logos-qt-sdk_38": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -49161,7 +48264,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_166",
+        "logos-lidl": "logos-lidl_163",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49193,6 +48296,47 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_39": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_169",
+        "logos-nix": "logos-nix_583",
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -49246,55 +48390,14 @@
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_172",
-        "logos-nix": "logos-nix_589",
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_41": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_176",
-        "logos-nix": "logos-nix_598",
-        "logos-plugin-qt": "logos-plugin-qt_77",
+        "logos-lidl": "logos-lidl_173",
+        "logos-nix": "logos-nix_592",
+        "logos-plugin-qt": "logos-plugin-qt_75",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49328,7 +48431,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_42": {
+    "logos-qt-sdk_41": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49339,9 +48442,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_180",
-        "logos-nix": "logos-nix_609",
-        "logos-plugin-qt": "logos-plugin-qt_79",
+        "logos-lidl": "logos-lidl_177",
+        "logos-nix": "logos-nix_603",
+        "logos-plugin-qt": "logos-plugin-qt_77",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49377,7 +48480,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_43": {
+    "logos-qt-sdk_42": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49389,7 +48492,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_183",
+        "logos-lidl": "logos-lidl_180",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49445,7 +48548,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_44": {
+    "logos-qt-sdk_43": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49456,9 +48559,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_190",
-        "logos-nix": "logos-nix_640",
-        "logos-plugin-qt": "logos-plugin-qt_83",
+        "logos-lidl": "logos-lidl_187",
+        "logos-nix": "logos-nix_634",
+        "logos-plugin-qt": "logos-plugin-qt_81",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49494,7 +48597,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_45": {
+    "logos-qt-sdk_44": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49509,9 +48612,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_196",
-        "logos-nix": "logos-nix_657",
-        "logos-plugin-qt": "logos-plugin-qt_85",
+        "logos-lidl": "logos-lidl_193",
+        "logos-nix": "logos-nix_651",
+        "logos-plugin-qt": "logos-plugin-qt_83",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49555,7 +48658,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_46": {
+    "logos-qt-sdk_45": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49571,7 +48674,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_199",
+        "logos-lidl": "logos-lidl_196",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49643,7 +48746,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_47": {
+    "logos-qt-sdk_46": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49656,8 +48759,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_204",
-        "logos-nix": "logos-nix_687",
+        "logos-lidl": "logos-lidl_201",
+        "logos-nix": "logos-nix_681",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49697,7 +48800,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_48": {
+    "logos-qt-sdk_47": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -49709,7 +48812,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_207",
+        "logos-lidl": "logos-lidl_204",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49765,13 +48868,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_49": {
+    "logos-qt-sdk_48": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_62",
-        "logos-lidl": "logos-lidl_211",
-        "logos-nix": "logos-nix_717",
-        "logos-plugin-qt": "logos-plugin-qt_93",
-        "logos-protocol": "logos-protocol_122",
+        "logos-cpp-sdk": "logos-cpp-sdk_60",
+        "logos-lidl": "logos-lidl_208",
+        "logos-nix": "logos-nix_711",
+        "logos-plugin-qt": "logos-plugin-qt_91",
+        "logos-protocol": "logos-protocol_118",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49788,6 +48891,54 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_49": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_211",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -49852,58 +49003,16 @@
     "logos-qt-sdk_50": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_214",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_215",
+        "logos-nix": "logos-nix_740",
         "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-plugin-qt"
         ],
         "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-protocol"
         ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_51": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_64",
-        "logos-lidl": "logos-lidl_218",
-        "logos-nix": "logos-nix_746",
-        "logos-plugin-qt": "logos-plugin-qt_98",
-        "logos-protocol": "logos-protocol_130",
         "nixpkgs": [
           "logos-qt-sdk",
           "logos-nix",
@@ -49932,8 +49041,8 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_26",
-        "logos-nix": "logos-nix_78",
+        "logos-lidl": "logos-lidl_25",
+        "logos-nix": "logos-nix_77",
         "logos-plugin-qt": "logos-plugin-qt_10",
         "logos-protocol": [
           "logos-liblogos",
@@ -49976,8 +49085,8 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_32",
-        "logos-nix": "logos-nix_95",
+        "logos-lidl": "logos-lidl_31",
+        "logos-nix": "logos-nix_94",
         "logos-plugin-qt": "logos-plugin-qt_12",
         "logos-protocol": [
           "logos-liblogos",
@@ -50029,7 +49138,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_35",
+        "logos-lidl": "logos-lidl_34",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50099,8 +49208,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_40",
-        "logos-nix": "logos-nix_125",
+        "logos-lidl": "logos-lidl_39",
+        "logos-nix": "logos-nix_124",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50177,7 +49286,7 @@
     },
     "logos-rust-sdk_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_101",
+        "logos-lidl": "logos-lidl_98",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50249,7 +49358,7 @@
     },
     "logos-rust-sdk_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_125",
+        "logos-lidl": "logos-lidl_122",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50265,7 +49374,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_71",
+        "logos-protocol": "logos-protocol_67",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50290,7 +49399,7 @@
     },
     "logos-rust-sdk_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_133",
+        "logos-lidl": "logos-lidl_130",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50318,7 +49427,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_75",
+        "logos-protocol": "logos-protocol_71",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50347,7 +49456,7 @@
     },
     "logos-rust-sdk_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_143",
+        "logos-lidl": "logos-lidl_140",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50375,7 +49484,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_80",
+        "logos-protocol": "logos-protocol_76",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50404,7 +49513,7 @@
     },
     "logos-rust-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_149",
+        "logos-lidl": "logos-lidl_146",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50476,7 +49585,7 @@
     },
     "logos-rust-sdk_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_173",
+        "logos-lidl": "logos-lidl_170",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50492,7 +49601,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_100",
+        "logos-protocol": "logos-protocol_96",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50517,7 +49626,7 @@
     },
     "logos-rust-sdk_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_181",
+        "logos-lidl": "logos-lidl_178",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50545,7 +49654,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_104",
+        "logos-protocol": "logos-protocol_100",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50574,7 +49683,7 @@
     },
     "logos-rust-sdk_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_191",
+        "logos-lidl": "logos-lidl_188",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50602,7 +49711,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_109",
+        "logos-protocol": "logos-protocol_105",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50631,7 +49740,7 @@
     },
     "logos-rust-sdk_18": {
       "inputs": {
-        "logos-lidl": "logos-lidl_197",
+        "logos-lidl": "logos-lidl_194",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50722,7 +49831,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_9",
+        "logos-protocol": "logos-protocol_8",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -50748,7 +49857,7 @@
     },
     "logos-rust-sdk_3": {
       "inputs": {
-        "logos-lidl": "logos-lidl_27",
+        "logos-lidl": "logos-lidl_26",
         "logos-logoscore-cli": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50767,7 +49876,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_14",
+        "logos-protocol": "logos-protocol_13",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50793,7 +49902,7 @@
     },
     "logos-rust-sdk_4": {
       "inputs": {
-        "logos-lidl": "logos-lidl_33",
+        "logos-lidl": "logos-lidl_32",
         "logos-logoscore-cli": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50853,7 +49962,7 @@
     },
     "logos-rust-sdk_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_54",
+        "logos-lidl": "logos-lidl_51",
         "logos-logoscore-cli": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -50869,7 +49978,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_30",
+        "logos-protocol": "logos-protocol_26",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -50894,7 +50003,7 @@
     },
     "logos-rust-sdk_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_60",
+        "logos-lidl": "logos-lidl_57",
         "logos-logoscore-cli": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -50950,7 +50059,7 @@
     },
     "logos-rust-sdk_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_77",
+        "logos-lidl": "logos-lidl_74",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50966,7 +50075,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_42",
+        "logos-protocol": "logos-protocol_38",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50991,7 +50100,7 @@
     },
     "logos-rust-sdk_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_85",
+        "logos-lidl": "logos-lidl_82",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51019,7 +50128,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_46",
+        "logos-protocol": "logos-protocol_42",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51048,7 +50157,7 @@
     },
     "logos-rust-sdk_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_95",
+        "logos-lidl": "logos-lidl_92",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51076,7 +50185,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_51",
+        "logos-protocol": "logos-protocol_47",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51105,7 +50214,7 @@
     },
     "logos-standalone-app": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_9",
+        "logos-cpp-sdk": "logos-cpp-sdk_8",
         "logos-design-system": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51113,9 +50222,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_126",
         "logos-plugin-qt": "logos-plugin-qt_16",
-        "logos-protocol": "logos-protocol_21",
+        "logos-protocol": "logos-protocol_20",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
           "logos-liblogos",
@@ -51148,16 +50257,16 @@
     },
     "logos-standalone-app_2": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_17",
+        "logos-cpp-sdk": "logos-cpp-sdk_15",
         "logos-design-system": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_3",
-        "logos-nix": "logos-nix_220",
-        "logos-plugin-qt": "logos-plugin-qt_29",
-        "logos-protocol": "logos-protocol_37",
+        "logos-nix": "logos-nix_214",
+        "logos-plugin-qt": "logos-plugin-qt_27",
+        "logos-protocol": "logos-protocol_33",
         "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": [
           "logos-modules-state-module",
@@ -51188,16 +50297,16 @@
     },
     "logos-standalone-app_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
-        "logos-nix": "logos-nix_382",
-        "logos-plugin-qt": "logos-plugin-qt_51",
-        "logos-protocol": "logos-protocol_66",
+        "logos-nix": "logos-nix_376",
+        "logos-plugin-qt": "logos-plugin-qt_49",
+        "logos-protocol": "logos-protocol_62",
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -51228,7 +50337,7 @@
     },
     "logos-standalone-app_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51239,9 +50348,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_351",
-        "logos-plugin-qt": "logos-plugin-qt_46",
-        "logos-protocol": "logos-protocol_58",
+        "logos-nix": "logos-nix_345",
+        "logos-plugin-qt": "logos-plugin-qt_44",
+        "logos-protocol": "logos-protocol_54",
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -51280,16 +50389,16 @@
     },
     "logos-standalone-app_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_554",
-        "logos-plugin-qt": "logos-plugin-qt_73",
-        "logos-protocol": "logos-protocol_95",
+        "logos-nix": "logos-nix_548",
+        "logos-plugin-qt": "logos-plugin-qt_71",
+        "logos-protocol": "logos-protocol_91",
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -51320,7 +50429,7 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51331,9 +50440,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_7",
-        "logos-nix": "logos-nix_523",
-        "logos-plugin-qt": "logos-plugin-qt_68",
-        "logos-protocol": "logos-protocol_87",
+        "logos-nix": "logos-nix_517",
+        "logos-plugin-qt": "logos-plugin-qt_66",
+        "logos-protocol": "logos-protocol_83",
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -51372,16 +50481,16 @@
     },
     "logos-standalone-app_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_51",
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_720",
-        "logos-plugin-qt": "logos-plugin-qt_94",
-        "logos-protocol": "logos-protocol_124",
+        "logos-nix": "logos-nix_714",
+        "logos-plugin-qt": "logos-plugin-qt_92",
+        "logos-protocol": "logos-protocol_120",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -51412,7 +50521,7 @@
     },
     "logos-standalone-app_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_57",
+        "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51423,9 +50532,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_9",
-        "logos-nix": "logos-nix_689",
-        "logos-plugin-qt": "logos-plugin-qt_89",
-        "logos-protocol": "logos-protocol_116",
+        "logos-nix": "logos-nix_683",
+        "logos-plugin-qt": "logos-plugin-qt_87",
+        "logos-protocol": "logos-protocol_112",
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -51502,10 +50611,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_387",
-        "logos-plugin-qt": "logos-plugin-qt_52",
-        "logos-protocol": "logos-protocol_67",
-        "logos-qt-sdk": "logos-qt-sdk_28",
+        "logos-nix": "logos-nix_381",
+        "logos-plugin-qt": "logos-plugin-qt_50",
+        "logos-protocol": "logos-protocol_63",
+        "logos-qt-sdk": "logos-qt-sdk_27",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51539,10 +50648,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_445",
-        "logos-plugin-qt": "logos-plugin-qt_59",
-        "logos-protocol": "logos-protocol_76",
-        "logos-qt-sdk": "logos-qt-sdk_32",
+        "logos-nix": "logos-nix_439",
+        "logos-plugin-qt": "logos-plugin-qt_57",
+        "logos-protocol": "logos-protocol_72",
+        "logos-qt-sdk": "logos-qt-sdk_31",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51584,10 +50693,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_493",
-        "logos-plugin-qt": "logos-plugin-qt_65",
-        "logos-protocol": "logos-protocol_83",
-        "logos-qt-sdk": "logos-qt-sdk_35",
+        "logos-nix": "logos-nix_487",
+        "logos-plugin-qt": "logos-plugin-qt_63",
+        "logos-protocol": "logos-protocol_79",
+        "logos-qt-sdk": "logos-qt-sdk_34",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51629,10 +50738,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_526",
-        "logos-plugin-qt": "logos-plugin-qt_69",
-        "logos-protocol": "logos-protocol_88",
-        "logos-qt-sdk": "logos-qt-sdk_37",
+        "logos-nix": "logos-nix_520",
+        "logos-plugin-qt": "logos-plugin-qt_67",
+        "logos-protocol": "logos-protocol_84",
+        "logos-qt-sdk": "logos-qt-sdk_36",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51666,10 +50775,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_559",
-        "logos-plugin-qt": "logos-plugin-qt_74",
-        "logos-protocol": "logos-protocol_96",
-        "logos-qt-sdk": "logos-qt-sdk_39",
+        "logos-nix": "logos-nix_553",
+        "logos-plugin-qt": "logos-plugin-qt_72",
+        "logos-protocol": "logos-protocol_92",
+        "logos-qt-sdk": "logos-qt-sdk_38",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51703,10 +50812,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_611",
-        "logos-plugin-qt": "logos-plugin-qt_80",
-        "logos-protocol": "logos-protocol_105",
-        "logos-qt-sdk": "logos-qt-sdk_43",
+        "logos-nix": "logos-nix_605",
+        "logos-plugin-qt": "logos-plugin-qt_78",
+        "logos-protocol": "logos-protocol_101",
+        "logos-qt-sdk": "logos-qt-sdk_42",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51748,10 +50857,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_659",
-        "logos-plugin-qt": "logos-plugin-qt_86",
-        "logos-protocol": "logos-protocol_112",
-        "logos-qt-sdk": "logos-qt-sdk_46",
+        "logos-nix": "logos-nix_653",
+        "logos-plugin-qt": "logos-plugin-qt_84",
+        "logos-protocol": "logos-protocol_108",
+        "logos-qt-sdk": "logos-qt-sdk_45",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51793,10 +50902,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_692",
-        "logos-plugin-qt": "logos-plugin-qt_90",
-        "logos-protocol": "logos-protocol_117",
-        "logos-qt-sdk": "logos-qt-sdk_48",
+        "logos-nix": "logos-nix_686",
+        "logos-plugin-qt": "logos-plugin-qt_88",
+        "logos-protocol": "logos-protocol_113",
+        "logos-qt-sdk": "logos-qt-sdk_47",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51830,10 +50939,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_725",
-        "logos-plugin-qt": "logos-plugin-qt_95",
-        "logos-protocol": "logos-protocol_125",
-        "logos-qt-sdk": "logos-qt-sdk_50",
+        "logos-nix": "logos-nix_719",
+        "logos-plugin-qt": "logos-plugin-qt_93",
+        "logos-protocol": "logos-protocol_121",
+        "logos-qt-sdk": "logos-qt-sdk_49",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51866,7 +50975,7 @@
         ],
         "logos-nix": "logos-nix_49",
         "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_10",
+        "logos-protocol": "logos-protocol_9",
         "logos-qt-sdk": "logos-qt-sdk_5",
         "nixpkgs": [
           "logos-liblogos",
@@ -51903,9 +51012,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_97",
+        "logos-nix": "logos-nix_96",
         "logos-plugin-qt": "logos-plugin-qt_13",
-        "logos-protocol": "logos-protocol_17",
+        "logos-protocol": "logos-protocol_16",
         "logos-qt-sdk": "logos-qt-sdk_8",
         "nixpkgs": [
           "logos-liblogos",
@@ -51942,9 +51051,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_129",
         "logos-plugin-qt": "logos-plugin-qt_17",
-        "logos-protocol": "logos-protocol_22",
+        "logos-protocol": "logos-protocol_21",
         "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
           "logos-liblogos",
@@ -51980,10 +51089,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_190",
-        "logos-plugin-qt": "logos-plugin-qt_26",
-        "logos-protocol": "logos-protocol_33",
-        "logos-qt-sdk": "logos-qt-sdk_15",
+        "logos-nix": "logos-nix_184",
+        "logos-plugin-qt": "logos-plugin-qt_24",
+        "logos-protocol": "logos-protocol_29",
+        "logos-qt-sdk": "logos-qt-sdk_14",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -52017,10 +51126,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_223",
-        "logos-plugin-qt": "logos-plugin-qt_30",
-        "logos-protocol": "logos-protocol_38",
-        "logos-qt-sdk": "logos-qt-sdk_17",
+        "logos-nix": "logos-nix_217",
+        "logos-plugin-qt": "logos-plugin-qt_28",
+        "logos-protocol": "logos-protocol_34",
+        "logos-qt-sdk": "logos-qt-sdk_16",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -52054,10 +51163,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_273",
-        "logos-plugin-qt": "logos-plugin-qt_37",
-        "logos-protocol": "logos-protocol_47",
-        "logos-qt-sdk": "logos-qt-sdk_21",
+        "logos-nix": "logos-nix_267",
+        "logos-plugin-qt": "logos-plugin-qt_35",
+        "logos-protocol": "logos-protocol_43",
+        "logos-qt-sdk": "logos-qt-sdk_20",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52099,10 +51208,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_321",
-        "logos-plugin-qt": "logos-plugin-qt_43",
-        "logos-protocol": "logos-protocol_54",
-        "logos-qt-sdk": "logos-qt-sdk_24",
+        "logos-nix": "logos-nix_315",
+        "logos-plugin-qt": "logos-plugin-qt_41",
+        "logos-protocol": "logos-protocol_50",
+        "logos-qt-sdk": "logos-qt-sdk_23",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52144,10 +51253,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_354",
-        "logos-plugin-qt": "logos-plugin-qt_47",
-        "logos-protocol": "logos-protocol_59",
-        "logos-qt-sdk": "logos-qt-sdk_26",
+        "logos-nix": "logos-nix_348",
+        "logos-plugin-qt": "logos-plugin-qt_45",
+        "logos-protocol": "logos-protocol_55",
+        "logos-qt-sdk": "logos-qt-sdk_25",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52233,10 +51342,10 @@
     },
     "logos-view-module-runtime_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
-        "logos-nix": "logos-nix_389",
-        "logos-plugin-qt": "logos-plugin-qt_53",
-        "logos-protocol": "logos-protocol_69",
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
+        "logos-nix": "logos-nix_383",
+        "logos-plugin-qt": "logos-plugin-qt_51",
+        "logos-protocol": "logos-protocol_65",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52261,10 +51370,10 @@
     },
     "logos-view-module-runtime_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
-        "logos-nix": "logos-nix_447",
-        "logos-plugin-qt": "logos-plugin-qt_60",
-        "logos-protocol": "logos-protocol_78",
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
+        "logos-nix": "logos-nix_441",
+        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-protocol": "logos-protocol_74",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -52293,10 +51402,10 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
-        "logos-nix": "logos-nix_495",
-        "logos-plugin-qt": "logos-plugin-qt_66",
-        "logos-protocol": "logos-protocol_85",
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-nix": "logos-nix_489",
+        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-protocol": "logos-protocol_81",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -52329,10 +51438,10 @@
     },
     "logos-view-module-runtime_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-nix": "logos-nix_528",
-        "logos-plugin-qt": "logos-plugin-qt_70",
-        "logos-protocol": "logos-protocol_90",
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-nix": "logos-nix_522",
+        "logos-plugin-qt": "logos-plugin-qt_68",
+        "logos-protocol": "logos-protocol_86",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -52361,10 +51470,10 @@
     },
     "logos-view-module-runtime_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_49",
-        "logos-nix": "logos-nix_561",
-        "logos-plugin-qt": "logos-plugin-qt_75",
-        "logos-protocol": "logos-protocol_98",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-nix": "logos-nix_555",
+        "logos-plugin-qt": "logos-plugin-qt_73",
+        "logos-protocol": "logos-protocol_94",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -52389,10 +51498,10 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_54",
-        "logos-nix": "logos-nix_613",
-        "logos-plugin-qt": "logos-plugin-qt_81",
-        "logos-protocol": "logos-protocol_107",
+        "logos-cpp-sdk": "logos-cpp-sdk_52",
+        "logos-nix": "logos-nix_607",
+        "logos-plugin-qt": "logos-plugin-qt_79",
+        "logos-protocol": "logos-protocol_103",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -52421,10 +51530,10 @@
     },
     "logos-view-module-runtime_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_59",
-        "logos-nix": "logos-nix_661",
-        "logos-plugin-qt": "logos-plugin-qt_87",
-        "logos-protocol": "logos-protocol_114",
+        "logos-cpp-sdk": "logos-cpp-sdk_57",
+        "logos-nix": "logos-nix_655",
+        "logos-plugin-qt": "logos-plugin-qt_85",
+        "logos-protocol": "logos-protocol_110",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -52457,10 +51566,10 @@
     },
     "logos-view-module-runtime_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_61",
-        "logos-nix": "logos-nix_694",
-        "logos-plugin-qt": "logos-plugin-qt_91",
-        "logos-protocol": "logos-protocol_119",
+        "logos-cpp-sdk": "logos-cpp-sdk_59",
+        "logos-nix": "logos-nix_688",
+        "logos-plugin-qt": "logos-plugin-qt_89",
+        "logos-protocol": "logos-protocol_115",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -52489,10 +51598,10 @@
     },
     "logos-view-module-runtime_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_63",
-        "logos-nix": "logos-nix_727",
-        "logos-plugin-qt": "logos-plugin-qt_96",
-        "logos-protocol": "logos-protocol_127",
+        "logos-cpp-sdk": "logos-cpp-sdk_61",
+        "logos-nix": "logos-nix_721",
+        "logos-plugin-qt": "logos-plugin-qt_94",
+        "logos-protocol": "logos-protocol_123",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -52517,10 +51626,16 @@
     },
     "logos-view-module-runtime_19": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_65",
-        "logos-nix": "logos-nix_748",
-        "logos-plugin-qt": "logos-plugin-qt_99",
-        "logos-protocol": "logos-protocol_132",
+        "logos-cpp-sdk": [
+          "logos-cpp-sdk"
+        ],
+        "logos-nix": "logos-nix_741",
+        "logos-plugin-qt": [
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-view-module-runtime",
           "logos-nix",
@@ -52546,7 +51661,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-nix": "logos-nix_51",
         "logos-plugin-qt": "logos-plugin-qt_8",
-        "logos-protocol": "logos-protocol_12",
+        "logos-protocol": "logos-protocol_11",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -52572,10 +51687,10 @@
     },
     "logos-view-module-runtime_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_11",
-        "logos-nix": "logos-nix_99",
+        "logos-cpp-sdk": "logos-cpp-sdk_10",
+        "logos-nix": "logos-nix_98",
         "logos-plugin-qt": "logos-plugin-qt_14",
-        "logos-protocol": "logos-protocol_19",
+        "logos-protocol": "logos-protocol_18",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -52605,10 +51720,10 @@
     },
     "logos-view-module-runtime_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_13",
-        "logos-nix": "logos-nix_132",
+        "logos-cpp-sdk": "logos-cpp-sdk_12",
+        "logos-nix": "logos-nix_131",
         "logos-plugin-qt": "logos-plugin-qt_18",
-        "logos-protocol": "logos-protocol_24",
+        "logos-protocol": "logos-protocol_23",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -52634,10 +51749,10 @@
     },
     "logos-view-module-runtime_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_19",
-        "logos-nix": "logos-nix_192",
-        "logos-plugin-qt": "logos-plugin-qt_27",
-        "logos-protocol": "logos-protocol_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_17",
+        "logos-nix": "logos-nix_186",
+        "logos-plugin-qt": "logos-plugin-qt_25",
+        "logos-protocol": "logos-protocol_31",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -52666,10 +51781,10 @@
     },
     "logos-view-module-runtime_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
-        "logos-nix": "logos-nix_225",
-        "logos-plugin-qt": "logos-plugin-qt_31",
-        "logos-protocol": "logos-protocol_40",
+        "logos-cpp-sdk": "logos-cpp-sdk_19",
+        "logos-nix": "logos-nix_219",
+        "logos-plugin-qt": "logos-plugin-qt_29",
+        "logos-protocol": "logos-protocol_36",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -52694,10 +51809,10 @@
     },
     "logos-view-module-runtime_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
-        "logos-nix": "logos-nix_275",
-        "logos-plugin-qt": "logos-plugin-qt_38",
-        "logos-protocol": "logos-protocol_49",
+        "logos-cpp-sdk": "logos-cpp-sdk_24",
+        "logos-nix": "logos-nix_269",
+        "logos-plugin-qt": "logos-plugin-qt_36",
+        "logos-protocol": "logos-protocol_45",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52726,10 +51841,10 @@
     },
     "logos-view-module-runtime_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-nix": "logos-nix_323",
-        "logos-plugin-qt": "logos-plugin-qt_44",
-        "logos-protocol": "logos-protocol_56",
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-nix": "logos-nix_317",
+        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-protocol": "logos-protocol_52",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52762,10 +51877,10 @@
     },
     "logos-view-module-runtime_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-nix": "logos-nix_356",
-        "logos-plugin-qt": "logos-plugin-qt_48",
-        "logos-protocol": "logos-protocol_61",
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
+        "logos-nix": "logos-nix_350",
+        "logos-plugin-qt": "logos-plugin-qt_46",
+        "logos-protocol": "logos-protocol_57",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -53440,7 +52555,7 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_139",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
           "logos-liblogos",
@@ -53551,7 +52666,7 @@
     },
     "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_194",
         "nix-bundle-dir": "nix-bundle-dir_27",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -53583,7 +52698,7 @@
     },
     "nix-bundle-appimage_14": {
       "inputs": {
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_207",
         "nix-bundle-dir": "nix-bundle-dir_30",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -53612,7 +52727,7 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_227",
         "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -53722,7 +52837,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_277",
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53888,7 +53003,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_325",
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53924,7 +53039,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_338",
         "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53957,7 +53072,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_358",
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53989,7 +53104,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_373",
+        "logos-nix": "logos-nix_367",
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -54018,7 +53133,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
+        "logos-nix": "logos-nix_391",
         "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -54046,7 +53161,7 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_399",
         "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -54072,7 +53187,7 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_410",
+        "logos-nix": "logos-nix_404",
         "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
           "logos-package-manager",
@@ -54208,7 +53323,7 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
+        "logos-nix": "logos-nix_449",
         "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54346,7 +53461,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_497",
         "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54382,7 +53497,7 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_510",
         "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54415,7 +53530,7 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_530",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54447,7 +53562,7 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_545",
+        "logos-nix": "logos-nix_539",
         "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54476,7 +53591,7 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_563",
         "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54504,7 +53619,7 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_577",
+        "logos-nix": "logos-nix_571",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -54650,7 +53765,7 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_615",
         "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54788,7 +53903,7 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_663",
         "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54824,7 +53939,7 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_676",
         "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54857,7 +53972,7 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_696",
         "nix-bundle-dir": "nix-bundle-dir_105",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54889,7 +54004,7 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
-        "logos-nix": "logos-nix_711",
+        "logos-nix": "logos-nix_705",
         "nix-bundle-dir": "nix-bundle-dir_108",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54918,7 +54033,7 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
-        "logos-nix": "logos-nix_735",
+        "logos-nix": "logos-nix_729",
         "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54946,7 +54061,7 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
-        "logos-nix": "logos-nix_750",
+        "logos-nix": "logos-nix_742",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "nix-bundle-appimage",
@@ -54999,7 +54114,7 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
-        "logos-nix": "logos-nix_756",
+        "logos-nix": "logos-nix_748",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -55113,7 +54228,7 @@
     },
     "nix-bundle-appimage_8": {
       "inputs": {
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_106",
         "nix-bundle-dir": "nix-bundle-dir_15",
         "nixpkgs": [
           "logos-liblogos",
@@ -55146,7 +54261,7 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_119",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
           "logos-liblogos",
@@ -55233,7 +54348,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_671",
+        "logos-nix": "logos-nix_665",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55268,7 +54383,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_668",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55303,7 +54418,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-        "logos-nix": "logos-nix_683",
+        "logos-nix": "logos-nix_677",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55334,7 +54449,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-        "logos-nix": "logos-nix_684",
+        "logos-nix": "logos-nix_678",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55366,7 +54481,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_698",
+        "logos-nix": "logos-nix_692",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55396,7 +54511,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
+        "logos-nix": "logos-nix_697",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55426,7 +54541,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_698",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55457,7 +54572,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_707",
+        "logos-nix": "logos-nix_701",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55488,7 +54603,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
+        "logos-nix": "logos-nix_706",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55515,7 +54630,7 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_707",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55571,7 +54686,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_731",
+        "logos-nix": "logos-nix_725",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55597,7 +54712,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_736",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55623,7 +54738,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-        "logos-nix": "logos-nix_737",
+        "logos-nix": "logos-nix_731",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55650,7 +54765,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-        "logos-nix": "logos-nix_740",
+        "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55677,7 +54792,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_751",
+        "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -55699,7 +54814,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_752",
+        "logos-nix": "logos-nix_744",
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -55722,7 +54837,7 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_757",
+        "logos-nix": "logos-nix_749",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -55746,7 +54861,7 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_758",
+        "logos-nix": "logos-nix_750",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -55771,7 +54886,7 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_761",
+        "logos-nix": "logos-nix_753",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -55866,7 +54981,7 @@
     },
     "nix-bundle-dir_14": {
       "inputs": {
-        "logos-nix": "logos-nix_103",
+        "logos-nix": "logos-nix_102",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55897,7 +55012,7 @@
     },
     "nix-bundle-dir_15": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_107",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55928,7 +55043,7 @@
     },
     "nix-bundle-dir_16": {
       "inputs": {
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_108",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55960,7 +55075,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55992,7 +55107,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_120",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56020,7 +55135,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56075,7 +55190,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_135",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56102,7 +55217,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56129,7 +55244,7 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_142",
+        "logos-nix": "logos-nix_141",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56157,7 +55272,7 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_144",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -56251,7 +55366,7 @@
     },
     "nix-bundle-dir_26": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_190",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56281,7 +55396,7 @@
     },
     "nix-bundle-dir_27": {
       "inputs": {
-        "logos-nix": "logos-nix_201",
+        "logos-nix": "logos-nix_195",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56311,7 +55426,7 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56342,7 +55457,7 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_199",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56399,7 +55514,7 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_214",
+        "logos-nix": "logos-nix_208",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56426,7 +55541,7 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
+        "logos-nix": "logos-nix_209",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56454,7 +55569,7 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_229",
+        "logos-nix": "logos-nix_223",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56480,7 +55595,7 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_228",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56506,7 +55621,7 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_235",
+        "logos-nix": "logos-nix_229",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56533,7 +55648,7 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_238",
+        "logos-nix": "logos-nix_232",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -56626,7 +55741,7 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_273",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56656,7 +55771,7 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_284",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56713,7 +55828,7 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56744,7 +55859,7 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-nix": "logos-nix_282",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56857,7 +55972,7 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_321",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56891,7 +56006,7 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": "logos-nix_332",
+        "logos-nix": "logos-nix_326",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56925,7 +56040,7 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56960,7 +56075,7 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56995,7 +56110,7 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_339",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57026,7 +56141,7 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57085,7 +56200,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_354",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57115,7 +56230,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_359",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57145,7 +56260,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_360",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57176,7 +56291,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_363",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57207,7 +56322,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_368",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57234,7 +56349,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57262,7 +56377,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_387",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57288,7 +56403,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_392",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57314,7 +56429,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_393",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57341,7 +56456,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57393,7 +56508,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
+        "logos-nix": "logos-nix_400",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -57417,7 +56532,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_407",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -57442,7 +56557,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_405",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -57465,7 +56580,7 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_412",
+        "logos-nix": "logos-nix_406",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-dir",
@@ -57555,7 +56670,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_445",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57585,7 +56700,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_456",
+        "logos-nix": "logos-nix_450",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57615,7 +56730,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_451",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57646,7 +56761,7 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57790,7 +56905,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": "logos-nix_493",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57824,7 +56939,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_504",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57858,7 +56973,7 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
+        "logos-nix": "logos-nix_499",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57893,7 +57008,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57928,7 +57043,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_517",
+        "logos-nix": "logos-nix_511",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57959,7 +57074,7 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_518",
+        "logos-nix": "logos-nix_512",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57991,7 +57106,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_526",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58021,7 +57136,7 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_537",
+        "logos-nix": "logos-nix_531",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58078,7 +57193,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_532",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58109,7 +57224,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_535",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58140,7 +57255,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_540",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58167,7 +57282,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
+        "logos-nix": "logos-nix_541",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58195,7 +57310,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
+        "logos-nix": "logos-nix_559",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58221,7 +57336,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_570",
+        "logos-nix": "logos-nix_564",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58247,7 +57362,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_565",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58274,7 +57389,7 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_574",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58301,7 +57416,7 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -58325,7 +57440,7 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_579",
+        "logos-nix": "logos-nix_573",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -58443,7 +57558,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_611",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58473,7 +57588,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_622",
+        "logos-nix": "logos-nix_616",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58503,7 +57618,7 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_623",
+        "logos-nix": "logos-nix_617",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58534,7 +57649,7 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_620",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58647,7 +57762,7 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_665",
+        "logos-nix": "logos-nix_659",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58681,7 +57796,7 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_670",
+        "logos-nix": "logos-nix_664",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58742,7 +57857,7 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_197",
         "logos-package": "logos-package_18",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
@@ -58774,7 +57889,7 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_221",
         "logos-package": "logos-package_20",
         "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
@@ -58801,7 +57916,7 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_236",
+        "logos-nix": "logos-nix_230",
         "logos-package": "logos-package_22",
         "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
@@ -58829,7 +57944,7 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
+        "logos-nix": "logos-nix_271",
         "logos-package": "logos-package_24",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -58860,7 +57975,7 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_280",
         "logos-package": "logos-package_26",
         "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
@@ -58892,7 +58007,7 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_319",
         "logos-package": "logos-package_27",
         "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
@@ -58927,7 +58042,7 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_328",
         "logos-package": "logos-package_29",
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
@@ -58963,7 +58078,7 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_352",
         "logos-package": "logos-package_31",
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
@@ -58994,7 +58109,7 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_361",
         "logos-package": "logos-package_33",
         "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
@@ -59026,7 +58141,7 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_385",
         "logos-package": "logos-package_35",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
@@ -59081,7 +58196,7 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_394",
         "logos-package": "logos-package_37",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
@@ -59109,7 +58224,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_443",
         "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
@@ -59140,7 +58255,7 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_452",
         "logos-package": "logos-package_42",
         "nix-bundle-dir": "nix-bundle-dir_69",
         "nixpkgs": [
@@ -59172,7 +58287,7 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_491",
         "logos-package": "logos-package_43",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
@@ -59207,7 +58322,7 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_500",
         "logos-package": "logos-package_45",
         "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
@@ -59243,7 +58358,7 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_524",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
@@ -59274,7 +58389,7 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_533",
         "logos-package": "logos-package_49",
         "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
@@ -59306,7 +58421,7 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_557",
         "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
@@ -59333,7 +58448,7 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_566",
         "logos-package": "logos-package_53",
         "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
@@ -59361,7 +58476,7 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_609",
         "logos-package": "logos-package_55",
         "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
@@ -59420,7 +58535,7 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_618",
         "logos-package": "logos-package_57",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
@@ -59452,7 +58567,7 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_663",
+        "logos-nix": "logos-nix_657",
         "logos-package": "logos-package_58",
         "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
@@ -59487,7 +58602,7 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_666",
         "logos-package": "logos-package_60",
         "nix-bundle-dir": "nix-bundle-dir_101",
         "nixpkgs": [
@@ -59523,7 +58638,7 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_690",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
@@ -59554,7 +58669,7 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_699",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
@@ -59586,7 +58701,7 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_729",
+        "logos-nix": "logos-nix_723",
         "logos-package": "logos-package_66",
         "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
@@ -59613,7 +58728,7 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_738",
+        "logos-nix": "logos-nix_732",
         "logos-package": "logos-package_68",
         "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
@@ -59641,7 +58756,7 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_759",
+        "logos-nix": "logos-nix_751",
         "logos-package": "logos-package_71",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
@@ -59696,7 +58811,7 @@
     },
     "nix-bundle-lgx_5": {
       "inputs": {
-        "logos-nix": "logos-nix_101",
+        "logos-nix": "logos-nix_100",
         "logos-package": "logos-package_8",
         "nix-bundle-dir": "nix-bundle-dir_14",
         "nixpkgs": [
@@ -59728,7 +58843,7 @@
     },
     "nix-bundle-lgx_6": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_109",
         "logos-package": "logos-package_10",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
@@ -59761,7 +58876,7 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_134",
+        "logos-nix": "logos-nix_133",
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_20",
         "nixpkgs": [
@@ -59789,7 +58904,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_142",
         "logos-package": "logos-package_14",
         "nix-bundle-dir": "nix-bundle-dir_23",
         "nixpkgs": [
@@ -59818,7 +58933,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_188",
         "logos-package": "logos-package_16",
         "nix-bundle-dir": "nix-bundle-dir_26",
         "nixpkgs": [
@@ -59876,7 +58991,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_388",
         "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": "nix-bundle-lgx_20",
         "nixpkgs": [
@@ -59903,7 +59018,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_446",
         "logos-package-manager": "logos-package-manager_16",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
         "nixpkgs": [
@@ -59934,7 +59049,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_494",
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
@@ -59969,7 +59084,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
+        "logos-nix": "logos-nix_527",
         "logos-package-manager": "logos-package-manager_19",
         "nix-bundle-lgx": "nix-bundle-lgx_26",
         "nixpkgs": [
@@ -60000,7 +59115,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_560",
         "logos-package-manager": "logos-package-manager_21",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
@@ -60027,7 +59142,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_612",
         "logos-package-manager": "logos-package-manager_23",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -60058,7 +59173,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_666",
+        "logos-nix": "logos-nix_660",
         "logos-package-manager": "logos-package-manager_24",
         "nix-bundle-lgx": "nix-bundle-lgx_32",
         "nixpkgs": [
@@ -60093,7 +59208,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_693",
         "logos-package-manager": "logos-package-manager_26",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
@@ -60124,7 +59239,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
+        "logos-nix": "logos-nix_726",
         "logos-package-manager": "logos-package-manager_28",
         "nix-bundle-lgx": "nix-bundle-lgx_36",
         "nixpkgs": [
@@ -60151,7 +59266,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_753",
+        "logos-nix": "logos-nix_745",
         "logos-package-manager": "logos-package-manager_29",
         "nix-bundle-lgx": "nix-bundle-lgx_37",
         "nixpkgs": [
@@ -60204,7 +59319,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_103",
         "logos-package-manager": "logos-package-manager_3",
         "nix-bundle-lgx": "nix-bundle-lgx_6",
         "nixpkgs": [
@@ -60236,7 +59351,7 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_136",
         "logos-package-manager": "logos-package-manager_5",
         "nix-bundle-lgx": "nix-bundle-lgx_8",
         "nixpkgs": [
@@ -60264,7 +59379,7 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_191",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
         "nixpkgs": [
@@ -60295,7 +59410,7 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_224",
         "logos-package-manager": "logos-package-manager_8",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
@@ -60322,7 +59437,7 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_280",
+        "logos-nix": "logos-nix_274",
         "logos-package-manager": "logos-package-manager_9",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
@@ -60353,7 +59468,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
+        "logos-nix": "logos-nix_322",
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
@@ -60388,7 +59503,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_355",
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -60965,7 +60080,7 @@
     },
     "nix-bundle-macos-app_20": {
       "inputs": {
-        "logos-nix": "logos-nix_762",
+        "logos-nix": "logos-nix_754",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -71661,135 +70776,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-windows_683": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_684": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_685": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_686": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_687": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_688": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_689": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
     "nixpkgs-windows_69": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_690": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -83965,135 +82952,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_755": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_756": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_757": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_758": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_759": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_76": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_760": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_761": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_762": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -84511,7 +83370,7 @@
     },
     "process-stats": {
       "inputs": {
-        "logos-nix": "logos-nix_126",
+        "logos-nix": "logos-nix_125",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -84539,7 +83398,7 @@
     },
     "process-stats_2": {
       "inputs": {
-        "logos-nix": "logos-nix_152",
+        "logos-nix": "logos-nix_146",
         "nixpkgs": [
           "logos-liblogos",
           "process-stats",
@@ -84563,7 +83422,7 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_219",
+        "logos-nix": "logos-nix_213",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -84590,7 +83449,7 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_350",
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -84621,7 +83480,7 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_381",
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -84648,7 +83507,7 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_522",
+        "logos-nix": "logos-nix_516",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -84679,7 +83538,7 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_553",
+        "logos-nix": "logos-nix_547",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -84706,7 +83565,7 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_688",
+        "logos-nix": "logos-nix_682",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -84737,7 +83596,7 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_719",
+        "logos-nix": "logos-nix_713",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -84768,19 +83627,19 @@
         "logos-cpp-sdk": "logos-cpp-sdk_3",
         "logos-design-system": "logos-design-system_2",
         "logos-liblogos": "logos-liblogos",
-        "logos-module": "logos-module_33",
+        "logos-module": "logos-module_31",
         "logos-module-loader-qt": "logos-module-loader-qt",
         "logos-modules-state-module": "logos-modules-state-module_2",
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_233",
         "logos-package": "logos-package_23",
         "logos-package-downloader-module": "logos-package-downloader-module",
         "logos-package-manager": "logos-package-manager_15",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-        "logos-plugin-qt": "logos-plugin-qt_97",
-        "logos-protocol": "logos-protocol_129",
+        "logos-plugin-qt": "logos-plugin-qt_95",
+        "logos-protocol": "logos-protocol_124",
         "logos-qt-mcp": "logos-qt-mcp_9",
-        "logos-qt-sdk": "logos-qt-sdk_51",
+        "logos-qt-sdk": "logos-qt-sdk_50",
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-appimage": "nix-bundle-appimage_49",
         "nix-bundle-dir": "nix-bundle-dir_115",

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,21 @@
     logos-module.url = "github:logos-co/logos-module";
     logos-module-loader-qt.url = "github:logos-co/logos-module-loader-qt";
     logos-liblogos.url = "github:logos-co/logos-liblogos";
+    # ONE logos-protocol, and ONE logos-qt-host, in what the app stages.
+    # logos-qt-host bakes sizeof(LogosAPIClient) into its own `operator new`
+    # while logos-protocol DEFINES that constructor, so a second protocol is an
+    # 8-byte heap overrun on every getClient() -- silent on macOS, where it
+    # rounds up into the next malloc size class, and fatal on glibc. Without
+    # these the app linked one protocol and qt-host was built against another.
+    logos-cpp-sdk.inputs.logos-protocol.follows = "logos-protocol";
+    logos-plugin-qt.inputs.logos-protocol.follows = "logos-protocol";
+    logos-qt-sdk.inputs.logos-protocol.follows = "logos-protocol";
+    logos-qt-sdk.inputs.logos-plugin-qt.follows = "logos-plugin-qt";
+    logos-qt-sdk.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
+    logos-liblogos.inputs.logos-protocol.follows = "logos-protocol";
+    logos-liblogos.inputs.logos-plugin-qt.follows = "logos-plugin-qt";
+    logos-liblogos.inputs.logos-qt-sdk.follows = "logos-qt-sdk";
+    logos-liblogos.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
     logos-package-manager.url = "github:logos-co/logos-package-manager";
     # liblogos_core links libpackage_manager_lib, so liblogos otherwise puts
     # its OWN older liblgx in the bundle's flat lib/ — where the module's
@@ -31,6 +46,10 @@
     logos-package-manager-ui.inputs.package_downloader.follows = "logos-package-downloader-module";
     logos-design-system.url = "github:logos-co/logos-design-system";
     logos-view-module-runtime.url = "github:logos-co/logos-view-module-runtime";
+    # ui-host links the same qt-host and protocol the app does.
+    logos-view-module-runtime.inputs.logos-protocol.follows = "logos-protocol";
+    logos-view-module-runtime.inputs.logos-plugin-qt.follows = "logos-plugin-qt";
+    logos-view-module-runtime.inputs.logos-cpp-sdk.follows = "logos-cpp-sdk";
     nix-bundle-logos-module-install.url = "github:logos-co/nix-bundle-logos-module-install";
     nix-bundle-dir.url = "github:logos-co/nix-bundle-dir";
     logos-qt-mcp.url = "github:logos-co/logos-qt-mcp";


### PR DESCRIPTION
The last of the qt-host/protocol pairing wave, after logos-co/logos-liblogos#212 and logos-co/logos-logoscore-cli#123.

`logos-qt-host` defines `LogosAPI::getClient()`, which does `new LogosAPIClient(...)` and therefore bakes `sizeof(LogosAPIClient)` into its own `operator new` at **its** compile time. `logos-protocol` DEFINES that constructor. The two are an ABI pair, not a version preference — and we took them as independent top-level inputs with no `follows` between them, then bundled `logosProtocolPkg` next to `logosQtHost`.

### The app already carried two protocols

Measured on `.#app` built from master, **no overrides**, using logos-protocol's own check:

```
subject: ./result-pre
  logos-protocol-lib: 2
    /nix/store/n7yilrs2pwdf…-logos-protocol-lib-0.8.0
    /nix/store/nksk84h32yp7…-logos-protocol-lib-0.8.0
  logos-qt-host:      1
FAIL: 2 distinct logos-protocol-lib in ONE closure.
```

`n7yil…` is the one `logos-qt-host` and `logos-qt-sdk-lib` were built against; `nksk8…` is the one the app links directly. Both are `0.8.0`, so nothing was corrupting yet — consistent by luck, and only while nothing moved. Seven distinct protocol revisions reached an output:

| edge | was |
|---|---|
| `logos-protocol` | `cac0642a` |
| `logos-plugin-qt` / `logos-qt-sdk` | `3d132f4b` |
| `logos-cpp-sdk` | `47d287cd` |
| `logos-liblogos`, `logos-view-module-runtime` | `2da8eab4` |
| `logos-liblogos/logos-plugin-qt`, `…/logos-qt-sdk` | `303ab08d` |
| `logos-liblogos/default-module-loader` | `42460e5b` |
| `logos-view-module-runtime/logos-cpp-sdk` | `03842db5` |

logos-protocol#85 (`4638634`) appended `m_pendingReadiness` to `LogosAPIClient` — 88 → 96 bytes — which is what arms this. It already bit logos-rust-sdk's concurrent-dispatch doctest.

### The change

Twelve `follows` so every protocol, qt-host, qt-sdk and cpp-sdk edge resolves to one revision, plus a relock of four roots onto master:

| input | was | now | what moves |
|---|---|---|---|
| `logos-protocol` | `cac0642a` | `9ba2f5a7` | 0.9 + the check this PR runs |
| `logos-plugin-qt` | `6990e588` | `1a0e399e` | lock only ("repin logos-protocol") |
| `logos-cpp-sdk` | `9cfb4a22` | `41ca4491` | lock only ("repin logos-protocol") |
| `logos-liblogos` | `95105df5` | `209e9824` | logos-co/logos-liblogos#212 — the same follows, one layer down |

plugin-qt and cpp-sdk move by lock-only commits, so **no new code arrives with them**; their code is byte-identical to the revisions we had.

### The CI step, and why the symbol gate cannot do this

`symbol-gate` reads what the package **ships** — one `liblogos_protocol` in `$out/lib` — which stays true while qt-host is compiled against a second one that only the closure names. So the new step sits next to it and runs logos-protocol's `abi-closure-check`, which asserts ONE protocol-lib, ONE qt-host, and that the qt-host was built against the very protocol-lib the output links. It shells out to `nix path-info`, so it is a CI step and never a `checks.` derivation. It runs from the revision we lock, not master, so the check and the build agree.

It reads the lock rather than the platform, so `test-linux` covers macOS and the Windows cross too.

### Verification

Verify the **edge**, not the lock's rev list — this lock still holds many `logos-protocol` revisions from node explosion, and `.locks.nodes["logos-protocol"]` reads whichever edge claimed the flat name first. Resolve from the root:

```
$l.nodes[$l.nodes[$l.root].inputs["logos-protocol"]]
```

After the change every protocol edge under every input that reaches an output resolves to `9ba2f5a7e`, every `logos-plugin-qt` edge to `1a0e399ef`, every `logos-cpp-sdk` edge to `41ca4491f`.

On the built `.#app`, with no overrides:

```
subject: ./result-abi-subject
  logos-protocol-lib: 1
    /nix/store/c2xmcw1kf6rv…-logos-protocol-lib-0.9.0
  logos-qt-host:      1
    /nix/store/sh3nh2pis438…-logos-qt-host-0.1.0
  paired: qt-host built against the protocol-lib this output links
PASS
```

The FAIL above is the negative control: the same check, same command, against the pre-change closure.

Green locally on `aarch64-darwin`: `symbol-gate`, `symbol-gate-negative`, `link-gate`, `link-gate-negative`, `smoke-test`, `unit-tests`, `qml-tests`. `.#packages.x86_64-windows.{bin-bundle-dir,symbol-gate}` and both Linux `app` attributes still evaluate.

### Two things left alone, deliberately

* **`logos-module-loader-qt` gets no follows.** It is declared and destructured in `outputs`, and then used by nothing — no output, no `nix/` file references it. It reaches no closure, so a follows there would only add lock churn. Worth removing, but not in this PR.
* **`logos-liblogos/default-module-loader/logos-qt-sdk` is not followed by liblogos**, so that leg lands on the same revisions by pin rather than by construction. Reaching two levels into another repo's private input name from here is exactly the sort of `follows` that goes silently inert when the name changes; the new CI step is what catches it if it drifts, and the durable fix belongs in logos-liblogos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
