### PR TITLE
Windows: a GUI-subsystem app, and an installer with a portable mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,47 +107,16 @@ jobs:
           nix build .#packages.x86_64-windows.symbol-gate -L
           nix build .#packages.x86_64-windows.symbol-gate-negative -L
 
-      - name: Build the Windows bundle
-        run: nix build .#packages.x86_64-windows.bin-bundle-dir -L
-
-      # `zip`, not tar.gz: this is the one artifact here whose users are on
-      # Windows, where Explorer opens a .zip and nothing opens a .tar.gz.
-      #
-      # -r through `result/` DEREFERENCES: the bundle's DLLs are symlinks into
-      # the nix store, and an archive of dangling links extracts to a tree that
-      # cannot start. nix-bundle-lgx shipped exactly that bug -- `cp -a` implied
-      # --no-dereference, the payload lost 75% of its files, and the step exited
-      # 0. The count assertion below is why it cannot recur silently.
-      - name: Package the bundle as a zip
-        run: |
-          set -euo pipefail
-          src=$(readlink -f result)
-          staged=$(find -L "$src" -type f | wc -l | tr -d ' ')
-          [ "$staged" -gt 0 ] || { echo "::error::the bundle is empty"; exit 1; }
-          mkdir -p pkg/logos-basecamp
-          # --no-preserve=mode is load-bearing: store dirs are r-xr-xr-x, and
-          # copying that leaves a pkg/ tree nothing can later unlink.
-          cp -rL --no-preserve=mode,ownership "$src"/. pkg/logos-basecamp/
-          ( cd pkg && zip -qr ../logos-basecamp-x86_64-windows.zip logos-basecamp )
-          zipped=$(unzip -l logos-basecamp-x86_64-windows.zip | tail -1 | awk '{print $2}')
-          echo "bundle $staged file(s) -> zip $zipped entr(ies)"
-          # A dropped symlink is invisible in an exit code. Compare the counts.
-          if [ "$zipped" -lt "$staged" ]; then
-            echo "::error::the zip holds $zipped entries but the bundle has $staged files."
-            echo "::error::Something was not dereferenced; the extracted tree would be"
-            echo "::error::missing DLLs and could not start."
-            exit 1
-          fi
-          # A PE with no .exe is a bundle nobody can run.
-          n_exe=$(find pkg -name '*.exe' | wc -l | tr -d ' ')
-          [ "$n_exe" -gt 0 ] || { echo "::error::no .exe in the bundle"; exit 1; }
-          echo "exe(s): $n_exe"
-
-      # Wraps the SAME bundle the zip step above just realised, so this costs
-      # only the makensis run. The installer carries a Windows-GUI subsystem
-      # assertion on LogosBasecamp.exe -- see nix/windows-installer.nix -- which
-      # is the one place a regression to a console build gets caught, since CI
-      # never runs the binary.
+      # The installer is the only Windows artifact. It builds bin-bundle-dir
+      # transitively, so dropping the separate bundle + zip steps costs no
+      # coverage: the two assertions the zip step carried -- that the tree was
+      # DEREFERENCED (its DLLs are symlinks into the nix store, and an archive
+      # of dangling links extracts to a tree that cannot start) and that it
+      # holds a runnable .exe -- moved into nix/windows-installer.nix, where
+      # they now run on every `nix build` rather than only here. That file also
+      # asserts LogosBasecamp.exe is subsystem 00000002: CI cross-builds this
+      # and never runs it, so a build-time check is the only signal a
+      # regression to a console-subsystem image would produce.
       - name: Build the Windows installer
         run: nix build .#packages.x86_64-windows.bin-installer -L -o result-installer
 
