### PR TITLE
fix(ci): bump retries count when uploading to s3 bucket

### DIFF
--- a/ci/linux.Jenkinsfile
+++ b/ci/linux.Jenkinsfile
@@ -65,7 +65,7 @@ pipeline {
 
     stage('Upload') {
       steps { script {
-        env.PKG_URL = s5cmd.upload(env.ARTIFACT)
+        env.PKG_URL = s5cmd.upload(env.ARTIFACT, retriesCount: 5)
         jenkins.setBuildDesc(AppImage: env.PKG_URL)
       } }
     }

--- a/ci/macos.Jenkinsfile
+++ b/ci/macos.Jenkinsfile
@@ -70,7 +70,7 @@ pipeline {
 
     stage('Upload') {
       steps { script {
-        env.PKG_URL = s5cmd.upload(env.ARTIFACT)
+        env.PKG_URL = s5cmd.upload(env.ARTIFACT, retriesCount: 5)
         jenkins.setBuildDesc(DMG: env.PKG_URL)
       } }
     }


### PR DESCRIPTION
- should fix flaky upload which can fail randomly
```
10:20:36  + nix-shell --show-trace --run $'\n        s5cmd --log=info --stat=true --numworkers=256 --retry-count=0 cp --show-progress=false --concurrency=5 --part-size=20 --acl=public-read pkg/LogosBasecamp-Desktop-v0.3.0-rc.1-dbacb8-aarch64.dmg s3://logos-basecamp-releases/\n        ' --impure --no-out-link --option sandbox relaxed --packages s5cmd
10:20:36  warning: ignoring the client-specified setting 'sandbox', because it is a restricted setting and you are not a trusted user
10:22:48  ERROR "cp pkg/LogosBasecamp-Desktop-v0.3.0-rc.1-dbacb8-aarch64.dmg s3://logos-basecamp-releases/LogosBasecamp-Desktop-v0.3.0-rc.1-dbacb8-aarch64.dmg": MultipartUpload: upload multipart failed upload id: 2~TmdXqIuOdLxjIVPzMWr7Mfron7KhBi2 caused by: GatewayTimeout: The server did not respond in time. status code: 504, request id: , host id:
10:22:48  
10:22:48  Operation    Total    Error    Success    
10:22:48  cp        1    1    0    
```