### PR TITLE
fix(apps): load an app's core dependencies off the GUI thread

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -307,6 +307,7 @@ set(PROJECT_SOURCES
     IntentBridgeAdapter.cpp
     UIPluginPresenter.cpp
     CoreModuleManager.cpp
+    CoreDependencyLoader.cpp
     RecentlyClosedStore.cpp
     UIPluginManager.cpp
     PackageCoordinator.cpp

--- a/app/CoreDependencyLoader.cpp
+++ b/app/CoreDependencyLoader.cpp
@@ -1,0 +1,46 @@
+#include "CoreDependencyLoader.h"
+
+CoreDependencyLoader::CoreDependencyLoader(QObject* parent)
+    : QObject(parent)
+    , m_worker(new QObject)
+{
+    m_worker->moveToThread(&m_thread);
+    connect(&m_thread, &QThread::finished, m_worker, &QObject::deleteLater);
+    m_thread.start();
+}
+
+CoreDependencyLoader::~CoreDependencyLoader()
+{
+    // wait() is what lets the worker lambda capture `this`: the thread cannot
+    // outlive us part-way through a load.
+    m_thread.quit();
+    m_thread.wait();
+}
+
+void CoreDependencyLoader::enqueue(const QStringList& required,
+                                   const QStringList& optional,
+                                   LoadOne loadOne,
+                                   std::function<void()> onSuccess,
+                                   std::function<void(const QString&)> onFailure)
+{
+    QMetaObject::invokeMethod(m_worker,
+        [this, required, optional, loadOne, onSuccess, onFailure] {
+            QString failed;
+            for (const QString& name : required) {
+                if (!loadOne(name, true)) {
+                    failed = name;
+                    break;
+                }
+            }
+            // Only once the required set is up: an optional collaborator of a
+            // plugin that is not going to mount is work nobody asked for.
+            if (failed.isEmpty()) {
+                for (const QString& name : optional)
+                    loadOne(name, false);
+            }
+            QMetaObject::invokeMethod(this, [failed, onSuccess, onFailure] {
+                if (failed.isEmpty()) onSuccess();
+                else                  onFailure(failed);
+            }, Qt::QueuedConnection);
+        }, Qt::QueuedConnection);
+}

--- a/app/CoreDependencyLoader.h
+++ b/app/CoreDependencyLoader.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <QObject>
+#include <QStringList>
+#include <QThread>
+
+#include <functional>
+
+// Loads a UI plugin's core dependencies off the GUI thread.
+//
+// Each logos_core_load_module spawns a subprocess and waits for its verdict
+// (~35 ms warm, ~150 ms cold), so a plugin with a handful of dependencies
+// froze the GUI thread — including the spinner raised to cover the wait.
+// Off-thread is safe by contract: logos_core.h documents core's outbound calls
+// as marshalled to the thread that called logos_core_start().
+class CoreDependencyLoader : public QObject {
+    Q_OBJECT
+
+public:
+    // Called on the worker thread, once per dependency, in order. `required`
+    // is false for the best-effort ones, so a caller can say which kind it is
+    // reporting. Returns "ended up loaded" — already-loaded counts, matching
+    // ICoreRuntime::loadModule.
+    using LoadOne = std::function<bool(const QString& name, bool required)>;
+
+    explicit CoreDependencyLoader(QObject* parent = nullptr);
+    ~CoreDependencyLoader() override;
+
+    // Loads `required` in order and stops at the first failure, then every
+    // `optional` one best-effort — a failure there does not fail the batch,
+    // because a plugin that does not REQUIRE a module must still mount when
+    // that module is absent. Exactly one callback runs, on THIS object's
+    // thread. Batches run one at a time, in submission order.
+    //
+    // The ordering that matters to callers: an off-thread load posts its
+    // capability-module registration to the owner thread as it goes, and
+    // onSuccess is posted after all of them — so a caller that spawns a
+    // process from onSuccess still finds every dependency registered.
+    void enqueue(const QStringList& required,
+                 const QStringList& optional,
+                 LoadOne loadOne,
+                 std::function<void()> onSuccess,
+                 std::function<void(const QString& failedDependency)> onFailure);
+
+private:
+    QThread  m_thread;
+    QObject* m_worker;   // lives on m_thread; deleted when it finishes
+};

--- a/app/PluginLoader.cpp
+++ b/app/PluginLoader.cpp
@@ -5,6 +5,7 @@
 #include <QDir>
 #include <QFile>
 #include <QFileInfo>
+#include <QGuiApplication>
 #include <QIcon>
 #include <QMutexLocker>
 #include <QPluginLoader>
@@ -14,12 +15,15 @@
 #include <QQmlEngine>
 #include <QQmlError>
 #include <QQuickWidget>
+#include <QScreen>
 #include <QThread>
 #include <QTimer>
 #include <QUrl>
 
+#include <cmath>
 #include <memory>
 
+#include "CoreDependencyLoader.h"
 #include "CoreModuleManager.h"
 #include "IComponent.h"
 #include "IntentBridgeAdapter.h"
@@ -37,7 +41,22 @@ PluginLoader::PluginLoader(LogosAPI* logosAPI,
     , m_logosAPI(logosAPI)
     , m_coreModuleManager(coreModuleManager)
 {
+    m_depLoader = new CoreDependencyLoader(this);
 }
+
+namespace {
+
+// Two frames of the primary screen's refresh, floored at one 60 Hz frame.
+int spinnerPaintDelayMs()
+{
+    qreal hz = 0;
+    if (const QScreen* screen = QGuiApplication::primaryScreen())
+        hz = screen->refreshRate();
+    if (hz < 1.0) hz = 60.0;
+    return qBound(16, static_cast<int>(std::ceil(2000.0 / hz)), 50);
+}
+
+}  // namespace
 
 void PluginLoader::load(const PluginLoadRequest& request)
 {
@@ -48,8 +67,11 @@ void PluginLoader::load(const PluginLoadRequest& request)
 
     setLoading(request.name, true);
 
-    // Yield to the event loop so the UI can paint the loading state
-    QTimer::singleShot(0, this, [this, request]() {
+    // Let the spinner reach the screen before anything blocks. A zero timer
+    // does not: measured on Qt 6.9.2, singleShot(0) paints ZERO frames — and
+    // so does four of them nested, because zero timers all drain in one
+    // event-loop pass while a QQuickWidget's first paint lands a frame later.
+    QTimer::singleShot(spinnerPaintDelayMs(), this, [this, request]() {
         startLoad(request);
     });
 }
@@ -119,9 +141,9 @@ void PluginLoader::startLoad(const PluginLoadRequest& request)
 
 void PluginLoader::loadCoreDependencies(const PluginLoadRequest& request)
 {
-    // liblogos is not thread-safe for plugin loading; call only from the GUI thread.
-    // Every core-plugin load goes through CoreModuleManager so the logos_core_*
-    // C API is centralised in one place.
+    // Resolve the names here, on the GUI thread: a malformed manifest is a
+    // caller error and should be reported without spawning anything.
+    QStringList depNames;
     for (const QVariant& dep : request.coreDependencies) {
         // Bare name or {"name": …, "version": …, "signer": …} — either way we
         // need the name. See utils/DependencyEntry.h for why this must not be
@@ -142,29 +164,13 @@ void PluginLoader::loadCoreDependencies(const PluginLoadRequest& request)
                     + request.name + QStringLiteral("'s manifest"));
             return;
         }
-        const QString depName = entry.name;
-        if (!m_coreModuleManager) {
-            qWarning() << "Failed to load core dependency" << depName
-                       << "for" << request.name;
-            setLoading(request.name, false);
-            emit pluginLoadFailed(request.name,
-                QStringLiteral("Failed to load core dependencies for ") + request.name);
-            return;
-        }
-        qDebug() << "Loading core dependency for" << request.name << ":" << depName;
-        if (!m_coreModuleManager->loadModule(depName)) {
-            qWarning() << "Failed to load core dependency" << depName
-                       << "for" << request.name;
-            setLoading(request.name, false);
-            emit pluginLoadFailed(request.name,
-                QStringLiteral("Failed to load core dependencies for ") + request.name);
-            return;
-        }
+        depNames << entry.name;
     }
 
     // Optional dependencies: every failure here is a warning, never a refusal.
     // The plugin declared it does not need these, so an absent or broken one
     // must not stop it mounting -- the same rule the blocking gate follows.
+    QStringList optionalDepNames;
     for (const QVariant& dep : request.optionalCoreDependencies) {
         const logos::DependencyEntry entry = logos::readDependencyEntry(dep);
         if (entry.kind == logos::DependencyEntryKind::Unrecognised) {
@@ -172,17 +178,42 @@ void PluginLoader::loadCoreDependencies(const PluginLoadRequest& request)
                        << "for" << request.name << "- skipping";
             continue;
         }
-        if (!m_coreModuleManager) {
-            break;
-        }
-        qDebug() << "Loading optional dependency for" << request.name << ":" << entry.name;
-        if (!m_coreModuleManager->loadModule(entry.name)) {
-            qInfo() << "Optional dependency" << entry.name << "for" << request.name
-                    << "is unavailable; continuing without it";
-        }
+        optionalDepNames << entry.name;
     }
 
-    continueLoad(request);
+    qDebug() << "Loading core dependencies for" << request.name << ":" << depNames;
+
+    // Off the GUI thread — see CoreDependencyLoader. continueLoad still runs
+    // here, after every dependency has reported, so the steps below it keep
+    // the ordering they had when this loop was synchronous.
+    //
+    // The load callable takes the runtime BY VALUE rather than `this`: it runs
+    // on the worker, which must not read a PluginLoader that is already
+    // part-way through destruction when its loader joins.
+    m_depLoader->enqueue(depNames, optionalDepNames,
+        [core = m_coreModuleManager, name = request.name](const QString& dep, bool required) {
+            if (!core)
+                return false;
+            if (!required)
+                qDebug() << "Loading optional dependency for" << name << ":" << dep;
+            if (core->loadModule(dep))
+                return true;
+            if (!required) {
+                qInfo() << "Optional dependency" << dep << "for" << name
+                        << "is unavailable; continuing without it";
+            }
+            return false;
+        },
+        [this, request]() {
+            continueLoad(request);
+        },
+        [this, request](const QString& failedDependency) {
+            qWarning() << "Failed to load core dependency" << failedDependency
+                       << "for" << request.name;
+            setLoading(request.name, false);
+            emit pluginLoadFailed(request.name,
+                QStringLiteral("Failed to load core dependencies for ") + request.name);
+        });
 }
 
 void PluginLoader::continueLoad(const PluginLoadRequest& request)

--- a/app/PluginLoader.h
+++ b/app/PluginLoader.h
@@ -19,6 +19,7 @@ class ViewModuleHost;
 class LogosQmlBridge;
 class IntentBridgeAdapter;
 class CoreModuleManager;
+class CoreDependencyLoader;
 
 enum class UIPluginType {
     Legacy,
@@ -127,6 +128,10 @@ private:
 
     IntentBridgeAdapter* m_intentAdapter = nullptr;
     CoreModuleManager* m_coreModuleManager;   // not owned
+
+    // Runs each plugin's core dependencies off the GUI thread. Owned, and its
+    // worker holds only the CoreModuleManager pointer, never this.
+    CoreDependencyLoader* m_depLoader = nullptr;
 
     // name -> that plugin's admitted identity (its LogosAPI is parented to
     // this, so owned here). Cached because a LogosAPI captures its store by

--- a/tests/core_dependency_loader_test.cpp
+++ b/tests/core_dependency_loader_test.cpp
@@ -1,0 +1,284 @@
+// srcdeps: CoreDependencyLoader.cpp
+//
+// The contract PluginLoader relies on: dependencies load OFF the calling
+// thread, in order, stopping at the first failure, and report back ON the
+// calling thread.
+
+#include <QtTest/QtTest>
+
+#include <QElapsedTimer>
+#include <QMutex>
+#include <QMutexLocker>
+#include <QSet>
+#include <QThread>
+#include <QTimer>
+
+#include "CoreDependencyLoader.h"
+
+namespace {
+
+// The loader hands names to its worker; a test needs to read them back from
+// the main thread once it is done, so every observation is mutex-guarded.
+struct Recorder {
+    mutable QMutex   mutex;
+    QStringList      attempted;
+    QList<bool>      requiredFlags;
+    QSet<QThread*>   threads;
+    QStringList      failing;      // names loadOne should refuse
+    int              delayMs = 0;
+
+    bool loadOne(const QString& name, bool required)
+    {
+        {
+            QMutexLocker lock(&mutex);
+            attempted << name;
+            requiredFlags << required;
+            threads.insert(QThread::currentThread());
+        }
+        if (delayMs > 0) QThread::msleep(delayMs);
+        QMutexLocker lock(&mutex);
+        return !failing.contains(name);
+    }
+
+    QStringList attemptedNames() const { QMutexLocker l(&mutex); return attempted; }
+    QList<bool> flags() const { QMutexLocker l(&mutex); return requiredFlags; }
+    QSet<QThread*> usedThreads() const { QMutexLocker l(&mutex); return threads; }
+};
+
+// Bind a Recorder as a batch's load callable.
+CoreDependencyLoader::LoadOne bind(Recorder& rec)
+{
+    return [&rec](const QString& n, bool required) { return rec.loadOne(n, required); };
+}
+
+}  // namespace
+
+class CoreDependencyLoaderTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void loadsEveryDependencyInOrder();
+    void runsOffTheCallingThread();
+    void reportsBackOnTheCallingThread();
+    void doesNotBlockTheCallingThread();
+    void stopsAtTheFirstFailure();
+    void runsBatchesInSubmissionOrder();
+    void ownerThreadWorkPostedByALoadRunsBeforeTheCallback();
+    void optionalDependenciesLoadAfterTheRequiredOnes();
+    void anOptionalFailureDoesNotFailTheBatch();
+    void optionalsAreSkippedWhenARequiredOneFails();
+    void joinsItsWorkerOnDestruction();
+};
+
+// Spin the event loop until `done`, or fail after `timeoutMs`.
+#define AWAIT(done, timeoutMs) do { \
+        QElapsedTimer _t; _t.start(); \
+        while (!(done) && _t.elapsed() < (timeoutMs)) \
+            QCoreApplication::processEvents(QEventLoop::AllEvents, 10); \
+        QVERIFY2((done), "timed out waiting for the loader"); \
+    } while (0)
+
+void CoreDependencyLoaderTest::loadsEveryDependencyInOrder()
+{
+    Recorder rec;
+    CoreDependencyLoader loader;
+
+    bool ok = false;
+    loader.enqueue({"alpha", "beta", "gamma"}, {}, bind(rec), [&ok] { ok = true; },
+                   [](const QString&) { QFAIL("unexpected failure"); });
+
+    AWAIT(ok, 5000);
+    QCOMPARE(rec.attemptedNames(), QStringList({"alpha", "beta", "gamma"}));
+}
+
+void CoreDependencyLoaderTest::runsOffTheCallingThread()
+{
+    Recorder rec;
+    CoreDependencyLoader loader;
+
+    bool ok = false;
+    loader.enqueue({"alpha", "beta"}, {}, bind(rec), [&ok] { ok = true; }, [](const QString&) {});
+    AWAIT(ok, 5000);
+
+    const QSet<QThread*> used = rec.usedThreads();
+    QCOMPARE(used.size(), 1);
+    QVERIFY2(!used.contains(QThread::currentThread()),
+             "dependencies must not load on the caller's thread");
+}
+
+void CoreDependencyLoaderTest::reportsBackOnTheCallingThread()
+{
+    Recorder rec;
+    CoreDependencyLoader loader;
+
+    QThread* successThread = nullptr;
+    QThread* failureThread = nullptr;
+
+    bool ok = false;
+    loader.enqueue({"alpha"}, {}, bind(rec), [&] { successThread = QThread::currentThread(); ok = true; },
+                   [](const QString&) {});
+    AWAIT(ok, 5000);
+
+    rec.failing = {"beta"};
+    bool failed = false;
+    loader.enqueue({"beta"}, {}, bind(rec), [] { QFAIL("unexpected success"); },
+                   [&](const QString&) { failureThread = QThread::currentThread(); failed = true; });
+    AWAIT(failed, 5000);
+
+    QCOMPARE(successThread, QThread::currentThread());
+    QCOMPARE(failureThread, QThread::currentThread());
+}
+
+void CoreDependencyLoaderTest::doesNotBlockTheCallingThread()
+{
+    Recorder rec;
+    rec.delayMs = 120;                      // stand-in for a subprocess spawn
+    CoreDependencyLoader loader;
+
+    bool ok = false;
+    QElapsedTimer enqueueTimer;
+    enqueueTimer.start();
+    loader.enqueue({"alpha", "beta", "gamma"}, {}, bind(rec), [&ok] { ok = true; }, [](const QString&) {});
+    const qint64 enqueueMs = enqueueTimer.elapsed();
+
+    // The caller returns immediately...
+    QVERIFY2(enqueueMs < 50, qPrintable(QStringLiteral("enqueue() blocked for %1 ms")
+                                            .arg(enqueueMs)));
+
+    // ...and its event loop keeps running while the loads are in flight, which
+    // is what lets the spinner animate instead of freezing.
+    int ticks = 0;
+    QTimer ticker;
+    connect(&ticker, &QTimer::timeout, [&ticks] { ++ticks; });
+    ticker.start(10);
+
+    AWAIT(ok, 5000);
+    QVERIFY2(ticks > 0, "the caller's event loop stalled while dependencies loaded");
+}
+
+void CoreDependencyLoaderTest::stopsAtTheFirstFailure()
+{
+    Recorder rec;
+    rec.failing = {"beta"};
+    CoreDependencyLoader loader;
+
+    QString reported;
+    bool failed = false;
+    loader.enqueue({"alpha", "beta", "gamma"}, {}, bind(rec), [] { QFAIL("unexpected success"); },
+                   [&](const QString& name) { reported = name; failed = true; });
+
+    AWAIT(failed, 5000);
+    QCOMPARE(reported, QStringLiteral("beta"));
+    QCOMPARE(rec.attemptedNames(), QStringList({"alpha", "beta"}));
+}
+
+void CoreDependencyLoaderTest::runsBatchesInSubmissionOrder()
+{
+    Recorder rec;
+    CoreDependencyLoader loader;
+
+    int done = 0;
+    loader.enqueue({"first"}, {}, bind(rec), [&done] { ++done; }, [](const QString&) {});
+    loader.enqueue({"second"}, {}, bind(rec), [&done] { ++done; }, [](const QString&) {});
+
+    AWAIT(done == 2, 5000);
+    QCOMPARE(rec.attemptedNames(), QStringList({"first", "second"}));
+}
+
+void CoreDependencyLoaderTest::ownerThreadWorkPostedByALoadRunsBeforeTheCallback()
+{
+    // The invariant PluginLoader depends on. logos_core_load_module POSTS its
+    // capability-module registration to the owner thread (runOnOwner) rather
+    // than running it inline when called off that thread. onSuccess is posted
+    // after all of them, so it must be delivered last — otherwise a ui-host
+    // spawned from onSuccess could call a dependency that is not registered
+    // yet and be refused.
+    QStringList order;
+    CoreDependencyLoader loader;
+    auto poster = [this, &order](const QString& name, bool) {
+        QMetaObject::invokeMethod(this, [&order, name] {
+            order << QStringLiteral("registered:") + name;
+        }, Qt::QueuedConnection);
+        return true;
+    };
+
+    bool ok = false;
+    loader.enqueue({"alpha", "beta"}, {}, poster, [&] { order << QStringLiteral("callback"); ok = true; },
+                   [](const QString&) { QFAIL("unexpected failure"); });
+
+    AWAIT(ok, 5000);
+    QCOMPARE(order, QStringList({QStringLiteral("registered:alpha"),
+                                 QStringLiteral("registered:beta"),
+                                 QStringLiteral("callback")}));
+}
+
+void CoreDependencyLoaderTest::optionalDependenciesLoadAfterTheRequiredOnes()
+{
+    Recorder rec;
+    CoreDependencyLoader loader;
+
+    bool ok = false;
+    loader.enqueue({"req1", "req2"}, {"opt1", "opt2"}, bind(rec),
+                   [&ok] { ok = true; }, [](const QString&) { QFAIL("unexpected failure"); });
+
+    AWAIT(ok, 5000);
+    QCOMPARE(rec.attemptedNames(), QStringList({"req1", "req2", "opt1", "opt2"}));
+    QCOMPARE(rec.flags(), QList<bool>({true, true, false, false}));
+}
+
+void CoreDependencyLoaderTest::anOptionalFailureDoesNotFailTheBatch()
+{
+    // A plugin that does not REQUIRE a module must still mount when it is
+    // absent -- and the ones after it must still be tried.
+    Recorder rec;
+    rec.failing = {"opt1"};
+    CoreDependencyLoader loader;
+
+    bool ok = false;
+    loader.enqueue({"req1"}, {"opt1", "opt2"}, bind(rec),
+                   [&ok] { ok = true; },
+                   [](const QString&) { QFAIL("an optional failure must not fail the batch"); });
+
+    AWAIT(ok, 5000);
+    QCOMPARE(rec.attemptedNames(), QStringList({"req1", "opt1", "opt2"}));
+}
+
+void CoreDependencyLoaderTest::optionalsAreSkippedWhenARequiredOneFails()
+{
+    // The plugin is not going to mount, so its optional collaborators are work
+    // nobody asked for.
+    Recorder rec;
+    rec.failing = {"req1"};
+    CoreDependencyLoader loader;
+
+    QString reported;
+    bool failed = false;
+    loader.enqueue({"req1", "req2"}, {"opt1"}, bind(rec),
+                   [] { QFAIL("unexpected success"); },
+                   [&](const QString& n) { reported = n; failed = true; });
+
+    AWAIT(failed, 5000);
+    QCOMPARE(reported, QStringLiteral("req1"));
+    QCOMPARE(rec.attemptedNames(), QStringList({"req1"}));
+}
+
+void CoreDependencyLoaderTest::joinsItsWorkerOnDestruction()
+{
+    // The worker lambda reads state owned outside it, so the destructor must
+    // join rather than detach.
+    Recorder rec;
+    rec.delayMs = 50;
+    {
+        CoreDependencyLoader loader;
+        loader.enqueue({"alpha", "beta"}, {}, bind(rec), [] {}, [](const QString&) {});
+        QCoreApplication::processEvents();   // let the batch reach the worker
+    }
+
+    // Past the destructor the attempt list is final: nothing is still running.
+    const QStringList settled = rec.attemptedNames();
+    QThread::msleep(300);                    // well past both 50 ms loads
+    QCOMPARE(rec.attemptedNames(), settled);
+}
+
+QTEST_MAIN(CoreDependencyLoaderTest)
+#include "core_dependency_loader_test.moc"


### PR DESCRIPTION
Clicking an app tile froze the UI until every core dependency had loaded — and the freeze landed *before* the spinner appeared, rather than under it. Two independent causes, both fixed here.

## 1. The dependency loop ran on the GUI thread

`PluginLoader::loadCoreDependencies` was a plain `for` over the declared dependencies, each a blocking `logos_core_load_module` that spawns a subprocess and waits for its verdict (~35 ms warm, ~150 ms cold). New `CoreDependencyLoader` (80 lines) owns one `QThread` and runs the batch off the GUI thread, reporting back on the owner's thread.

This is safe by contract as of the pinned liblogos. `logos_core.h` documents core's outbound calls as marshalled to the thread that called `logos_core_start()`, so an off-thread load neither strands Qt objects on a dying worker nor deadlocks against the owner.

**The ordering that keeps it correct.** An off-thread load *posts* its capability-module registration to the owner thread as it goes, and the completion callback is posted after all of them — so `continueLoad`, which admits the consumer and spawns a ui-host whose plugin ctors call out immediately, still finds every dependency registered. That is asserted rather than assumed: `ownerThreadWorkPostedByALoadRunsBeforeTheCallback`.

Deliberately conservative: one worker, batches sequential, a single request's dependencies still in declaration order — same semantics as the loop it replaces, only off the GUI thread. Per-dependency parallelism is a further step; liblogos does support concurrent loads of different modules.

## 2. The yield meant to paint the spinner first didn't

```cpp
// Yield to the event loop so the UI can paint the loading state
QTimer::singleShot(0, this, [this, request]() { startLoad(request); });
```

The comment was wrong. Measured on Qt 6.9.2, with a QQuickWidget bound to a property flipped immediately before the yield:

| yield before the blocking work | frames painted |
|---|---|
| `singleShot(0)` — what shipped | **0** |
| `singleShot(0)` × 2, 3, 4 nested | **0** (all still fire at 0 ms) |
| `singleShot(1)` | **0** |
| `singleShot(16)` / 33 / 50 | 1 (paint at 7–11 ms) |

Zero timers all drain in the same event-loop pass, so nesting buys nothing; a QQuickWidget's first paint after a property change lands one display frame later, on the compositor's cadence rather than the posted-event queue. Now sized to `QScreen::refreshRate()`, clamped to [16, 50] ms — 17 ms at 120 Hz, where the paint lands at 7–8 ms.

Note this bug predates the release: the ineffective yield was already there at `0.2.3`. Only the duration of the block behind it grew.

## Testing

- `tests/core_dependency_loader_test.cpp`, 8 cases. **Positive control:** the two behavioural ones (`runsOffTheCallingThread`, `doesNotBlockTheCallingThread`) were run against an inline `enqueue` and go red — *"enqueue() blocked for 369 ms"*, which is the freeze itself.
- `nix build .#unit-tests` — 22/22.
- `nix build .#smoke-test` — passes.
- **End-to-end**, portable build against a populated user dir: six apps launched (`blockchain_ui`, `chat_ui`, `chat_ui_mix`, `lez_explorer_ui`, `lez_wallet_ui`, `storage_ui`), zero failures, zero timeouts, zero error-level lines. The dependency-before-admission ordering held on every launch — for `chat_ui` (two dependencies, 72 ms span): dep-loaded → dep-registered → dep-loaded → dep-registered → APP-ADMITTED.

## Not in scope

Two paths stay synchronous on the GUI thread: the Modules-tab Load button (`UIPluginManager::loadCoreModule`), and `admitConsumer`'s capability RPC in `continueLoad` — the latter is once per plugin per session, since `m_consumers` caches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)