### PR TITLE
chore(deps): pick up the catalog fix that dropped whole repositories

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -34081,16 +34081,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1789076288,
+        "lastModified": 1789076965,
         "narHash": "sha256-7F10LKMf0OXNqKQTcKBfgnN8IjGXpMqbZEWKpQ/uihM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "467b4deaa8485dc00eeec12f1cc9443faa47f6d4",
+        "rev": "9a7cdb4f979cb44b4aebe09e6b58c1aa9a58f534",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "fix/catalog-array-valued-provides",
         "repo": "logos-package-downloader",
         "type": "github"
       }
@@ -34101,16 +34100,15 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1789076397,
-        "narHash": "sha256-44Kbq6wBV7R/w9G/0CFKn8Q6YTFYiZw0EsbIIsp6Ljo=",
+        "lastModified": 1789077644,
+        "narHash": "sha256-ROMJ9/nkkU3yNbMua/ebnJ46L3Lno3K71bEVkETH2Ls=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "bcfe61c22a7fd4212dc59bd163e7d4c644eb7de7",
+        "rev": "848e035fac35719ac751b869044ebb9043cfa379",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
-        "ref": "fix/catalog-array-valued-provides",
         "repo": "logos-package-downloader-module",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -34081,15 +34081,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1788902518,
-        "narHash": "sha256-XR7K6WB0NTKm9zZcecXOOAI/jac2B0quQKcQA673JcE=",
+        "lastModified": 1789076288,
+        "narHash": "sha256-7F10LKMf0OXNqKQTcKBfgnN8IjGXpMqbZEWKpQ/uihM=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "c8b22faba75c38629f9c7e928298f15b720df7fa",
+        "rev": "467b4deaa8485dc00eeec12f1cc9443faa47f6d4",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "fix/catalog-array-valued-provides",
         "repo": "logos-package-downloader",
         "type": "github"
       }
@@ -34100,15 +34101,16 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1788903889,
-        "narHash": "sha256-iAYmDNf5zfjkC3c3fMoAKQLJBqF2Yr0b8xcc0MixV1E=",
+        "lastModified": 1789076397,
+        "narHash": "sha256-44Kbq6wBV7R/w9G/0CFKn8Q6YTFYiZw0EsbIIsp6Ljo=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "917cf3cb12a2b0b9f04ecfcb81fdc3402519f1e4",
+        "rev": "bcfe61c22a7fd4212dc59bd163e7d4c644eb7de7",
         "type": "github"
       },
       "original": {
         "owner": "logos-co",
+        "ref": "fix/catalog-array-valued-provides",
         "repo": "logos-package-downloader-module",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,7 @@
     # newer copy can never win on macOS, and package_manager crashes.
     logos-liblogos.inputs.logos-package-manager.follows = "logos-package-manager";
     logos-package-manager-module.url = "github:logos-co/logos-package-manager-module";
-    # TEMPORARY: revert to the bare URL when
-    # logos-co/logos-package-downloader-module#36 merges.
-    logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module?ref=fix/catalog-array-valued-provides";
+    logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
     logos-modules-state-module.url = "github:logos-co/logos-modules-state-module";
     logos-package.url = "github:logos-co/logos-package";

--- a/flake.nix
+++ b/flake.nix
@@ -33,7 +33,9 @@
     # newer copy can never win on macOS, and package_manager crashes.
     logos-liblogos.inputs.logos-package-manager.follows = "logos-package-manager";
     logos-package-manager-module.url = "github:logos-co/logos-package-manager-module";
-    logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module";
+    # TEMPORARY: revert to the bare URL when
+    # logos-co/logos-package-downloader-module#36 merges.
+    logos-package-downloader-module.url = "github:logos-co/logos-package-downloader-module?ref=fix/catalog-array-valued-provides";
     logos-capability-module.url = "github:logos-co/logos-capability-module";
     logos-modules-state-module.url = "github:logos-co/logos-modules-state-module";
     logos-package.url = "github:logos-co/logos-package";


### PR DESCRIPTION
Depends on **logos-co/logos-package-downloader-module#36** → **logos-co/logos-package-downloader#39**.

## What this fixes in the app

A configured, enabled third-party repository rendered **no section at all** in the Applications view. `appendCatalogEntries` read the manifest's `provides` — an array of intent objects — with `value("provides", "")`, nlohmann threw, and the `catch` around the whole package loop discarded every package in that repository. The official catalog carries no `provides`, so only third-party repos were affected.

Nothing surfaced it: `resolveError` stayed empty, `refreshCatalogs` reported success, and `AppRepoSection` hides at `repoFilter.visibleCount === 0`, so the repo vanished rather than showing an empty section.

Measured against a real two-repo config, catalog rows grouped by `repositoryUrl`: 19 + **0** → 19 + **14** (6 of them `ui_qml`).

`flake.nix` carries a temporary `?ref=fix/catalog-array-valued-provides`; revert it to the bare URL and re-lock when #36 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)