### PR TITLE
ci: add Windows build pipeline

### DIFF
--- a/ci/windows.Jenkinsfile
+++ b/ci/windows.Jenkinsfile
@@ -1,0 +1,80 @@
+#!/usr/bin/env groovy
+
+library 'status-jenkins-lib@v1.9.48'
+
+def isPRBuild = utils.isPRBuild()
+
+pipeline {
+  agent {
+    docker {
+      label 'linuxcontainer'
+      image 'harbor.status.im/infra/ci-build-containers:linux-base-1.0.2'
+      args '--volume=/nix:/nix ' +
+           '--volume=/etc/nix:/etc/nix '
+    }
+  }
+
+  parameters {
+    booleanParam(
+      name: 'RELEASE',
+      description: 'Decides whether release credentials are used.',
+      defaultValue: params.RELEASE ?: false
+    )
+  }
+
+  options {
+    timestamps()
+    ansiColor('xterm')
+    timeout(time: 45, unit: 'MINUTES')
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+      artifactNumToKeepStr: '1',
+    ))
+    disableConcurrentBuilds(
+      abortPrevious: isPRBuild
+    )
+    copyArtifactPermission('/logos/logos-basecamp/*')
+  }
+
+  environment {
+    PLATFORM = 'windows/x86_64'
+    ARTIFACT = "pkg/${utils.pkgFilename(name: 'LogosBasecamp', type: 'Desktop', ext: 'zip', arch: 'x86_64')}"
+  }
+
+  stages {
+    stage('Build Windows Bundle') {
+      steps { script {
+        nix.flake('packages.x86_64-windows.bin-bundle-dir')
+      } }
+    }
+
+    stage('Package') {
+      steps {
+        sh "./scripts/create-exe.sh --bundle result --output ${env.ARTIFACT}"
+      }
+    }
+
+    stage('Upload') {
+      steps { script {
+        env.PKG_URL = s5cmd.upload(env.ARTIFACT)
+        jenkins.setBuildDesc(Windows: env.PKG_URL)
+      } }
+    }
+
+    stage('Archive') {
+      steps {
+        archiveArtifacts(env.ARTIFACT)
+      }
+    }
+  }
+
+  post {
+    success { script { github.notifyPR(true) } }
+    failure { script { github.notifyPR(false) } }
+    cleanup {
+      cleanWs(disableDeferredWipeout: true)
+      dir(env.WORKSPACE_TMP) { deleteDir() }
+    }
+  }
+}

--- a/scripts/create-exe.sh
+++ b/scripts/create-exe.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --bundle <path> --output <path.zip>"
+  exit 1
+}
+
+BUNDLE=""
+OUTPUT=""
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --bundle) BUNDLE="$2"; shift 2 ;;
+    --output) OUTPUT="$2"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+
+[[ -z "$BUNDLE" || -z "$OUTPUT" ]] && usage
+
+src=$(readlink -f "$BUNDLE")
+
+# Verify bundle is not empty
+staged=$(find -L "$src" -type f | wc -l | tr -d ' ')
+[[ "$staged" -gt 0 ]] || { echo "ERROR: bundle is empty"; exit 1; }
+
+# Copy with dereferenced symlinks
+mkdir -p pkg/logos-basecamp
+cp -rL "$src"/. pkg/logos-basecamp/
+
+# Create zip
+nix-shell -p zip --run "cd pkg && zip -qr '../$OUTPUT' logos-basecamp"
+
+# Verify symlinks were dereferenced
+zipped=$(nix-shell -p unzip --run "unzip -l '$OUTPUT'" | tail -1 | awk '{print $2}')
+echo "bundle $staged file(s) -> zip $zipped entr(ies)"
+
+if [[ "$zipped" -lt "$staged" ]]; then
+  echo "ERROR: zip has $zipped entries but bundle has $staged files."
+  echo "ERROR: Symlinks not dereferenced; DLLs would be missing."
+  exit 1
+fi
+
+# Verify at least one .exe exists
+n_exe=$(find pkg -name '*.exe' | wc -l | tr -d ' ')
+[[ "$n_exe" -gt 0 ]] || { echo "ERROR: no .exe in bundle"; exit 1; }
+echo "exe(s): $n_exe"
+
+echo "Created: $OUTPUT"


### PR DESCRIPTION
- Add create-exe.sh script for packaging Windows bundle
- Add windows.Jenkinsfile for cross-compiling on Linux via Nix
- Validates symlink dereferencing and .exe presence

Ref.: https://github.com/logos-co/logos-basecamp/issues/28