@@ -160,9 +129,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64
-          path: |
-            logos-basecamp-x86_64-windows.zip
-            *-setup.exe
+          path: '*-setup.exe'
 
   build-macos-app:
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
@@ -394,5 +361,4 @@ jobs:
           files: |
             artifacts/*.AppImage
             artifacts/*.app.tar.gz
-            artifacts/*-windows.zip
             artifacts/*-setup.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -143,10 +143,26 @@ jobs:
           [ "$n_exe" -gt 0 ] || { echo "::error::no .exe in the bundle"; exit 1; }
           echo "exe(s): $n_exe"
 
+      # Wraps the SAME bundle the zip step above just realised, so this costs
+      # only the makensis run. The installer carries a Windows-GUI subsystem
+      # assertion on LogosBasecamp.exe -- see nix/windows-installer.nix -- which
+      # is the one place a regression to a console build gets caught, since CI
+      # never runs the binary.
+      - name: Build the Windows installer
+        run: nix build .#packages.x86_64-windows.bin-installer -L -o result-installer
+
+      - name: Stage the installer
+        run: |
+          set -euo pipefail
+          cp -L result-installer/*-setup.exe .
+          ls -la ./*-setup.exe
+
       - uses: actions/upload-artifact@v4
         with:
           name: windows-x86_64
-          path: logos-basecamp-x86_64-windows.zip
+          path: |
+            logos-basecamp-x86_64-windows.zip
+            *-setup.exe
 
   build-macos-app:
     environment: ${{ github.ref == 'refs/heads/master' && 'public-cache' || '' }}
@@ -379,3 +395,4 @@ jobs:
             artifacts/*.AppImage
             artifacts/*.app.tar.gz
             artifacts/*-windows.zip
+            artifacts/*-setup.exe

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -344,6 +344,17 @@ qt_add_executable(LogosBasecamp
     ${PROJECT_SOURCES}
 )
 
+if(WIN32)
+    # Without this the PE links as Windows CUI and the OS hands the process a
+    # console window before main() runs -- so a user who double-clicks the app
+    # gets a terminal that then sits behind the GUI for the whole session.
+    #
+    # Also the switch that gives the image an entry point: Qt6::Core links
+    # Qt6::EntryPointPrivate (which supplies the WinMain that calls main())
+    # under $<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>> and nowhere else.
+    set_target_properties(LogosBasecamp PROPERTIES WIN32_EXECUTABLE TRUE)
+endif()
+
 # The UI shell's seven qt_add_qml_module targets live in ../src. They are STATIC
 # modules registering their types from a static initializer, so they link into
 # the main_ui plugin — the image that loads the QML — not this executable.

--- a/app/utils/LogSink.cpp
+++ b/app/utils/LogSink.cpp
@@ -189,6 +189,18 @@ bool LogSink::start(const Options& opts)
         m_linkPath.clear();
     };
 
+#ifdef Q_OS_WIN
+    // A GUI-subsystem process started without a console has no stdio at all:
+    // the CRT leaves stdout/stderr at _NO_CONSOLE_FILENO (-2), so the dup below
+    // fails, start() returns false and the app runs with NO file logging --
+    // silently, because the only channel that could have said so is the one
+    // that is missing. Bind them to NUL so the redirect has a real fd to take
+    // over; the mirror at the bottom of the reader then writes to NUL, which is
+    // where a console-less process's terminal output was going anyway.
+    if (::_fileno(stdout) < 0) ::freopen("NUL", "w", stdout);
+    if (::_fileno(stderr) < 0) ::freopen("NUL", "w", stderr);
+#endif
+
     m_originalStdout = ::dup(fileno(stdout));
     m_originalStderr = ::dup(fileno(stderr));
     if (m_originalStdout < 0 || m_originalStderr < 0) {

--- a/flake.lock
+++ b/flake.lock
@@ -12,11 +12,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788471596,
-        "narHash": "sha256-ru7kJXaakp4TV6Gu67RSFBtivPukOqQ77Z0Htoaj9TA=",
+        "lastModified": 1789077426,
+        "narHash": "sha256-ZHkDEiEt8FE+59I7y2/5rfxV4RcDmUVCRmTmqx22KuA=",
         "owner": "logos-co",
         "repo": "logos-container-subprocess",
-        "rev": "24e103a3a1a24e8fd639e8ee58ea999b229f3dd5",
+        "rev": "1919ef3509147f058cd8e18d41f074af51b97362",
         "type": "github"
       },
       "original": {
@@ -5373,11 +5373,11 @@
         "process-stats": "process-stats_2"
       },
       "locked": {
-        "lastModified": 1788908252,
-        "narHash": "sha256-qXgKzrpzpkkkkNnl5CsiQv2MkxYfhJeIIOx7UofB8+E=",
+        "lastModified": 1789085774,
+        "narHash": "sha256-kSO/GYuPxaia4Ui8WAWHBP4jaLc0JrYMpYNlMCUcxUk=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "209e9824e1f867a761a37c8c04df44cd310f6d52",
+        "rev": "9ad7920088d77734c13d0efe916de4aec0b97b3f",
         "type": "github"
       },
       "original": {
@@ -51643,11 +51643,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788814481,
-        "narHash": "sha256-Eq6kiB04ErzzBzNjCzV7+oGaZVi25Xb+I6g3/zf/8qs=",
+        "lastModified": 1789077450,
+        "narHash": "sha256-tOOJTW9zHAIDyEamDoMYGEiz9AI66kwdRPvF1SHGNwE=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "318977b5b8ddc3edbbd7df7d6a1f14375ad8178c",
+        "rev": "7eeae34241853b6c185e8e59d226b614cd0610c3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -179,10 +179,14 @@
         installDev = nix-bundle-logos-module-install.bundlers.${system}.dev;
         installPortable = nix-bundle-logos-module-install.bundlers.${system}.portable;
         dirBundler = nix-bundle-dir.bundlers.${buildSystem}.qtApp;
+        # Plain nixpkgs, not the logos-nix-overlaid `pkgs` above: the only
+        # consumer is nix/windows-installer.nix, whose three tools (makensis,
+        # imagemagick, binutils) the overlay does not touch.
+        buildPkgs = nixpkgs.legacyPackages.${buildSystem};
       });
     in
     {
-      packages = forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, ... }:
+      packages = forAllSystems ({ pkgs, system, logosSdk, logosSdkBuild, logosProtocolPkg, logosQtHost, logosQtSdk, logosModule, logosLiblogos, logosLiblogosPortable, logosPackageManagerLibrary, logosPackageManagerModule, logosPackageManagerModuleLib, logosPackageManagerModuleLibPortable, logosPackageDownloaderModule, logosPackageDownloaderModuleLib, logosPackageLib, logosPackageHeaders, logosPackageManagerUI, logosCapabilityModule, logosModulesStateModule, logosDesignSystem, logosViewModuleRuntime, logosQtMcp, installDev, installPortable, dirBundler, buildPkgs, ... }:
         let
           # Common configuration
           common = import ./nix/default.nix {
@@ -424,6 +428,18 @@
           #    is an x86_64-linux derivation, so it cannot run on an
           #    aarch64-darwin host without one.)
           binBundleDir = withMainProgram (dirBundler appDistributed);
+
+          # The Windows installer wraps the SAME tree bin-bundle-dir ships --
+          # it is a delivery format, not a second build. Its two modes (install
+          # / extract-only) therefore carry identical bits, which is the only
+          # thing that could be true here: portable is compile-time on Windows
+          # (LOGOS_PORTABLE_BUILD) and appDistributed already chose it.
+          windowsInstaller = import ./nix/windows-installer.nix {
+            pkgs = buildPkgs;
+            bundle = binBundleDir;
+            version = common.version;
+            icon = ./app/icons/logos.png;
+          };
           binBundleDirMock = withMainProgram (dirBundler appMockPortable);
           binBundleDirInspector = withMainProgram (dirBundler appDistributedWithInspector);
 
@@ -580,6 +596,9 @@
 
           # Default package
           default = app;
+        } // pkgs.lib.optionalAttrs pkgs.stdenv.hostPlatform.isWindows {
+          # nix build .#packages.x86_64-windows.bin-installer
+          bin-installer = windowsInstaller;
         } // pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           bin-appimage = nix-bundle-appimage.lib.${system}.mkAppImage {
             drv = appDistributed;

--- a/nix/nsis/logos-basecamp.nsi
+++ b/nix/nsis/logos-basecamp.nsi
@@ -1,0 +1,240 @@
+; Windows installer for Logos Basecamp.
+;
+; ONE binary, TWO modes, chosen on the first page:
+;   install   -- per-user tree under %LOCALAPPDATA%\Programs, Start Menu entry,
+;                uninstaller registered in Add/Remove Programs
+;   portable  -- the same files extracted to a folder of the user's choosing,
+;                with no shortcut, no registry key and no uninstaller
+;
+; The two modes ship IDENTICAL bits. There is no portable/dev split to make
+; here: on Windows that distinction is compile-time (LOGOS_PORTABLE_BUILD), and
+; the bundle this wraps is already the portable variant.
+;
+; Per-user, never Program Files, and that is load-bearing rather than a
+; courtesy: Basecamp installs modules at runtime through lgpm, into its own
+; tree. An admin-owned Program Files install would make every such install fail
+; for the user who is running it.
+
+Unicode true
+ManifestDPIAware true
+
+; 9000 fires because the output is named ...-setup.exe, which puts Windows'
+; installer-detection heuristic in play. Suppressed rather than renamed: that
+; heuristic only AUTO-ELEVATES an image carrying no requestedExecutionLevel,
+; and RequestExecutionLevel below writes one. What is left is the AppCompat
+; shim load, which every conventionally-named installer takes.
+!pragma warning disable 9000
+SetCompressor /SOLID lzma
+SetCompressorDictSize 64
+
+!include "MUI2.nsh"
+!include "nsDialogs.nsh"
+!include "LogicLib.nsh"
+!include "FileFunc.nsh"
+
+!define REGROOT   "Software\${APPNAME}"
+!define UNINSTKEY "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+
+Name    "${APPNAME} ${APPVERSION}"
+OutFile "${OUTFILE}"
+BrandingText "${APPNAME} ${APPVERSION}"
+RequestExecutionLevel user
+InstallDir "$LOCALAPPDATA\Programs\${APPNAME}"
+ShowInstDetails show
+ShowUninstDetails show
+
+VIProductVersion "${APPVERSION_QUAD}"
+VIAddVersionKey "ProductName"     "${APPNAME}"
+VIAddVersionKey "ProductVersion"  "${APPVERSION}"
+VIAddVersionKey "FileVersion"     "${APPVERSION}"
+VIAddVersionKey "CompanyName"     "${APPPUBLISHER}"
+VIAddVersionKey "LegalCopyright"  "${APPPUBLISHER}"
+VIAddVersionKey "FileDescription" "${APPNAME} installer"
+
+Var Portable          ; 1 = extract only, 0 = install
+Var WantDesktopIcon
+Var RadioInstall
+Var RadioPortable
+Var CheckDesktop
+
+!define MUI_ICON   "${APPICON}"
+!define MUI_UNICON "${APPICON}"
+!define MUI_ABORTWARNING
+
+!insertmacro MUI_PAGE_WELCOME
+Page custom ModePageCreate ModePageLeave
+!define MUI_PAGE_CUSTOMFUNCTION_PRE DirectoryPagePre
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_INSTFILES
+!define MUI_FINISHPAGE_RUN "$INSTDIR\bin\${APPEXE}"
+!define MUI_FINISHPAGE_RUN_TEXT "Run ${APPNAME}"
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+Function .onInit
+    StrCpy $Portable 0
+    StrCpy $WantDesktopIcon 1
+FunctionEnd
+
+; Windows keeps a running image open for read and delete but NOT for write, so
+; an append open is a plugin-free in-use test. Worth the lines: RMDir /r deletes
+; what it can and still reports success, so uninstalling over a running app
+; leaves a half-removed tree behind an exit code of 0. Measured -- 1825 files
+; survived, status 0. Installing over one produces a mixed tree the same way.
+!macro RefuseIfRunning UN
+Function ${UN}RefuseIfRunning
+    ${IfNot} ${FileExists} "$INSTDIR\bin\${APPEXE}"
+        Return
+    ${EndIf}
+    ClearErrors
+    FileOpen $0 "$INSTDIR\bin\${APPEXE}" a
+    ${If} ${Errors}
+        ${IfNot} ${Silent}
+            MessageBox MB_ICONSTOP \
+                "${APPNAME} is still running. Close it and run this again."
+        ${EndIf}
+        DetailPrint "${APPNAME} is running; nothing was changed."
+        SetErrorLevel 1
+        Abort
+    ${EndIf}
+    FileClose $0
+FunctionEnd
+!macroend
+!insertmacro RefuseIfRunning ""
+!insertmacro RefuseIfRunning "un."
+
+; ---------------------------------------------------------------------------
+; Mode page
+; ---------------------------------------------------------------------------
+Function ModePageCreate
+    !insertmacro MUI_HEADER_TEXT "Installation type" \
+        "Choose how ${APPNAME} should be put on this machine."
+    nsDialogs::Create 1018
+    Pop $0
+    ${If} $0 == error
+        Abort
+    ${EndIf}
+
+    ${NSD_CreateRadioButton} 0 0 100% 12u "&Install (recommended)"
+    Pop $RadioInstall
+    ${NSD_CreateLabel} 12u 14u 94% 26u \
+        "Installs for the current user only -- no administrator prompt. Adds a \
+Start Menu entry and an uninstaller listed in Add or remove programs."
+
+    ${NSD_CreateRadioButton} 0 46u 100% 12u "&Portable (extract only)"
+    Pop $RadioPortable
+    ${NSD_CreateLabel} 12u 60u 94% 26u \
+        "Unpacks the same files to a folder you choose and stops there: no \
+shortcut, no registry entry, no uninstaller. Delete the folder to remove it."
+
+    ${NSD_CreateCheckBox} 0 96u 100% 12u "Create a &desktop shortcut"
+    Pop $CheckDesktop
+
+    ${If} $Portable == 1
+        ${NSD_SetState} $RadioPortable ${BST_CHECKED}
+    ${Else}
+        ${NSD_SetState} $RadioInstall ${BST_CHECKED}
+    ${EndIf}
+    ${NSD_SetState} $CheckDesktop $WantDesktopIcon
+    ${NSD_OnClick} $RadioInstall  ModeChanged
+    ${NSD_OnClick} $RadioPortable ModeChanged
+    Call ModeChanged
+
+    nsDialogs::Show
+FunctionEnd
+
+; The desktop-shortcut box is meaningless in portable mode -- that mode's whole
+; contract is that it writes nothing outside the folder.
+Function ModeChanged
+    ${NSD_GetState} $RadioPortable $0
+    ${If} $0 == ${BST_CHECKED}
+        EnableWindow $CheckDesktop 0
+    ${Else}
+        EnableWindow $CheckDesktop 1
+    ${EndIf}
+FunctionEnd
+
+Function ModePageLeave
+    ${NSD_GetState} $RadioPortable $Portable
+    ${NSD_GetState} $CheckDesktop  $WantDesktopIcon
+    ${If} $Portable == ${BST_CHECKED}
+        StrCpy $Portable 1
+        StrCpy $INSTDIR "$DESKTOP\${APPNAME}"
+    ${Else}
+        StrCpy $Portable 0
+        StrCpy $INSTDIR "$LOCALAPPDATA\Programs\${APPNAME}"
+    ${EndIf}
+FunctionEnd
+
+Function DirectoryPagePre
+    ${If} $Portable == 1
+        !insertmacro MUI_HEADER_TEXT "Choose a folder" \
+            "${APPNAME} will be extracted here and will write nothing else."
+    ${EndIf}
+FunctionEnd
+
+; ---------------------------------------------------------------------------
+Section "${APPNAME}" SecMain
+    Call RefuseIfRunning
+    SetOutPath "$INSTDIR"
+    File /r "${STAGEDIR}/*"
+    File "/oname=${APPNAME}.ico" "${APPICON}"
+
+    ${If} $Portable == 1
+        DetailPrint "Portable extraction -- no shortcuts, registry keys or uninstaller written."
+        Return
+    ${EndIf}
+
+    CreateShortcut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\bin\${APPEXE}" "" \
+                   "$INSTDIR\${APPNAME}.ico"
+    ${If} $WantDesktopIcon == ${BST_CHECKED}
+        CreateShortcut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\bin\${APPEXE}" "" \
+                       "$INSTDIR\${APPNAME}.ico"
+    ${EndIf}
+
+    WriteUninstaller "$INSTDIR\Uninstall.exe"
+    WriteRegStr HKCU "${REGROOT}" "InstallDir" "$INSTDIR"
+
+    ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+    WriteRegStr   HKCU "${UNINSTKEY}" "DisplayName"     "${APPNAME}"
+    WriteRegStr   HKCU "${UNINSTKEY}" "DisplayVersion"  "${APPVERSION}"
+    WriteRegStr   HKCU "${UNINSTKEY}" "Publisher"       "${APPPUBLISHER}"
+    WriteRegStr   HKCU "${UNINSTKEY}" "DisplayIcon"     "$INSTDIR\${APPNAME}.ico"
+    WriteRegStr   HKCU "${UNINSTKEY}" "InstallLocation" "$INSTDIR"
+    WriteRegStr   HKCU "${UNINSTKEY}" "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+    WriteRegStr   HKCU "${UNINSTKEY}" "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
+    WriteRegDWORD HKCU "${UNINSTKEY}" "EstimatedSize"   "$0"
+    WriteRegDWORD HKCU "${UNINSTKEY}" "NoModify"        1
+    WriteRegDWORD HKCU "${UNINSTKEY}" "NoRepair"        1
+SectionEnd
+
+Section "Uninstall"
+    ; Refuse to recurse through a directory that is not ours. $INSTDIR comes
+    ; from the registry, and RMDir /r on a wrong one is unrecoverable.
+    ${IfNot} ${FileExists} "$INSTDIR\bin\${APPEXE}"
+        ; Never a dialog under /S. NSIS does not suppress MessageBox in silent
+        ; mode, and Add/Remove Programs can invoke a quiet uninstall with no
+        ; desktop to draw on -- the box would then block forever, invisibly.
+        ${IfNot} ${Silent}
+            MessageBox MB_ICONSTOP \
+                "$INSTDIR does not look like a ${APPNAME} installation; nothing was removed."
+        ${EndIf}
+        DetailPrint "$INSTDIR is not a ${APPNAME} installation; nothing removed."
+        Abort
+    ${EndIf}
+    Call un.RefuseIfRunning
+
+    Delete "$SMPROGRAMS\${APPNAME}.lnk"
+    Delete "$DESKTOP\${APPNAME}.lnk"
+    RMDir /r "$INSTDIR"
+    DeleteRegKey HKCU "${UNINSTKEY}"
+    DeleteRegKey HKCU "${REGROOT}"
+
+    ; %APPDATA%\${APPNAME} is deliberately left alone: it holds the user's
+    ; logs, installed modules and module data, and an uninstall is not a
+    ; request to lose them.
+SectionEnd

--- a/nix/windows-installer.nix
+++ b/nix/windows-installer.nix
@@ -1,0 +1,95 @@
+# NSIS installer for a bundled Windows Basecamp tree.
+#
+# `pkgs` is the BUILD system's, never the target's. makensis, objdump and the
+# icon conversion RUN on the builder, so reaching for packages.x86_64-windows
+# here would put a PE where a native binary has to execute -- the same rule lgx
+# and nix-bundle-dir already follow.
+#
+# Deliberately kept in this repo rather than started as a sibling of
+# nix-bundle-appimage / nix-bundle-macos-app: Basecamp is the only consumer
+# today. It is written as a plain function over `bundle` so that lifting it into
+# a nix-bundle-nsis flake later is a move rather than a rewrite.
+{ pkgs
+, bundle
+, version
+, name ? "Logos Basecamp"
+, exeName ? "LogosBasecamp.exe"
+, publisher ? "Logos"
+, icon
+}:
+
+let
+  # A Windows file name has no room for the space in `name`, and this is the
+  # string a user downloads and later searches for.
+  slug = "logos-basecamp";
+in
+pkgs.runCommand "${slug}-installer-${version}"
+  {
+    nativeBuildInputs = [ pkgs.nsis pkgs.imagemagick pkgs.binutils ];
+    meta.description = "Windows installer for ${name} ${version}";
+  }
+  ''
+    set -eo pipefail
+    mkdir -p "$out"
+
+    # -L DEREFERENCES, and that is the whole ballgame. A third of the bundle's
+    # bin/ reaches its DLLs through symlinks into /nix/store; an installer built
+    # over those links ships a tree that dies with 0xC0000135 before main(),
+    # with no output at all. It is the same failure nix-bundle-lgx once shipped
+    # by letting `cp -a` imply --no-dereference.
+    stage="$PWD/stage"
+    mkdir -p "$stage"
+    cp -rL --no-preserve=mode,ownership ${bundle}/. "$stage/"
+
+    staged=$(find "$stage" -type f | wc -l | tr -d ' ')
+    echo "staging $staged file(s) from ${bundle}"
+    [ "$staged" -gt 0 ] || { echo "the bundle staged empty"; exit 1; }
+    [ -f "$stage/bin/${exeName}" ] || {
+      echo "no bin/${exeName} staged; the installer would have nothing to launch"
+      exit 1
+    }
+
+    # The installer's whole user-visible promise is a GUI that opens with no
+    # console behind it, and a CUI image breaks that silently. Assert it where
+    # the artifact is made rather than trusting that a CMake property survived.
+    # Fails closed: a reader that cannot parse the PE yields an empty string,
+    # which is not 00000002 either.
+    subsystem=$(objdump -p "$stage/bin/${exeName}" 2>/dev/null \
+                  | sed -n 's/^Subsystem[[:space:]]*\([0-9]*\).*/\1/p' | head -1)
+    if [ "$subsystem" != "00000002" ]; then
+      echo "${exeName} reports PE subsystem '$subsystem', expected 00000002 (Windows GUI)."
+      echo "A console-subsystem image is handed a console window by the OS before"
+      echo "main() runs. Set WIN32_EXECUTABLE on the target."
+      exit 1
+    fi
+
+    magick ${icon} -define icon:auto-resize=256,128,64,48,32,16 "$PWD/app.ico"
+
+    # VIProductVersion takes exactly four numeric fields, so a tag like
+    # 0.0.0-dev has to be reduced rather than passed through.
+    quad=$(printf '%s' "${version}" | sed 's/[^0-9.].*$//' \
+             | awk -F. '{printf "%d.%d.%d.%d", $1+0, $2+0, $3+0, $4+0}')
+
+    out_exe="$out/${slug}-${version}-x86_64-setup.exe"
+    makensis -V3 \
+      -DAPPNAME="${name}" \
+      -DAPPVERSION="${version}" \
+      -DAPPVERSION_QUAD="$quad" \
+      -DAPPPUBLISHER="${publisher}" \
+      -DAPPEXE="${exeName}" \
+      -DAPPICON="$PWD/app.ico" \
+      -DSTAGEDIR="$stage" \
+      -DOUTFILE="$out_exe" \
+      ${./nsis/logos-basecamp.nsi}
+
+    [ -f "$out_exe" ] || { echo "makensis produced no installer"; exit 1; }
+    size=$(stat -c %s "$out_exe")
+    echo "installer: $(( size / 1024 / 1024 )) MB from $staged staged file(s)"
+    # Solid LZMA over this tree lands near 65 MB. Under 16 means File /r matched
+    # a fraction of it, which makensis reports as success -- a wildcard that
+    # matches SOMETHING is not an error.
+    [ "$size" -gt $((16 * 1024 * 1024)) ] || {
+      echo "installer is only $(( size / 1024 / 1024 )) MB; the payload is short"
+      exit 1
+    }
+  ''

