### PR TITLE
feat(plugins): load a ui plugin's own optional dependencies

### DIFF
--- a/app/PluginLoader.cpp
+++ b/app/PluginLoader.cpp
@@ -109,7 +109,7 @@ logos::ConsumerIdentity PluginLoader::consumerFor(const QString& name)
 
 void PluginLoader::startLoad(const PluginLoadRequest& request)
 {
-    if (request.coreDependencies.isEmpty()) {
+    if (request.coreDependencies.isEmpty() && request.optionalCoreDependencies.isEmpty()) {
         continueLoad(request);
         return;
     }
@@ -161,6 +161,27 @@ void PluginLoader::loadCoreDependencies(const PluginLoadRequest& request)
             return;
         }
     }
+
+    // Optional dependencies: every failure here is a warning, never a refusal.
+    // The plugin declared it does not need these, so an absent or broken one
+    // must not stop it mounting -- the same rule the blocking gate follows.
+    for (const QVariant& dep : request.optionalCoreDependencies) {
+        const logos::DependencyEntry entry = logos::readDependencyEntry(dep);
+        if (entry.kind == logos::DependencyEntryKind::Unrecognised) {
+            qWarning() << "Unrecognised optional dependency entry" << dep
+                       << "for" << request.name << "- skipping";
+            continue;
+        }
+        if (!m_coreModuleManager) {
+            break;
+        }
+        qDebug() << "Loading optional dependency for" << request.name << ":" << entry.name;
+        if (!m_coreModuleManager->loadModule(entry.name)) {
+            qInfo() << "Optional dependency" << entry.name << "for" << request.name
+                    << "is unavailable; continuing without it";
+        }
+    }
+
     continueLoad(request);
 }
 

--- a/app/PluginLoader.h
+++ b/app/PluginLoader.h
@@ -31,6 +31,10 @@ struct PluginLoadRequest {
     QString pluginPath;
     QString iconPath;
     QVariantList coreDependencies;
+    // Best-effort: loaded after the required ones, and a failure here never
+    // fails the plugin. A plugin that does not REQUIRE a module must still
+    // mount when that module is absent or broken.
+    QVariantList optionalCoreDependencies;
 
     // ui_qml module fields
     QString installDir;      // Module install directory (import paths root)

--- a/app/UIPluginManager.cpp
+++ b/app/UIPluginManager.cpp
@@ -294,6 +294,7 @@ void UIPluginManager::loadUiModule(const QString& moduleName)
         if (hasBackendPlugin(moduleName))
             request.mainFilePath = meta.value("mainFilePath").toString();
         request.coreDependencies = meta.value("dependencies").toList();
+        request.optionalCoreDependencies = meta.value("optionalDependencies").toList();
 
         m_pluginLoader->load(request);
         return;
@@ -1145,6 +1146,8 @@ void UIPluginManager::loadLegacyUiModule(const QString& moduleName)
     request.iconPath = pluginIconUrl(moduleName, true);
     if (m_uiPluginMetadata.contains(moduleName)) {
         request.coreDependencies = m_uiPluginMetadata[moduleName].value("dependencies").toList();
+        request.optionalCoreDependencies =
+            m_uiPluginMetadata[moduleName].value("optionalDependencies").toList();
     }
 
     m_pluginLoader->load(request);

--- a/flake.lock
+++ b/flake.lock
@@ -34148,11 +34148,11 @@
         "logos-package-manager": "logos-package-manager_22"
       },
       "locked": {
-        "lastModified": 1788803121,
-        "narHash": "sha256-JY/muWBPL/AcGXOP7XD2/3SnYJ4dLykgUSoAVca2484=",
+        "lastModified": 1789066157,
+        "narHash": "sha256-JQLIOHj6dZ2/qY/ESf9un2SEC+cIH3z/Dw+wjuMFbuA=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "6f2b84fce9a8730d4d2599f1442fa7effcb672dd",
+        "rev": "e991615120228844003fa5be78db76b8dce44924",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Optional dependencies have auto-loaded since #399 — but only for the modules already in the load set. A `ui_qml` plugin's **own** optional edge was never a root of that expansion:

```
UIPluginManager.cpp:296   request.coreDependencies = meta.value("dependencies").toList();
                          ← optional_dependencies never read (also :1147, legacy path)
PluginLoader.cpp:125,155  for (dep : request.coreDependencies) → loadModule(depName)
CoreModuleManager.cpp:92  → loadModule(name, LoadPolicy::RequiredAndOptional)
```

So each **required** dep brings its own optional deps, and the plugin's never do. The effect is not "loaded late" or "degraded" — the module is never loaded and the plugin's optional collaborator simply does not exist.

Measured before this change, on a plugin whose installed manifest declares `optional_dependencies: ["token_list_module"]`:

```
Module loaded: keystore_module      ← required
(token_list_module: absent)         ← optional, declared, never loaded
```

### Why a separate field

`optionalCoreDependencies` rather than appending to `coreDependencies`, because the two have different failure rules. A required dep that fails is fatal and emits `pluginLoadFailed`; an optional one is a warning and the plugin mounts anyway — the plugin declared it does not need it, and the resolver never fails a load over an optional edge, so neither may this. That is the rule `DependencyBlocker` already applies to the blocking gate (#389).

### Key name

Reads `optionalDependencies`. The module ABI is camelCase (`displayName`, `mainFilePath`, `dependencyConstraints`), and `package_manager` emits that key as of [logos-package-manager-module#68](https://github.com/logos-co/logos-package-manager-module/pull/68) — its projection previously dropped the field entirely.

**Depends on that PR.** Without it this reads an absent key and changes nothing, which is the safe direction: this cannot regress anything on its own.

### Verified live, both directions

| optional dep | result |
|---|---|
| installed | `Loading optional dependency … token_list_module` → `Module loaded: token_list_module` |
| absent | `…is unavailable; continuing without it`; **0** `pluginLoadFailed`; plugin still mounts |

The absent case is the one that matters: a plugin that does not *require* a module must still open when it is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)