--- a/nix/windows-installer.nix
+++ b/nix/windows-installer.nix
@@ -44,6 +44,17 @@ pkgs.runCommand "${slug}-installer-${version}"
     staged=$(find "$stage" -type f | wc -l | tr -d ' ')
     echo "staging $staged file(s) from ${bundle}"
     [ "$staged" -gt 0 ] || { echo "the bundle staged empty"; exit 1; }
+
+    # Assert the dereference DIRECTLY rather than inferring it from a file
+    # count. A staging that quietly kept links is invisible in an exit code,
+    # and this is the only check standing between that and a shipped installer.
+    links=$(find "$stage" -type l | wc -l | tr -d ' ')
+    [ "$links" -eq 0 ] || {
+      echo "$links symlink(s) survived staging; the installed tree would carry"
+      echo "dangling links into /nix/store and die 0xC0000135 before main()"
+      find "$stage" -type l | head -5
+      exit 1
+    }
     [ -f "$stage/bin/${exeName}" ] || {
       echo "no bin/${exeName} staged; the installer would have nothing to launch"
       exit 1


### PR DESCRIPTION
Two related Windows changes. Launching `LogosBasecamp.exe` opened a console that then sat behind the GUI for the whole session, and the only Windows artifact we publish is a `.zip` of the bundle tree.

## 1. `fix(windows): link LogosBasecamp as a GUI-subsystem PE`

All three shipped PEs were `IMAGE_SUBSYSTEM_WINDOWS_CUI` — measured, not assumed:

```
LogosBasecamp.exe   Subsystem 00000003  (Windows CUI)
logos_host.exe      Subsystem 00000003  (Windows CUI)
ui-host.exe         Subsystem 00000003  (Windows CUI)
```

`WIN32_EXECUTABLE` is also what gives the image an entry point: Qt6Core attaches `Qt6::EntryPointPrivate` — the `WinMain` that calls `main()` — under `$<BOOL:$<TARGET_PROPERTY:WIN32_EXECUTABLE>>` and nowhere else. Nothing extra to link.

**Flipping only this target would make things worse**, which is why two sibling PRs go with it: a parent with no console of its own makes Windows allocate a fresh console — and a console window — for every console-subsystem child. logos-co/logos-container-subprocess#8 (`logos_host`) and logos-co/logos-view-module-runtime#32 (`ui-host`) suppress that at the spawn sites. The children stay CUI deliberately, so running either directly from a terminal still prints.

### The LogSink change is not incidental

`app/utils/LogSink.cpp` captures stdout/stderr through a pipe, starting with `::dup(fileno(stdout))`. A GUI-subsystem process started without a console has **no stdio at all** — the CRT leaves both streams at `_NO_CONSOLE_FILENO` (-2) — so that dup fails, `start()` returns false, and the app runs with **no file logging whatsoever**. Silently, because the only channel that could report it is the one that is missing. Binding the streams to `NUL` first gives the redirect a real fd to take over.

### Measured

Windows 11 26200, four modules loaded. Window *visibility* has to be read from the interactive session (`schtasks /it`) — in session 0 everything reports `visible=False`, and counting `conhost.exe` does not discriminate at all, since `CREATE_NO_WINDOW` allocates a console and only suppresses its window.

| | visible console windows |
|---|---|
| baseline, nothing running | 2 — the user's own Windows Terminal |
| all three changes | **2** — zero from Logos |
| control, children unpatched | **10** |

## 2. `feat(windows): ship an NSIS installer with a portable mode`

Adds `packages.x86_64-windows.bin-installer` and makes it the **only** Windows artifact — the `.zip` of the bundle tree is gone. One binary, two modes chosen on the first page: a per-user install with a Start Menu entry and an uninstaller in Add/Remove Programs, or extract-only to a folder, writing nothing outside it.

| | |
|---|---|
| zip (deflate) — what this replaces | 113 MB |
| tar.xz | 62 MB |
| **NSIS solid LZMA** | **51 MB** |

It beats plain xz because NSIS's datablock optimizer dedupes ~15% before compressing — this tree has many repeated DLLs.

**Per-user (`%LOCALAPPDATA%\Programs`, `RequestExecutionLevel user`) is load-bearing rather than a courtesy**: Basecamp installs modules at runtime through lgpm, into its own tree. An admin-owned Program Files install would make every one of those fail for the user running it.

Both modes carry identical bits, which is the only thing that could be true here — portable is compile-time on Windows (`LOGOS_PORTABLE_BUILD`), and `appDistributed` has already chosen it.

A single-file self-extracting `.exe` was considered and rejected on the numbers: 480 MB / 1724 files unpacked per launch is ~10–20 s and 480 MB of scratch every run.

### Verified on Windows 11 26200

| | |
|---|---|
| silent install | full tree, both shortcuts, complete Add/Remove entry (`EstimatedSize` 475 MB) |
| uninstall | tree, both shortcuts and registry key all gone |
| uninstall while running | refused, exit 1, nothing touched |
| portable mode | files only — no shortcut, no registry key, no uninstaller |

Two defects found by testing rather than by reading:

- **`RMDir /r` deletes what it can and still reports success.** An uninstall over a running Basecamp left 1825 files behind an exit code of 0. Windows keeps a running image open for read and delete but not for write, so an append open on `bin\<exe>` is a plugin-free in-use test.
- **NSIS does not suppress `MessageBox` under `/S`.** A quiet uninstall from Add/Remove Programs would have blocked forever on a dialog with no desktop to draw it. Every `MessageBox` is now guarded with `${IfNot} ${Silent}`.

`nix/windows-installer.nix` asserts `LogosBasecamp.exe` is subsystem `00000002` before it packages anything — CI cross-builds this bundle and never runs it, so a build-time assertion is the only signal a regression to a console image would produce. It also runs `cp -rL`: a third of the bundle's `bin/` reaches its DLLs through symlinks into `/nix/store`, and an installer built over those ships a tree that dies `0xC0000135` before `main()`.

## 3. `ci(windows): publish only the installer`

The zip and the installer carry the same tree, so shipping both asked every Windows user to choose between two downloads of the same thing — and the zip is the worse one: 113 MB against 51 MB, with no shortcut, no uninstaller and no extract-only prompt. The installer's portable mode is what the zip was for.

Nothing outside this workflow consumed that artifact (checked: the only other `download-artifact` in the repo is the doctests workflow pulling its own reports, and a nameless download only sees the same run).

The job loses no coverage. `bin-installer` builds `bin-bundle-dir` transitively, so the separate bundle step was redundant, and the two assertions the zip step carried now live in `nix/windows-installer.nix`, running on every `nix build` rather than only in CI:

- **the tree was dereferenced** — the zip step *inferred* this from a count (`entries >= files`); the nix expression asserts the property itself, that no symlink survived staging. Negative-controlled: seeded with one dangling link, it fires.
- **a runnable `.exe` is present** — stronger there, since it names `bin/LogosBasecamp.exe` rather than accepting any `*.exe` under the tree.

The Windows job is now: symbol gate → build installer → stage → upload.

## 4. `chore(nix): relock for the Windows console fix`

Both sibling PRs are merged, and this commit locks onto them — together, because this repo merging without them is the worst intermediate state: one console window removed, eight added.

- `logos-view-module-runtime` → `7eeae342` (logos-co/logos-view-module-runtime#32) — `ui-host.exe`, staged by `nix/app.nix` straight out of this **direct** input, so no intermediate repo moves.
- `logos-liblogos` → `9ad79200` (logos-co/logos-liblogos#213), and with it transitively `logos-liblogos/default-container` → `1919ef35` (logos-co/logos-container-subprocess#8) — `logos_host.exe` is built by liblogos from its own container input and staged here out of liblogos, so it takes the hop.

`ws update-order` asks for 8 repos; the rest is the module-builder ↔ standalone-app cycle and moves no binary this bundle ships. The stale duplicate nodes (9 `logos-container-subprocess`, 19 `logos-view-module-runtime`) sit on non-load-bearing paths and are left pinned — which is what keeps this to 12 lines.

### Verified end to end

Built before either relock merged, with `--override-input logos-liblogos` pointed at the relocked clone; nix ≥2.26 honours an overridden input's own lock, so it reproduces the post-merge state. liblogos' merge commit has a single parent equal to that clone's base, so nothing landed in between and this measurement describes exactly what is locked here.

Windows 11 26200, installed from this installer, four modules loaded, probing window visibility from the interactive session:

| | visible console windows |
|---|---|
| baseline, nothing running | 2 — the machine's own Windows Terminal |
| **this lock** | **2** — zero from Logos |
| control, children unpatched | 10 |

Four `conhost.exe` are alive in the passing case: the consoles exist and simply have no windows, which is what `CREATE_NO_WINDOW` does. Counting conhosts cannot verify this fix.

Docs: logos-co/logos-tutorial#90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


