### PR TITLE
chore: relock the wave onto the reserved completion channel

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -28,7 +28,7 @@
     "default-container_2": {
       "inputs": {
         "logos-container": "logos-container_6",
-        "logos-nix": "logos-nix_80",
+        "logos-nix": "logos-nix_76",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -57,7 +57,7 @@
     "default-container_3": {
       "inputs": {
         "logos-container": "logos-container_13",
-        "logos-nix": "logos-nix_168",
+        "logos-nix": "logos-nix_164",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -85,7 +85,7 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
-        "logos-nix": "logos-nix_247",
+        "logos-nix": "logos-nix_243",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -113,7 +113,7 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
-        "logos-nix": "logos-nix_299",
+        "logos-nix": "logos-nix_295",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -145,7 +145,7 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
-        "logos-nix": "logos-nix_419",
+        "logos-nix": "logos-nix_415",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -173,7 +173,7 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_33",
-        "logos-nix": "logos-nix_471",
+        "logos-nix": "logos-nix_467",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -205,7 +205,7 @@
     "default-container_8": {
       "inputs": {
         "logos-container": "logos-container_38",
-        "logos-nix": "logos-nix_585",
+        "logos-nix": "logos-nix_581",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -233,7 +233,7 @@
     "default-container_9": {
       "inputs": {
         "logos-container": "logos-container_43",
-        "logos-nix": "logos-nix_637",
+        "logos-nix": "logos-nix_633",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -265,12 +265,21 @@
     "default-module-loader": {
       "inputs": {
         "logos-container": "logos-container_2",
-        "logos-cpp-sdk": "logos-cpp-sdk_4",
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
         "logos-module": "logos-module_6",
         "logos-module-loader": "logos-module-loader",
-        "logos-nix": "logos-nix_34",
-        "logos-protocol": "logos-protocol_6",
-        "logos-qt-sdk": "logos-qt-sdk_3",
+        "logos-nix": "logos-nix_33",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-liblogos",
+          "logos-qt-sdk"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -279,11 +288,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788892274,
-        "narHash": "sha256-MwIDGS/W4Mkz4BTfI2DzJ49oBq/zQHbPkgLejB1emq0=",
+        "lastModified": 1789108040,
+        "narHash": "sha256-3V//OwqhLDNHBAfWkH92dmBAW1xjk01Uts7MdqXc1e4=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "b48871c78369ea664745aa2f3d6ef7a3cfcc3bec",
+        "rev": "1d31cd7099d93fe8db84127118905da65d0bc666",
         "type": "github"
       },
       "original": {
@@ -303,9 +312,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_19",
+        "logos-module": "logos-module_18",
         "logos-module-loader": "logos-module-loader_3",
-        "logos-nix": "logos-nix_84",
+        "logos-nix": "logos-nix_80",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -357,9 +366,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_38",
+        "logos-module": "logos-module_37",
         "logos-module-loader": "logos-module-loader_6",
-        "logos-nix": "logos-nix_172",
+        "logos-nix": "logos-nix_168",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -401,12 +410,12 @@
     "default-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_19",
-        "logos-cpp-sdk": "logos-cpp-sdk_22",
-        "logos-module": "logos-module_54",
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-module": "logos-module_53",
         "logos-module-loader": "logos-module-loader_8",
-        "logos-nix": "logos-nix_252",
-        "logos-protocol": "logos-protocol_40",
-        "logos-qt-sdk": "logos-qt-sdk_18",
+        "logos-nix": "logos-nix_248",
+        "logos-protocol": "logos-protocol_39",
+        "logos-qt-sdk": "logos-qt-sdk_17",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -445,9 +454,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_67",
+        "logos-module": "logos-module_66",
         "logos-module-loader": "logos-module-loader_10",
-        "logos-nix": "logos-nix_303",
+        "logos-nix": "logos-nix_299",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -501,12 +510,12 @@
     "default-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_29",
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
-        "logos-module": "logos-module_88",
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-module": "logos-module_87",
         "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_424",
-        "logos-protocol": "logos-protocol_69",
-        "logos-qt-sdk": "logos-qt-sdk_29",
+        "logos-nix": "logos-nix_420",
+        "logos-protocol": "logos-protocol_68",
+        "logos-qt-sdk": "logos-qt-sdk_28",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -545,9 +554,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_101",
+        "logos-module": "logos-module_100",
         "logos-module-loader": "logos-module-loader_14",
-        "logos-nix": "logos-nix_475",
+        "logos-nix": "logos-nix_471",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -601,12 +610,12 @@
     "default-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_39",
-        "logos-cpp-sdk": "logos-cpp-sdk_50",
-        "logos-module": "logos-module_121",
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-module": "logos-module_120",
         "logos-module-loader": "logos-module-loader_16",
-        "logos-nix": "logos-nix_590",
-        "logos-protocol": "logos-protocol_98",
-        "logos-qt-sdk": "logos-qt-sdk_40",
+        "logos-nix": "logos-nix_586",
+        "logos-protocol": "logos-protocol_97",
+        "logos-qt-sdk": "logos-qt-sdk_39",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -645,9 +654,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_134",
+        "logos-module": "logos-module_133",
         "logos-module-loader": "logos-module-loader_18",
-        "logos-nix": "logos-nix_641",
+        "logos-nix": "logos-nix_637",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -946,7 +955,7 @@
     },
     "logos-container_11": {
       "inputs": {
-        "logos-nix": "logos-nix_148",
+        "logos-nix": "logos-nix_144",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-container",
@@ -1034,7 +1043,7 @@
     },
     "logos-container_14": {
       "inputs": {
-        "logos-nix": "logos-nix_169",
+        "logos-nix": "logos-nix_165",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -1099,7 +1108,7 @@
     },
     "logos-container_16": {
       "inputs": {
-        "logos-nix": "logos-nix_200",
+        "logos-nix": "logos-nix_196",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -1196,7 +1205,7 @@
     },
     "logos-container_19": {
       "inputs": {
-        "logos-nix": "logos-nix_248",
+        "logos-nix": "logos-nix_244",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1286,7 +1295,7 @@
     },
     "logos-container_21": {
       "inputs": {
-        "logos-nix": "logos-nix_283",
+        "logos-nix": "logos-nix_279",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1391,7 +1400,7 @@
     },
     "logos-container_24": {
       "inputs": {
-        "logos-nix": "logos-nix_300",
+        "logos-nix": "logos-nix_296",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1468,7 +1477,7 @@
     },
     "logos-container_26": {
       "inputs": {
-        "logos-nix": "logos-nix_331",
+        "logos-nix": "logos-nix_327",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1577,7 +1586,7 @@
     },
     "logos-container_29": {
       "inputs": {
-        "logos-nix": "logos-nix_420",
+        "logos-nix": "logos-nix_416",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1673,7 +1682,7 @@
     },
     "logos-container_31": {
       "inputs": {
-        "logos-nix": "logos-nix_455",
+        "logos-nix": "logos-nix_451",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1778,7 +1787,7 @@
     },
     "logos-container_34": {
       "inputs": {
-        "logos-nix": "logos-nix_472",
+        "logos-nix": "logos-nix_468",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1855,7 +1864,7 @@
     },
     "logos-container_36": {
       "inputs": {
-        "logos-nix": "logos-nix_503",
+        "logos-nix": "logos-nix_499",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1964,7 +1973,7 @@
     },
     "logos-container_39": {
       "inputs": {
-        "logos-nix": "logos-nix_586",
+        "logos-nix": "logos-nix_582",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -1992,7 +2001,7 @@
     },
     "logos-container_4": {
       "inputs": {
-        "logos-nix": "logos-nix_65",
+        "logos-nix": "logos-nix_61",
         "nixpkgs": [
           "logos-liblogos",
           "logos-container",
@@ -2053,7 +2062,7 @@
     },
     "logos-container_41": {
       "inputs": {
-        "logos-nix": "logos-nix_621",
+        "logos-nix": "logos-nix_617",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2158,7 +2167,7 @@
     },
     "logos-container_44": {
       "inputs": {
-        "logos-nix": "logos-nix_638",
+        "logos-nix": "logos-nix_634",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2235,7 +2244,7 @@
     },
     "logos-container_46": {
       "inputs": {
-        "logos-nix": "logos-nix_669",
+        "logos-nix": "logos-nix_665",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2375,7 +2384,7 @@
     },
     "logos-container_7": {
       "inputs": {
-        "logos-nix": "logos-nix_81",
+        "logos-nix": "logos-nix_77",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2443,7 +2452,7 @@
     },
     "logos-container_9": {
       "inputs": {
-        "logos-nix": "logos-nix_112",
+        "logos-nix": "logos-nix_108",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -2503,27 +2512,21 @@
     "logos-cpp-sdk_10": {
       "inputs": {
         "logos-lidl": "logos-lidl_35",
-        "logos-nix": [
+        "logos-nix": "logos-nix_109",
+        "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+          "logos-protocol"
         ],
-        "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2545,22 +2548,20 @@
     },
     "logos-cpp-sdk_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_37",
-        "logos-nix": "logos-nix_113",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_41",
+        "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_21",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2583,30 +2584,24 @@
     "logos-cpp-sdk_12": {
       "inputs": {
         "logos-lidl": "logos-lidl_43",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+        "logos-nix": "logos-nix_145",
+        "logos-protocol": [
+          "logos-module-loader-qt",
+          "logos-protocol"
         ],
-        "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-module-loader-qt",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2618,13 +2613,15 @@
     "logos-cpp-sdk_13": {
       "inputs": {
         "logos-lidl": "logos-lidl_45",
-        "logos-nix": "logos-nix_149",
+        "logos-nix": "logos-nix_152",
         "logos-protocol": [
-          "logos-module-loader-qt",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-module-loader-qt",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2646,27 +2643,24 @@
     },
     "logos-cpp-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_47",
-        "logos-nix": "logos-nix_156",
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
+        "logos-lidl": "logos-lidl_50",
+        "logos-nix": "logos-nix_163",
+        "logos-protocol": "logos-protocol_26",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -2677,13 +2671,24 @@
     },
     "logos-cpp-sdk_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_52",
-        "logos-nix": "logos-nix_167",
-        "logos-protocol": "logos-protocol_27",
+        "logos-lidl": "logos-lidl_51",
+        "logos-nix": "logos-nix_169",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2705,46 +2710,7 @@
     },
     "logos-cpp-sdk_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_53",
-        "logos-nix": "logos-nix_173",
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_17": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_60",
+        "logos-lidl": "logos-lidl_58",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -2755,7 +2721,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_30",
+        "logos-protocol": "logos-protocol_29",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -2783,10 +2749,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_18": {
+    "logos-cpp-sdk_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_62",
-        "logos-nix": "logos-nix_201",
+        "logos-lidl": "logos-lidl_60",
+        "logos-nix": "logos-nix_197",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -2799,6 +2765,39 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_18": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_66",
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_34",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2821,28 +2820,26 @@
     "logos-cpp-sdk_19": {
       "inputs": {
         "logos-lidl": "logos-lidl_68",
-        "logos-nix": [
-          "logos-modules-state-module",
+        "logos-nix": "logos-nix_231",
+        "logos-protocol": [
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+          "logos-protocol"
         ],
-        "logos-protocol": "logos-protocol_35",
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -2886,16 +2883,13 @@
     },
     "logos-cpp-sdk_20": {
       "inputs": {
-        "logos-lidl": "logos-lidl_70",
-        "logos-nix": "logos-nix_235",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
+        "logos-lidl": "logos-lidl_73",
+        "logos-nix": "logos-nix_242",
+        "logos-protocol": "logos-protocol_38",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2917,13 +2911,22 @@
     },
     "logos-cpp-sdk_21": {
       "inputs": {
-        "logos-lidl": "logos-lidl_75",
-        "logos-nix": "logos-nix_246",
-        "logos-protocol": "logos-protocol_39",
+        "logos-lidl": "logos-lidl_74",
+        "logos-nix": "logos-nix_245",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2946,13 +2949,14 @@
     "logos-cpp-sdk_22": {
       "inputs": {
         "logos-lidl": "logos-lidl_76",
-        "logos-nix": "logos-nix_249",
+        "logos-nix": "logos-nix_252",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -2960,7 +2964,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2982,46 +2987,7 @@
     },
     "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-lidl": "logos-lidl_78",
-        "logos-nix": "logos-nix_256",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_24": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_85",
+        "logos-lidl": "logos-lidl_83",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3032,7 +2998,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_44",
+        "logos-protocol": "logos-protocol_43",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3060,10 +3026,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_25": {
+    "logos-cpp-sdk_24": {
       "inputs": {
-        "logos-lidl": "logos-lidl_87",
-        "logos-nix": "logos-nix_284",
+        "logos-lidl": "logos-lidl_85",
+        "logos-nix": "logos-nix_280",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3076,6 +3042,45 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_25": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_86",
+        "logos-nix": "logos-nix_283",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3097,17 +3102,9 @@
     },
     "logos-cpp-sdk_26": {
       "inputs": {
-        "logos-lidl": "logos-lidl_88",
-        "logos-nix": "logos-nix_287",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
+        "logos-lidl": "logos-lidl_91",
+        "logos-nix": "logos-nix_294",
+        "logos-protocol": "logos-protocol_47",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3115,17 +3112,18 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3136,9 +3134,21 @@
     },
     "logos-cpp-sdk_27": {
       "inputs": {
-        "logos-lidl": "logos-lidl_93",
-        "logos-nix": "logos-nix_298",
-        "logos-protocol": "logos-protocol_48",
+        "logos-lidl": "logos-lidl_92",
+        "logos-nix": "logos-nix_300",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3147,6 +3157,9 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3168,54 +3181,7 @@
     },
     "logos-cpp-sdk_28": {
       "inputs": {
-        "logos-lidl": "logos-lidl_94",
-        "logos-nix": "logos-nix_304",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_29": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_101",
+        "logos-lidl": "logos-lidl_99",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3230,7 +3196,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_51",
+        "logos-protocol": "logos-protocol_50",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3243,6 +3209,49 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_29": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_101",
+        "logos-nix": "logos-nix_328",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3276,11 +3285,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788891074,
-        "narHash": "sha256-wRkB7y/NJ9CFjpj718W5VKrC3WiB83n4yTHJ5lPT/MQ=",
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "41ca4491f0163e0735511b6ac7d9020dec88a84c",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
         "type": "github"
       },
       "original": {
@@ -3291,19 +3300,18 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_103",
-        "logos-nix": "logos-nix_332",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_107",
+        "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_55",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3311,8 +3319,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3333,47 +3340,6 @@
       }
     },
     "logos-cpp-sdk_31": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_109",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_56",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_32": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -3424,16 +3390,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_33": {
+    "logos-cpp-sdk_32": {
       "inputs": {
-        "logos-lidl": "logos-lidl_116",
+        "logos-lidl": "logos-lidl_114",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_64",
+        "logos-protocol": "logos-protocol_63",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3457,10 +3423,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_34": {
+    "logos-cpp-sdk_33": {
       "inputs": {
-        "logos-lidl": "logos-lidl_118",
-        "logos-nix": "logos-nix_407",
+        "logos-lidl": "logos-lidl_116",
+        "logos-nix": "logos-nix_403",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3488,15 +3454,52 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_35": {
+    "logos-cpp-sdk_34": {
       "inputs": {
-        "logos-lidl": "logos-lidl_123",
-        "logos-nix": "logos-nix_418",
-        "logos-protocol": "logos-protocol_68",
+        "logos-lidl": "logos-lidl_121",
+        "logos-nix": "logos-nix_414",
+        "logos-protocol": "logos-protocol_67",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_35": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_122",
+        "logos-nix": "logos-nix_417",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3519,13 +3522,14 @@
     "logos-cpp-sdk_36": {
       "inputs": {
         "logos-lidl": "logos-lidl_124",
-        "logos-nix": "logos-nix_421",
+        "logos-nix": "logos-nix_424",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3533,7 +3537,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3555,46 +3560,7 @@
     },
     "logos-cpp-sdk_37": {
       "inputs": {
-        "logos-lidl": "logos-lidl_126",
-        "logos-nix": "logos-nix_428",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_38": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_133",
+        "logos-lidl": "logos-lidl_131",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3605,7 +3571,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_73",
+        "logos-protocol": "logos-protocol_72",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3633,10 +3599,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_39": {
+    "logos-cpp-sdk_38": {
       "inputs": {
-        "logos-lidl": "logos-lidl_135",
-        "logos-nix": "logos-nix_456",
+        "logos-lidl": "logos-lidl_133",
+        "logos-nix": "logos-nix_452",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3649,6 +3615,45 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_39": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_134",
+        "logos-nix": "logos-nix_455",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3671,53 +3676,16 @@
     "logos-cpp-sdk_4": {
       "inputs": {
         "logos-lidl": "logos-lidl_11",
-        "logos-nix": "logos-nix_31",
+        "logos-nix": "logos-nix_34",
         "logos-protocol": [
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788891074,
-        "narHash": "sha256-wRkB7y/NJ9CFjpj718W5VKrC3WiB83n4yTHJ5lPT/MQ=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "41ca4491f0163e0735511b6ac7d9020dec88a84c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_40": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_136",
-        "logos-nix": "logos-nix_459",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -3738,11 +3706,11 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_41": {
+    "logos-cpp-sdk_40": {
       "inputs": {
-        "logos-lidl": "logos-lidl_141",
-        "logos-nix": "logos-nix_470",
-        "logos-protocol": "logos-protocol_77",
+        "logos-lidl": "logos-lidl_139",
+        "logos-nix": "logos-nix_466",
+        "logos-protocol": "logos-protocol_76",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3751,6 +3719,53 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_41": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_140",
+        "logos-nix": "logos-nix_472",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3772,54 +3787,7 @@
     },
     "logos-cpp-sdk_42": {
       "inputs": {
-        "logos-lidl": "logos-lidl_142",
-        "logos-nix": "logos-nix_476",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_43": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_149",
+        "logos-lidl": "logos-lidl_147",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3834,7 +3802,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_80",
+        "logos-protocol": "logos-protocol_79",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3847,6 +3815,49 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_43": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_149",
+        "logos-nix": "logos-nix_500",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3868,19 +3879,18 @@
     },
     "logos-cpp-sdk_44": {
       "inputs": {
-        "logos-lidl": "logos-lidl_151",
-        "logos-nix": "logos-nix_504",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_155",
+        "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_84",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3888,8 +3898,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3910,47 +3919,6 @@
       }
     },
     "logos-cpp-sdk_45": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_157",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_85",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_46": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -4001,16 +3969,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_47": {
+    "logos-cpp-sdk_46": {
       "inputs": {
-        "logos-lidl": "logos-lidl_164",
+        "logos-lidl": "logos-lidl_162",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_93",
+        "logos-protocol": "logos-protocol_92",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4034,10 +4002,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_48": {
+    "logos-cpp-sdk_47": {
       "inputs": {
-        "logos-lidl": "logos-lidl_166",
-        "logos-nix": "logos-nix_574",
+        "logos-lidl": "logos-lidl_164",
+        "logos-nix": "logos-nix_570",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4065,15 +4033,52 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_49": {
+    "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-lidl": "logos-lidl_171",
-        "logos-nix": "logos-nix_584",
-        "logos-protocol": "logos-protocol_97",
+        "logos-lidl": "logos-lidl_169",
+        "logos-nix": "logos-nix_580",
+        "logos-protocol": "logos-protocol_96",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_49": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_170",
+        "logos-nix": "logos-nix_583",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4095,29 +4100,31 @@
     },
     "logos-cpp-sdk_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_13",
-        "logos-nix": "logos-nix_38",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_18",
+        "logos-nix": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_9",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -4129,13 +4136,14 @@
     "logos-cpp-sdk_50": {
       "inputs": {
         "logos-lidl": "logos-lidl_172",
-        "logos-nix": "logos-nix_587",
+        "logos-nix": "logos-nix_590",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -4143,7 +4151,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4165,46 +4174,7 @@
     },
     "logos-cpp-sdk_51": {
       "inputs": {
-        "logos-lidl": "logos-lidl_174",
-        "logos-nix": "logos-nix_594",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_52": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_181",
+        "logos-lidl": "logos-lidl_179",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4215,7 +4185,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_102",
+        "logos-protocol": "logos-protocol_101",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4243,10 +4213,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_53": {
+    "logos-cpp-sdk_52": {
       "inputs": {
-        "logos-lidl": "logos-lidl_183",
-        "logos-nix": "logos-nix_622",
+        "logos-lidl": "logos-lidl_181",
+        "logos-nix": "logos-nix_618",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4259,6 +4229,45 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_53": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_182",
+        "logos-nix": "logos-nix_621",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4280,17 +4289,9 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
-        "logos-lidl": "logos-lidl_184",
-        "logos-nix": "logos-nix_625",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
+        "logos-lidl": "logos-lidl_187",
+        "logos-nix": "logos-nix_632",
+        "logos-protocol": "logos-protocol_105",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4298,17 +4299,18 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -4319,9 +4321,21 @@
     },
     "logos-cpp-sdk_55": {
       "inputs": {
-        "logos-lidl": "logos-lidl_189",
-        "logos-nix": "logos-nix_636",
-        "logos-protocol": "logos-protocol_106",
+        "logos-lidl": "logos-lidl_188",
+        "logos-nix": "logos-nix_638",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4330,6 +4344,9 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4351,54 +4368,7 @@
     },
     "logos-cpp-sdk_56": {
       "inputs": {
-        "logos-lidl": "logos-lidl_190",
-        "logos-nix": "logos-nix_642",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_57": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_197",
+        "logos-lidl": "logos-lidl_195",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4413,7 +4383,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_109",
+        "logos-protocol": "logos-protocol_108",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4426,6 +4396,49 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_57": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_197",
+        "logos-nix": "logos-nix_666",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4447,19 +4460,18 @@
     },
     "logos-cpp-sdk_58": {
       "inputs": {
-        "logos-lidl": "logos-lidl_199",
-        "logos-nix": "logos-nix_670",
-        "logos-protocol": [
+        "logos-lidl": "logos-lidl_203",
+        "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
+          "logos-view-module-runtime",
+          "logos-nix"
         ],
+        "logos-protocol": "logos-protocol_113",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4467,8 +4479,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4489,82 +4500,6 @@
       }
     },
     "logos-cpp-sdk_59": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_205",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_114",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_6": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_20",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_10",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_60": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -4615,43 +4550,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_61": {
+    "logos-cpp-sdk_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_212",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_122",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_7": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_22",
-        "logos-nix": "logos-nix_68",
+        "logos-lidl": "logos-lidl_20",
+        "logos-nix": "logos-nix_64",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -4681,11 +4583,44 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_8": {
+    "logos-cpp-sdk_60": {
       "inputs": {
-        "logos-lidl": "logos-lidl_27",
-        "logos-nix": "logos-nix_79",
-        "logos-protocol": "logos-protocol_14",
+        "logos-lidl": "logos-lidl_210",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_121",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_7": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_25",
+        "logos-nix": "logos-nix_75",
+        "logos-protocol": "logos-protocol_13",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -4710,10 +4645,10 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_9": {
+    "logos-cpp-sdk_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_28",
-        "logos-nix": "logos-nix_85",
+        "logos-lidl": "logos-lidl_26",
+        "logos-nix": "logos-nix_81",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -4743,6 +4678,49 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_9": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_33",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_16",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -4781,7 +4759,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-        "logos-nix": "logos-nix_288",
+        "logos-nix": "logos-nix_284",
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
@@ -4813,7 +4791,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-        "logos-nix": "logos-nix_305",
+        "logos-nix": "logos-nix_301",
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nix-bundle-macos-app": "nix-bundle-macos-app_11",
@@ -4849,7 +4827,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-        "logos-nix": "logos-nix_408",
+        "logos-nix": "logos-nix_404",
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nix-bundle-macos-app": "nix-bundle-macos-app_12",
@@ -4877,7 +4855,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-        "logos-nix": "logos-nix_429",
+        "logos-nix": "logos-nix_425",
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_65",
         "nix-bundle-macos-app": "nix-bundle-macos-app_13",
@@ -4909,7 +4887,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-        "logos-nix": "logos-nix_460",
+        "logos-nix": "logos-nix_456",
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nix-bundle-macos-app": "nix-bundle-macos-app_14",
@@ -4941,7 +4919,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-        "logos-nix": "logos-nix_477",
+        "logos-nix": "logos-nix_473",
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nix-bundle-macos-app": "nix-bundle-macos-app_15",
@@ -4977,7 +4955,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-        "logos-nix": "logos-nix_575",
+        "logos-nix": "logos-nix_571",
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_90",
         "nix-bundle-macos-app": "nix-bundle-macos-app_16",
@@ -5005,7 +4983,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-        "logos-nix": "logos-nix_595",
+        "logos-nix": "logos-nix_591",
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_91",
         "nix-bundle-macos-app": "nix-bundle-macos-app_17",
@@ -5037,7 +5015,7 @@
     },
     "logos-design-system_18": {
       "inputs": {
-        "logos-nix": "logos-nix_626",
+        "logos-nix": "logos-nix_622",
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_96",
         "nix-bundle-macos-app": "nix-bundle-macos-app_18",
@@ -5069,7 +5047,7 @@
     },
     "logos-design-system_19": {
       "inputs": {
-        "logos-nix": "logos-nix_643",
+        "logos-nix": "logos-nix_639",
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_97",
         "nix-bundle-macos-app": "nix-bundle-macos-app_19",
@@ -5131,7 +5109,7 @@
     },
     "logos-design-system_3": {
       "inputs": {
-        "logos-nix": "logos-nix_39",
+        "logos-nix": "logos-nix_35",
         "nix-bundle-appimage": "nix-bundle-appimage_4",
         "nix-bundle-dir": "nix-bundle-dir_7",
         "nix-bundle-macos-app": "nix-bundle-macos-app_3",
@@ -5160,7 +5138,7 @@
     },
     "logos-design-system_4": {
       "inputs": {
-        "logos-nix": "logos-nix_69",
+        "logos-nix": "logos-nix_65",
         "nix-bundle-appimage": "nix-bundle-appimage_6",
         "nix-bundle-dir": "nix-bundle-dir_12",
         "nix-bundle-macos-app": "nix-bundle-macos-app_4",
@@ -5189,7 +5167,7 @@
     },
     "logos-design-system_5": {
       "inputs": {
-        "logos-nix": "logos-nix_86",
+        "logos-nix": "logos-nix_82",
         "nix-bundle-appimage": "nix-bundle-appimage_7",
         "nix-bundle-dir": "nix-bundle-dir_13",
         "nix-bundle-macos-app": "nix-bundle-macos-app_5",
@@ -5222,7 +5200,7 @@
     },
     "logos-design-system_6": {
       "inputs": {
-        "logos-nix": "logos-nix_157",
+        "logos-nix": "logos-nix_153",
         "nix-bundle-appimage": "nix-bundle-appimage_11",
         "nix-bundle-dir": "nix-bundle-dir_24",
         "nix-bundle-macos-app": "nix-bundle-macos-app_6",
@@ -5250,7 +5228,7 @@
     },
     "logos-design-system_7": {
       "inputs": {
-        "logos-nix": "logos-nix_174",
+        "logos-nix": "logos-nix_170",
         "nix-bundle-appimage": "nix-bundle-appimage_12",
         "nix-bundle-dir": "nix-bundle-dir_25",
         "nix-bundle-macos-app": "nix-bundle-macos-app_7",
@@ -5282,7 +5260,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-        "logos-nix": "logos-nix_236",
+        "logos-nix": "logos-nix_232",
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
@@ -5310,7 +5288,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-        "logos-nix": "logos-nix_257",
+        "logos-nix": "logos-nix_253",
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
@@ -5349,10 +5327,10 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-module": "logos-module_14",
+        "logos-module": "logos-module_13",
         "logos-module-loader": "logos-module-loader_2",
         "logos-modules-state-module": "logos-modules-state-module",
-        "logos-nix": "logos-nix_145",
+        "logos-nix": "logos-nix_141",
         "logos-package-manager": [
           "logos-package-manager"
         ],
@@ -5373,11 +5351,11 @@
         "process-stats": "process-stats_2"
       },
       "locked": {
-        "lastModified": 1789085774,
-        "narHash": "sha256-kSO/GYuPxaia4Ui8WAWHBP4jaLc0JrYMpYNlMCUcxUk=",
+        "lastModified": 1789123116,
+        "narHash": "sha256-QFAZrnCDNmoQRbZ8h9z6dI71NYKsp/SbBsnhRVnjxQM=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "9ad7920088d77734c13d0efe916de4aec0b97b3f",
+        "rev": "34a83419b027e8390f1e898038047245039f1e6d",
         "type": "github"
       },
       "original": {
@@ -5392,14 +5370,14 @@
         "default-module-loader": "default-module-loader_2",
         "logos-capability-module": "logos-capability-module_3",
         "logos-container": "logos-container_9",
-        "logos-cpp-sdk": "logos-cpp-sdk_11",
-        "logos-module": "logos-module_26",
+        "logos-cpp-sdk": "logos-cpp-sdk_10",
+        "logos-module": "logos-module_25",
         "logos-module-loader": "logos-module-loader_4",
-        "logos-nix": "logos-nix_116",
+        "logos-nix": "logos-nix_112",
         "logos-package-manager": "logos-package-manager_4",
-        "logos-plugin-qt": "logos-plugin-qt_15",
-        "logos-protocol": "logos-protocol_19",
-        "logos-qt-sdk": "logos-qt-sdk_9",
+        "logos-plugin-qt": "logos-plugin-qt_14",
+        "logos-protocol": "logos-protocol_18",
+        "logos-qt-sdk": "logos-qt-sdk_8",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -5431,14 +5409,14 @@
         "default-module-loader": "default-module-loader_3",
         "logos-capability-module": "logos-capability-module_4",
         "logos-container": "logos-container_16",
-        "logos-cpp-sdk": "logos-cpp-sdk_18",
-        "logos-module": "logos-module_45",
+        "logos-cpp-sdk": "logos-cpp-sdk_17",
+        "logos-module": "logos-module_44",
         "logos-module-loader": "logos-module-loader_7",
-        "logos-nix": "logos-nix_204",
+        "logos-nix": "logos-nix_200",
         "logos-package-manager": "logos-package-manager_7",
-        "logos-plugin-qt": "logos-plugin-qt_26",
-        "logos-protocol": "logos-protocol_32",
-        "logos-qt-sdk": "logos-qt-sdk_15",
+        "logos-plugin-qt": "logos-plugin-qt_25",
+        "logos-protocol": "logos-protocol_31",
+        "logos-qt-sdk": "logos-qt-sdk_14",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -5469,15 +5447,15 @@
         "default-module-loader": "default-module-loader_4",
         "logos-capability-module": "logos-capability-module_5",
         "logos-container": "logos-container_21",
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
-        "logos-module": "logos-module_62",
+        "logos-cpp-sdk": "logos-cpp-sdk_24",
+        "logos-module": "logos-module_61",
         "logos-module-loader": "logos-module-loader_9",
         "logos-modules-state-module": "logos-modules-state-module_3",
-        "logos-nix": "logos-nix_364",
+        "logos-nix": "logos-nix_360",
         "logos-package-manager": "logos-package-manager_13",
-        "logos-plugin-qt": "logos-plugin-qt_47",
-        "logos-protocol": "logos-protocol_59",
-        "logos-qt-sdk": "logos-qt-sdk_26",
+        "logos-plugin-qt": "logos-plugin-qt_46",
+        "logos-protocol": "logos-protocol_58",
+        "logos-qt-sdk": "logos-qt-sdk_25",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5508,14 +5486,14 @@
         "default-module-loader": "default-module-loader_5",
         "logos-capability-module": "logos-capability-module_6",
         "logos-container": "logos-container_26",
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
-        "logos-module": "logos-module_74",
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-module": "logos-module_73",
         "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_335",
+        "logos-nix": "logos-nix_331",
         "logos-package-manager": "logos-package-manager_11",
-        "logos-plugin-qt": "logos-plugin-qt_43",
-        "logos-protocol": "logos-protocol_53",
-        "logos-qt-sdk": "logos-qt-sdk_24",
+        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-protocol": "logos-protocol_52",
+        "logos-qt-sdk": "logos-qt-sdk_23",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5550,15 +5528,15 @@
         "default-module-loader": "default-module-loader_6",
         "logos-capability-module": "logos-capability-module_7",
         "logos-container": "logos-container_31",
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-module": "logos-module_96",
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
+        "logos-module": "logos-module_95",
         "logos-module-loader": "logos-module-loader_13",
         "logos-modules-state-module": "logos-modules-state-module_4",
-        "logos-nix": "logos-nix_536",
+        "logos-nix": "logos-nix_532",
         "logos-package-manager": "logos-package-manager_20",
-        "logos-plugin-qt": "logos-plugin-qt_69",
-        "logos-protocol": "logos-protocol_88",
-        "logos-qt-sdk": "logos-qt-sdk_37",
+        "logos-plugin-qt": "logos-plugin-qt_68",
+        "logos-protocol": "logos-protocol_87",
+        "logos-qt-sdk": "logos-qt-sdk_36",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5589,14 +5567,14 @@
         "default-module-loader": "default-module-loader_7",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_36",
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
-        "logos-module": "logos-module_108",
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-module": "logos-module_107",
         "logos-module-loader": "logos-module-loader_15",
-        "logos-nix": "logos-nix_507",
+        "logos-nix": "logos-nix_503",
         "logos-package-manager": "logos-package-manager_18",
-        "logos-plugin-qt": "logos-plugin-qt_65",
-        "logos-protocol": "logos-protocol_82",
-        "logos-qt-sdk": "logos-qt-sdk_35",
+        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-protocol": "logos-protocol_81",
+        "logos-qt-sdk": "logos-qt-sdk_34",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5631,15 +5609,15 @@
         "default-module-loader": "default-module-loader_8",
         "logos-capability-module": "logos-capability-module_9",
         "logos-container": "logos-container_41",
-        "logos-cpp-sdk": "logos-cpp-sdk_53",
-        "logos-module": "logos-module_129",
+        "logos-cpp-sdk": "logos-cpp-sdk_52",
+        "logos-module": "logos-module_128",
         "logos-module-loader": "logos-module-loader_17",
         "logos-modules-state-module": "logos-modules-state-module_5",
-        "logos-nix": "logos-nix_702",
+        "logos-nix": "logos-nix_698",
         "logos-package-manager": "logos-package-manager_27",
-        "logos-plugin-qt": "logos-plugin-qt_90",
-        "logos-protocol": "logos-protocol_117",
-        "logos-qt-sdk": "logos-qt-sdk_48",
+        "logos-plugin-qt": "logos-plugin-qt_89",
+        "logos-protocol": "logos-protocol_116",
+        "logos-qt-sdk": "logos-qt-sdk_47",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5670,14 +5648,14 @@
         "default-module-loader": "default-module-loader_9",
         "logos-capability-module": "logos-capability-module_10",
         "logos-container": "logos-container_46",
-        "logos-cpp-sdk": "logos-cpp-sdk_58",
-        "logos-module": "logos-module_141",
+        "logos-cpp-sdk": "logos-cpp-sdk_57",
+        "logos-module": "logos-module_140",
         "logos-module-loader": "logos-module-loader_19",
-        "logos-nix": "logos-nix_673",
+        "logos-nix": "logos-nix_669",
         "logos-package-manager": "logos-package-manager_25",
-        "logos-plugin-qt": "logos-plugin-qt_86",
-        "logos-protocol": "logos-protocol_111",
-        "logos-qt-sdk": "logos-qt-sdk_46",
+        "logos-plugin-qt": "logos-plugin-qt_85",
+        "logos-protocol": "logos-protocol_110",
+        "logos-qt-sdk": "logos-qt-sdk_45",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5777,8 +5755,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5792,8 +5770,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5824,9 +5802,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -5839,9 +5814,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -5873,9 +5845,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -5888,9 +5857,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -5922,7 +5888,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5934,7 +5900,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5964,7 +5930,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -5976,7 +5941,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6006,9 +5970,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6018,9 +5981,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6049,8 +6011,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6060,8 +6022,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6090,8 +6052,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6101,8 +6063,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6131,8 +6093,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6142,8 +6104,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6170,10 +6132,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6181,21 +6140,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6208,13 +6164,15 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6222,11 +6180,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788811494,
-        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6242,10 +6200,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6253,21 +6208,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6282,7 +6234,6 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -6290,7 +6241,6 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6316,28 +6266,26 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6351,26 +6299,26 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6384,15 +6332,15 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6417,26 +6365,26 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6448,16 +6396,14 @@
     "logos-lidl_116": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6465,11 +6411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6481,17 +6427,15 @@
     "logos-lidl_117": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6516,13 +6460,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6547,13 +6491,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6577,25 +6521,27 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1788811494,
-        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6609,13 +6555,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6640,13 +6586,15 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6671,13 +6619,19 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6703,14 +6657,18 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6737,7 +6695,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -6746,7 +6705,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6774,8 +6734,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6783,8 +6744,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6813,7 +6775,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6823,7 +6785,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6852,7 +6814,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6862,7 +6824,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6891,7 +6853,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6901,7 +6863,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6930,7 +6892,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6940,18 +6903,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6966,14 +6930,14 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7002,7 +6966,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7012,18 +6977,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7041,8 +7007,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7052,8 +7018,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7082,88 +7048,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_133": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_134": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
@@ -7196,7 +7080,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_135": {
+    "logos-lidl_133": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -7212,6 +7096,84 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_134": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_135": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7240,7 +7202,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7250,7 +7212,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7279,7 +7241,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7289,7 +7251,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7318,7 +7280,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7328,7 +7290,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7357,7 +7319,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7367,18 +7330,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7393,14 +7357,14 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7429,7 +7393,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7439,18 +7407,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7469,7 +7441,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7480,7 +7455,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7513,7 +7491,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7527,7 +7505,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7560,7 +7538,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7574,7 +7552,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7607,7 +7585,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7621,18 +7599,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -7654,7 +7632,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7668,7 +7647,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7701,7 +7681,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7715,18 +7696,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7748,8 +7730,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7763,8 +7745,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7797,8 +7779,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7812,8 +7794,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7844,9 +7826,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -7859,9 +7838,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7888,14 +7864,14 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7926,9 +7902,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7941,9 +7914,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7975,7 +7945,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7987,7 +7957,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8017,7 +7987,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8029,7 +7998,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8059,9 +8027,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8071,9 +8038,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8102,8 +8068,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8113,8 +8079,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8143,8 +8109,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8154,8 +8120,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8184,8 +8150,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8195,8 +8161,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8223,10 +8189,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8234,21 +8197,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8264,10 +8224,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8275,21 +8232,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8304,7 +8258,6 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8312,7 +8265,6 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8339,25 +8291,27 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8371,28 +8325,26 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8406,26 +8358,26 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8439,15 +8391,15 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8472,26 +8424,26 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8503,16 +8455,14 @@
     "logos-lidl_164": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8520,11 +8470,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8536,17 +8486,15 @@
     "logos-lidl_165": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8571,13 +8519,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8602,13 +8550,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8633,13 +8581,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8664,13 +8612,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8696,25 +8646,27 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8728,13 +8680,19 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8760,14 +8718,18 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8794,7 +8756,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -8803,7 +8766,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8831,8 +8795,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8840,8 +8805,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8870,7 +8836,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8880,7 +8846,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8909,7 +8875,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8919,7 +8885,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8948,7 +8914,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8958,7 +8924,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8987,84 +8953,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_178": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_179": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
@@ -9097,22 +8985,104 @@
         "type": "github"
       }
     },
+    "logos-lidl_178": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_179": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
     "logos-lidl_18": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9141,88 +9111,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_181": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_182": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
@@ -9255,7 +9143,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_183": {
+    "logos-lidl_181": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -9271,6 +9159,84 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_182": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_183": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9299,7 +9265,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9309,7 +9275,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9338,7 +9304,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9348,7 +9314,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9377,7 +9343,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9387,7 +9353,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9416,7 +9382,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9426,18 +9393,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9455,7 +9423,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9465,18 +9437,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9495,7 +9471,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9506,7 +9485,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9532,27 +9514,27 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9574,7 +9556,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9588,7 +9570,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9621,7 +9603,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9635,7 +9617,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9656,100 +9638,6 @@
       }
     },
     "logos-lidl_192": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_193": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_194": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -9796,7 +9684,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_195": {
+    "logos-lidl_193": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -9826,6 +9714,104 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_194": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_195": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9858,8 +9844,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9873,8 +9859,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9905,9 +9891,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -9920,9 +9903,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9954,9 +9934,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9969,9 +9946,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10003,7 +9977,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10015,7 +9989,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10070,17 +10044,15 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -10088,11 +10060,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10111,7 +10083,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10123,7 +10094,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10153,9 +10123,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10165,9 +10134,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10196,8 +10164,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10207,8 +10175,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10237,8 +10205,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10248,8 +10216,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10278,8 +10246,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10289,8 +10257,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10317,10 +10285,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10328,21 +10293,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10358,10 +10320,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10369,21 +10328,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10398,7 +10354,6 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10406,7 +10361,6 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10432,28 +10386,26 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10467,26 +10419,26 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10499,18 +10451,16 @@
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10535,15 +10485,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10568,26 +10518,26 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10599,28 +10549,22 @@
     "logos-lidl_212": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10630,66 +10574,6 @@
       }
     },
     "logos-lidl_213": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_214": {
-      "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_215": {
       "inputs": {
         "logos-nix": [
           "logos-qt-sdk",
@@ -10722,14 +10606,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10755,14 +10639,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10788,14 +10672,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10821,25 +10705,27 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10854,25 +10740,33 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10888,7 +10782,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10896,7 +10793,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10926,7 +10826,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10937,7 +10837,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10967,7 +10867,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10978,7 +10878,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11039,88 +10939,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_31": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_32": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-rust-sdk",
           "logos-nix"
         ],
@@ -11152,7 +10970,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_33": {
+    "logos-lidl_31": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -11176,6 +10994,92 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_32": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_33": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11205,8 +11109,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11217,8 +11121,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11246,9 +11150,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -11258,9 +11159,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -11289,9 +11187,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -11301,9 +11196,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -11332,7 +11224,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11341,7 +11233,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11368,7 +11260,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -11377,7 +11268,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -11404,18 +11294,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11472,16 +11360,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11507,16 +11395,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11542,16 +11430,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11572,76 +11460,6 @@
       }
     },
     "logos-lidl_43": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_44": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_45": {
       "inputs": {
         "logos-nix": [
           "logos-module-loader-qt",
@@ -11670,7 +11488,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_46": {
+    "logos-lidl_44": {
       "inputs": {
         "logos-nix": [
           "logos-module-loader-qt",
@@ -11680,6 +11498,68 @@
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_45": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_46": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11704,13 +11584,13 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11735,13 +11615,13 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11766,13 +11646,13 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11828,24 +11708,26 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11859,24 +11741,32 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11891,14 +11781,20 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11927,7 +11823,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11937,7 +11833,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11966,7 +11862,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11976,7 +11872,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11997,84 +11893,6 @@
       }
     },
     "logos-lidl_55": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_56": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_57": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -12113,7 +11931,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_58": {
+    "logos-lidl_56": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -12154,7 +11972,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_59": {
+    "logos-lidl_57": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -12176,6 +11994,88 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_58": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_59": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12235,9 +12135,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -12246,9 +12143,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12276,9 +12170,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -12287,9 +12178,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12317,7 +12205,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12325,7 +12213,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12351,7 +12239,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -12359,7 +12246,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12385,17 +12271,15 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12420,15 +12304,15 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12453,15 +12337,15 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12486,15 +12370,15 @@
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12517,16 +12401,14 @@
     "logos-lidl_68": {
       "inputs": {
         "logos-nix": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12534,11 +12416,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -12550,28 +12432,26 @@
     "logos-lidl_69": {
       "inputs": {
         "logos-nix": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-modules-state-module",
+          "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -12618,13 +12498,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12649,13 +12529,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12680,13 +12560,13 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12711,13 +12591,15 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12742,13 +12624,19 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12774,14 +12662,18 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12808,7 +12700,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -12817,7 +12710,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12845,8 +12739,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12854,8 +12749,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12884,7 +12780,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12894,7 +12790,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12923,7 +12819,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12933,7 +12829,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12995,7 +12891,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13005,7 +12901,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13034,7 +12930,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13044,18 +12941,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13073,7 +12971,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13083,18 +12982,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13112,8 +13012,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13123,8 +13023,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13153,88 +13053,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_85": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_86": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
@@ -13267,7 +13085,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_87": {
+    "logos-lidl_85": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -13283,6 +13101,84 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_86": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_87": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13311,7 +13207,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13321,7 +13217,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13350,7 +13246,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13360,7 +13256,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13422,7 +13318,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13432,7 +13328,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13461,7 +13357,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13471,18 +13368,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13500,7 +13398,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13510,18 +13412,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13540,7 +13446,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13551,7 +13460,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13584,7 +13496,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13598,7 +13510,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13631,7 +13543,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13645,7 +13557,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13666,100 +13578,6 @@
       }
     },
     "logos-lidl_96": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_97": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_98": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -13806,7 +13624,7 @@
         "type": "github"
       }
     },
-    "logos-lidl_99": {
+    "logos-lidl_97": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -13836,6 +13654,104 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_98": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_99": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13923,14 +13839,14 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-design-system": "logos-design-system_11",
-        "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_307",
+        "logos-module": "logos-module_67",
+        "logos-nix": "logos-nix_303",
         "logos-plugin-core": "logos-plugin-core_10",
-        "logos-plugin-qt": "logos-plugin-qt_39",
-        "logos-protocol": "logos-protocol_49",
-        "logos-qt-sdk": "logos-qt-sdk_22",
+        "logos-plugin-qt": "logos-plugin-qt_38",
+        "logos-protocol": "logos-protocol_48",
+        "logos-qt-sdk": "logos-qt-sdk_21",
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -13980,14 +13896,14 @@
     },
     "logos-module-builder_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-design-system": "logos-design-system_12",
-        "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_410",
+        "logos-module": "logos-module_83",
+        "logos-nix": "logos-nix_406",
         "logos-plugin-core": "logos-plugin-core_11",
-        "logos-plugin-qt": "logos-plugin-qt_52",
-        "logos-protocol": "logos-protocol_66",
-        "logos-qt-sdk": "logos-qt-sdk_28",
+        "logos-plugin-qt": "logos-plugin-qt_51",
+        "logos-protocol": "logos-protocol_65",
+        "logos-qt-sdk": "logos-qt-sdk_27",
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
         "logos-test-framework": "logos-test-framework_14",
@@ -14019,14 +13935,14 @@
     },
     "logos-module-builder_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-design-system": "logos-design-system_13",
-        "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_431",
+        "logos-module": "logos-module_89",
+        "logos-nix": "logos-nix_427",
         "logos-plugin-core": "logos-plugin-core_12",
-        "logos-plugin-qt": "logos-plugin-qt_55",
-        "logos-protocol": "logos-protocol_70",
-        "logos-qt-sdk": "logos-qt-sdk_30",
+        "logos-plugin-qt": "logos-plugin-qt_54",
+        "logos-protocol": "logos-protocol_69",
+        "logos-qt-sdk": "logos-qt-sdk_29",
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -14068,14 +13984,14 @@
     },
     "logos-module-builder_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-design-system": "logos-design-system_14",
-        "logos-module": "logos-module_97",
-        "logos-nix": "logos-nix_462",
+        "logos-module": "logos-module_96",
+        "logos-nix": "logos-nix_458",
         "logos-plugin-core": "logos-plugin-core_13",
-        "logos-plugin-qt": "logos-plugin-qt_59",
-        "logos-protocol": "logos-protocol_75",
-        "logos-qt-sdk": "logos-qt-sdk_32",
+        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-protocol": "logos-protocol_74",
+        "logos-qt-sdk": "logos-qt-sdk_31",
         "logos-rust-sdk": "logos-rust-sdk_13",
         "logos-standalone-app": "logos-standalone-app_6",
         "logos-test-framework": "logos-test-framework_13",
@@ -14111,14 +14027,14 @@
     },
     "logos-module-builder_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-design-system": "logos-design-system_15",
-        "logos-module": "logos-module_102",
-        "logos-nix": "logos-nix_479",
+        "logos-module": "logos-module_101",
+        "logos-nix": "logos-nix_475",
         "logos-plugin-core": "logos-plugin-core_14",
-        "logos-plugin-qt": "logos-plugin-qt_61",
-        "logos-protocol": "logos-protocol_78",
-        "logos-qt-sdk": "logos-qt-sdk_33",
+        "logos-plugin-qt": "logos-plugin-qt_60",
+        "logos-protocol": "logos-protocol_77",
+        "logos-qt-sdk": "logos-qt-sdk_32",
         "logos-rust-sdk": "logos-rust-sdk_14",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -14168,14 +14084,14 @@
     },
     "logos-module-builder_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_48",
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
         "logos-design-system": "logos-design-system_16",
-        "logos-module": "logos-module_118",
-        "logos-nix": "logos-nix_577",
+        "logos-module": "logos-module_117",
+        "logos-nix": "logos-nix_573",
         "logos-plugin-core": "logos-plugin-core_15",
-        "logos-plugin-qt": "logos-plugin-qt_74",
-        "logos-protocol": "logos-protocol_95",
-        "logos-qt-sdk": "logos-qt-sdk_39",
+        "logos-plugin-qt": "logos-plugin-qt_73",
+        "logos-protocol": "logos-protocol_94",
+        "logos-qt-sdk": "logos-qt-sdk_38",
         "logos-rust-sdk": "logos-rust-sdk_15",
         "logos-standalone-app": "logos-standalone-app_7",
         "logos-test-framework": "logos-test-framework_18",
@@ -14207,14 +14123,14 @@
     },
     "logos-module-builder_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_51",
+        "logos-cpp-sdk": "logos-cpp-sdk_50",
         "logos-design-system": "logos-design-system_17",
-        "logos-module": "logos-module_123",
-        "logos-nix": "logos-nix_597",
+        "logos-module": "logos-module_122",
+        "logos-nix": "logos-nix_593",
         "logos-plugin-core": "logos-plugin-core_16",
-        "logos-plugin-qt": "logos-plugin-qt_76",
-        "logos-protocol": "logos-protocol_99",
-        "logos-qt-sdk": "logos-qt-sdk_41",
+        "logos-plugin-qt": "logos-plugin-qt_75",
+        "logos-protocol": "logos-protocol_98",
+        "logos-qt-sdk": "logos-qt-sdk_40",
         "logos-rust-sdk": "logos-rust-sdk_16",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14256,14 +14172,14 @@
     },
     "logos-module-builder_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_54",
+        "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-design-system": "logos-design-system_18",
-        "logos-module": "logos-module_130",
-        "logos-nix": "logos-nix_628",
+        "logos-module": "logos-module_129",
+        "logos-nix": "logos-nix_624",
         "logos-plugin-core": "logos-plugin-core_17",
-        "logos-plugin-qt": "logos-plugin-qt_80",
-        "logos-protocol": "logos-protocol_104",
-        "logos-qt-sdk": "logos-qt-sdk_43",
+        "logos-plugin-qt": "logos-plugin-qt_79",
+        "logos-protocol": "logos-protocol_103",
+        "logos-qt-sdk": "logos-qt-sdk_42",
         "logos-rust-sdk": "logos-rust-sdk_17",
         "logos-standalone-app": "logos-standalone-app_8",
         "logos-test-framework": "logos-test-framework_17",
@@ -14299,14 +14215,14 @@
     },
     "logos-module-builder_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-design-system": "logos-design-system_19",
-        "logos-module": "logos-module_135",
-        "logos-nix": "logos-nix_645",
+        "logos-module": "logos-module_134",
+        "logos-nix": "logos-nix_641",
         "logos-plugin-core": "logos-plugin-core_18",
-        "logos-plugin-qt": "logos-plugin-qt_82",
-        "logos-protocol": "logos-protocol_107",
-        "logos-qt-sdk": "logos-qt-sdk_44",
+        "logos-plugin-qt": "logos-plugin-qt_81",
+        "logos-protocol": "logos-protocol_106",
+        "logos-qt-sdk": "logos-qt-sdk_43",
         "logos-rust-sdk": "logos-rust-sdk_18",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14356,14 +14272,14 @@
     },
     "logos-module-builder_2": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_5",
+        "logos-cpp-sdk": "logos-cpp-sdk_4",
         "logos-design-system": "logos-design-system_3",
-        "logos-module": "logos-module_8",
-        "logos-nix": "logos-nix_41",
+        "logos-module": "logos-module_7",
+        "logos-nix": "logos-nix_37",
         "logos-plugin-core": "logos-plugin-core_2",
-        "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": "logos-protocol_7",
-        "logos-qt-sdk": "logos-qt-sdk_4",
+        "logos-plugin-qt": "logos-plugin-qt_4",
+        "logos-protocol": "logos-protocol_6",
+        "logos-qt-sdk": "logos-qt-sdk_3",
         "logos-rust-sdk": "logos-rust-sdk_2",
         "logos-standalone-app": [
           "logos-liblogos",
@@ -14399,14 +14315,14 @@
     },
     "logos-module-builder_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_7",
+        "logos-cpp-sdk": "logos-cpp-sdk_6",
         "logos-design-system": "logos-design-system_4",
-        "logos-module": "logos-module_15",
-        "logos-nix": "logos-nix_71",
+        "logos-module": "logos-module_14",
+        "logos-nix": "logos-nix_67",
         "logos-plugin-core": "logos-plugin-core_3",
-        "logos-plugin-qt": "logos-plugin-qt_9",
-        "logos-protocol": "logos-protocol_12",
-        "logos-qt-sdk": "logos-qt-sdk_6",
+        "logos-plugin-qt": "logos-plugin-qt_8",
+        "logos-protocol": "logos-protocol_11",
+        "logos-qt-sdk": "logos-qt-sdk_5",
         "logos-rust-sdk": "logos-rust-sdk_3",
         "logos-standalone-app": "logos-standalone-app",
         "logos-test-framework": "logos-test-framework_4",
@@ -14439,14 +14355,14 @@
     },
     "logos-module-builder_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_9",
+        "logos-cpp-sdk": "logos-cpp-sdk_8",
         "logos-design-system": "logos-design-system_5",
-        "logos-module": "logos-module_20",
-        "logos-nix": "logos-nix_88",
+        "logos-module": "logos-module_19",
+        "logos-nix": "logos-nix_84",
         "logos-plugin-core": "logos-plugin-core_4",
-        "logos-plugin-qt": "logos-plugin-qt_11",
-        "logos-protocol": "logos-protocol_15",
-        "logos-qt-sdk": "logos-qt-sdk_7",
+        "logos-plugin-qt": "logos-plugin-qt_10",
+        "logos-protocol": "logos-protocol_14",
+        "logos-qt-sdk": "logos-qt-sdk_6",
         "logos-rust-sdk": "logos-rust-sdk_4",
         "logos-standalone-app": [
           "logos-liblogos",
@@ -14490,14 +14406,14 @@
     },
     "logos-module-builder_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_14",
+        "logos-cpp-sdk": "logos-cpp-sdk_13",
         "logos-design-system": "logos-design-system_6",
-        "logos-module": "logos-module_34",
-        "logos-nix": "logos-nix_159",
+        "logos-module": "logos-module_33",
+        "logos-nix": "logos-nix_155",
         "logos-plugin-core": "logos-plugin-core_5",
-        "logos-plugin-qt": "logos-plugin-qt_20",
-        "logos-protocol": "logos-protocol_25",
-        "logos-qt-sdk": "logos-qt-sdk_12",
+        "logos-plugin-qt": "logos-plugin-qt_19",
+        "logos-protocol": "logos-protocol_24",
+        "logos-qt-sdk": "logos-qt-sdk_11",
         "logos-rust-sdk": "logos-rust-sdk_5",
         "logos-standalone-app": "logos-standalone-app_2",
         "logos-test-framework": "logos-test-framework_6",
@@ -14529,14 +14445,14 @@
     },
     "logos-module-builder_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_16",
+        "logos-cpp-sdk": "logos-cpp-sdk_15",
         "logos-design-system": "logos-design-system_7",
-        "logos-module": "logos-module_39",
-        "logos-nix": "logos-nix_176",
+        "logos-module": "logos-module_38",
+        "logos-nix": "logos-nix_172",
         "logos-plugin-core": "logos-plugin-core_6",
-        "logos-plugin-qt": "logos-plugin-qt_22",
-        "logos-protocol": "logos-protocol_28",
-        "logos-qt-sdk": "logos-qt-sdk_13",
+        "logos-plugin-qt": "logos-plugin-qt_21",
+        "logos-protocol": "logos-protocol_27",
+        "logos-qt-sdk": "logos-qt-sdk_12",
         "logos-rust-sdk": "logos-rust-sdk_6",
         "logos-standalone-app": [
           "logos-modules-state-module",
@@ -14578,14 +14494,14 @@
     },
     "logos-module-builder_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_20",
+        "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-design-system": "logos-design-system_8",
-        "logos-module": "logos-module_50",
-        "logos-nix": "logos-nix_238",
+        "logos-module": "logos-module_49",
+        "logos-nix": "logos-nix_234",
         "logos-plugin-core": "logos-plugin-core_7",
-        "logos-plugin-qt": "logos-plugin-qt_30",
-        "logos-protocol": "logos-protocol_37",
-        "logos-qt-sdk": "logos-qt-sdk_17",
+        "logos-plugin-qt": "logos-plugin-qt_29",
+        "logos-protocol": "logos-protocol_36",
+        "logos-qt-sdk": "logos-qt-sdk_16",
         "logos-rust-sdk": "logos-rust-sdk_7",
         "logos-standalone-app": "logos-standalone-app_3",
         "logos-test-framework": "logos-test-framework_10",
@@ -14617,14 +14533,14 @@
     },
     "logos-module-builder_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-design-system": "logos-design-system_9",
-        "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_259",
+        "logos-module": "logos-module_55",
+        "logos-nix": "logos-nix_255",
         "logos-plugin-core": "logos-plugin-core_8",
-        "logos-plugin-qt": "logos-plugin-qt_33",
-        "logos-protocol": "logos-protocol_41",
-        "logos-qt-sdk": "logos-qt-sdk_19",
+        "logos-plugin-qt": "logos-plugin-qt_32",
+        "logos-protocol": "logos-protocol_40",
+        "logos-qt-sdk": "logos-qt-sdk_18",
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -14666,14 +14582,14 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
         "logos-design-system": "logos-design-system_10",
-        "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_290",
+        "logos-module": "logos-module_62",
+        "logos-nix": "logos-nix_286",
         "logos-plugin-core": "logos-plugin-core_9",
-        "logos-plugin-qt": "logos-plugin-qt_37",
-        "logos-protocol": "logos-protocol_46",
-        "logos-qt-sdk": "logos-qt-sdk_21",
+        "logos-plugin-qt": "logos-plugin-qt_36",
+        "logos-protocol": "logos-protocol_45",
+        "logos-qt-sdk": "logos-qt-sdk_20",
         "logos-rust-sdk": "logos-rust-sdk_9",
         "logos-standalone-app": "logos-standalone-app_4",
         "logos-test-framework": "logos-test-framework_9",
@@ -14710,7 +14626,7 @@
     "logos-module-loader": {
       "inputs": {
         "logos-container": "logos-container_3",
-        "logos-nix": "logos-nix_33",
+        "logos-nix": "logos-nix_32",
         "nixpkgs": [
           "logos-liblogos",
           "default-module-loader",
@@ -14736,12 +14652,12 @@
     "logos-module-loader-qt": {
       "inputs": {
         "logos-container": "logos-container_11",
-        "logos-cpp-sdk": "logos-cpp-sdk_13",
-        "logos-module": "logos-module_32",
+        "logos-cpp-sdk": "logos-cpp-sdk_12",
+        "logos-module": "logos-module_31",
         "logos-module-loader": "logos-module-loader_5",
-        "logos-nix": "logos-nix_152",
-        "logos-protocol": "logos-protocol_24",
-        "logos-qt-sdk": "logos-qt-sdk_11",
+        "logos-nix": "logos-nix_148",
+        "logos-protocol": "logos-protocol_23",
+        "logos-qt-sdk": "logos-qt-sdk_10",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-nix",
@@ -14765,7 +14681,7 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
-        "logos-nix": "logos-nix_302",
+        "logos-nix": "logos-nix_298",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -14798,7 +14714,7 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
-        "logos-nix": "logos-nix_334",
+        "logos-nix": "logos-nix_330",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -14830,7 +14746,7 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-        "logos-nix": "logos-nix_423",
+        "logos-nix": "logos-nix_419",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14859,7 +14775,7 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
-        "logos-nix": "logos-nix_458",
+        "logos-nix": "logos-nix_454",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14887,7 +14803,7 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
-        "logos-nix": "logos-nix_474",
+        "logos-nix": "logos-nix_470",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14920,7 +14836,7 @@
     "logos-module-loader_15": {
       "inputs": {
         "logos-container": "logos-container_37",
-        "logos-nix": "logos-nix_506",
+        "logos-nix": "logos-nix_502",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14952,7 +14868,7 @@
     "logos-module-loader_16": {
       "inputs": {
         "logos-container": "logos-container_40",
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_585",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -14981,7 +14897,7 @@
     "logos-module-loader_17": {
       "inputs": {
         "logos-container": "logos-container_42",
-        "logos-nix": "logos-nix_624",
+        "logos-nix": "logos-nix_620",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15009,7 +14925,7 @@
     "logos-module-loader_18": {
       "inputs": {
         "logos-container": "logos-container_45",
-        "logos-nix": "logos-nix_640",
+        "logos-nix": "logos-nix_636",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15042,7 +14958,7 @@
     "logos-module-loader_19": {
       "inputs": {
         "logos-container": "logos-container_47",
-        "logos-nix": "logos-nix_672",
+        "logos-nix": "logos-nix_668",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15074,7 +14990,7 @@
     "logos-module-loader_2": {
       "inputs": {
         "logos-container": "logos-container_5",
-        "logos-nix": "logos-nix_67",
+        "logos-nix": "logos-nix_63",
         "nixpkgs": [
           "logos-liblogos",
           "logos-module-loader",
@@ -15099,7 +15015,7 @@
     "logos-module-loader_3": {
       "inputs": {
         "logos-container": "logos-container_8",
-        "logos-nix": "logos-nix_83",
+        "logos-nix": "logos-nix_79",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -15129,7 +15045,7 @@
     "logos-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_10",
-        "logos-nix": "logos-nix_115",
+        "logos-nix": "logos-nix_111",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -15158,7 +15074,7 @@
     "logos-module-loader_5": {
       "inputs": {
         "logos-container": "logos-container_12",
-        "logos-nix": "logos-nix_151",
+        "logos-nix": "logos-nix_147",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-module-loader",
@@ -15183,7 +15099,7 @@
     "logos-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_15",
-        "logos-nix": "logos-nix_171",
+        "logos-nix": "logos-nix_167",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -15212,7 +15128,7 @@
     "logos-module-loader_7": {
       "inputs": {
         "logos-container": "logos-container_17",
-        "logos-nix": "logos-nix_203",
+        "logos-nix": "logos-nix_199",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -15240,7 +15156,7 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
-        "logos-nix": "logos-nix_251",
+        "logos-nix": "logos-nix_247",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15269,7 +15185,7 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
-        "logos-nix": "logos-nix_286",
+        "logos-nix": "logos-nix_282",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15301,6 +15217,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15331,37 +15248,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_101": {
-      "inputs": {
-        "logos-nix": "logos-nix_473",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
@@ -15384,9 +15270,9 @@
         "type": "github"
       }
     },
-    "logos-module_102": {
+    "logos-module_101": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_474",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15417,9 +15303,9 @@
         "type": "github"
       }
     },
-    "logos-module_103": {
+    "logos-module_102": {
       "inputs": {
-        "logos-nix": "logos-nix_480",
+        "logos-nix": "logos-nix_476",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15432,6 +15318,40 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_103": {
+      "inputs": {
+        "logos-nix": "logos-nix_478",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15465,6 +15385,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15487,7 +15408,7 @@
     },
     "logos-module_105": {
       "inputs": {
-        "logos-nix": "logos-nix_486",
+        "logos-nix": "logos-nix_484",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15499,7 +15420,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15522,7 +15443,7 @@
     },
     "logos-module_106": {
       "inputs": {
-        "logos-nix": "logos-nix_488",
+        "logos-nix": "logos-nix_486",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15534,7 +15455,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15557,7 +15478,7 @@
     },
     "logos-module_107": {
       "inputs": {
-        "logos-nix": "logos-nix_490",
+        "logos-nix": "logos-nix_501",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15567,10 +15488,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15592,7 +15509,7 @@
     },
     "logos-module_108": {
       "inputs": {
-        "logos-nix": "logos-nix_505",
+        "logos-nix": "logos-nix_509",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15602,6 +15519,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15623,7 +15541,7 @@
     },
     "logos-module_109": {
       "inputs": {
-        "logos-nix": "logos-nix_513",
+        "logos-nix": "logos-nix_514",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15632,7 +15550,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15655,12 +15572,12 @@
     },
     "logos-module_11": {
       "inputs": {
-        "logos-nix": "logos-nix_48",
+        "logos-nix": "logos-nix_46",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15683,38 +15600,7 @@
     },
     "logos-module_110": {
       "inputs": {
-        "logos-nix": "logos-nix_518",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_111": {
-      "inputs": {
-        "logos-nix": "logos-nix_521",
+        "logos-nix": "logos-nix_517",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15743,9 +15629,9 @@
         "type": "github"
       }
     },
-    "logos-module_112": {
+    "logos-module_111": {
       "inputs": {
-        "logos-nix": "logos-nix_523",
+        "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15754,6 +15640,34 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_112": {
+      "inputs": {
+        "logos-nix": "logos-nix_538",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15782,6 +15696,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15804,13 +15719,11 @@
     },
     "logos-module_114": {
       "inputs": {
-        "logos-nix": "logos-nix_546",
+        "logos-nix": "logos-nix_545",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15833,34 +15746,7 @@
     },
     "logos-module_115": {
       "inputs": {
-        "logos-nix": "logos-nix_549",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_116": {
-      "inputs": {
-        "logos-nix": "logos-nix_554",
+        "logos-nix": "logos-nix_550",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15885,9 +15771,9 @@
         "type": "github"
       }
     },
-    "logos-module_117": {
+    "logos-module_116": {
       "inputs": {
-        "logos-nix": "logos-nix_556",
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15912,9 +15798,9 @@
         "type": "github"
       }
     },
-    "logos-module_118": {
+    "logos-module_117": {
       "inputs": {
-        "logos-nix": "logos-nix_576",
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15937,9 +15823,9 @@
         "type": "github"
       }
     },
-    "logos-module_119": {
+    "logos-module_118": {
       "inputs": {
-        "logos-nix": "logos-nix_578",
+        "logos-nix": "logos-nix_574",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15963,37 +15849,9 @@
         "type": "github"
       }
     },
-    "logos-module_12": {
+    "logos-module_119": {
       "inputs": {
-        "logos-nix": "logos-nix_50",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_120": {
-      "inputs": {
-        "logos-nix": "logos-nix_580",
+        "logos-nix": "logos-nix_576",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16017,9 +15875,37 @@
         "type": "github"
       }
     },
-    "logos-module_121": {
+    "logos-module_12": {
       "inputs": {
-        "logos-nix": "logos-nix_588",
+        "logos-nix": "logos-nix_48",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_120": {
+      "inputs": {
+        "logos-nix": "logos-nix_584",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16045,9 +15931,9 @@
         "type": "github"
       }
     },
-    "logos-module_122": {
+    "logos-module_121": {
       "inputs": {
-        "logos-nix": "logos-nix_593",
+        "logos-nix": "logos-nix_589",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16075,9 +15961,9 @@
         "type": "github"
       }
     },
-    "logos-module_123": {
+    "logos-module_122": {
       "inputs": {
-        "logos-nix": "logos-nix_596",
+        "logos-nix": "logos-nix_592",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16104,9 +15990,9 @@
         "type": "github"
       }
     },
-    "logos-module_124": {
+    "logos-module_123": {
       "inputs": {
-        "logos-nix": "logos-nix_598",
+        "logos-nix": "logos-nix_594",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16115,6 +16001,36 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_124": {
+      "inputs": {
+        "logos-nix": "logos-nix_596",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16144,6 +16060,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16166,38 +16083,7 @@
     },
     "logos-module_126": {
       "inputs": {
-        "logos-nix": "logos-nix_604",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_127": {
-      "inputs": {
-        "logos-nix": "logos-nix_606",
+        "logos-nix": "logos-nix_602",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16226,9 +16112,9 @@
         "type": "github"
       }
     },
-    "logos-module_128": {
+    "logos-module_127": {
       "inputs": {
-        "logos-nix": "logos-nix_608",
+        "logos-nix": "logos-nix_604",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16238,6 +16124,33 @@
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_128": {
+      "inputs": {
+        "logos-nix": "logos-nix_619",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16265,6 +16178,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16286,24 +16201,21 @@
     },
     "logos-module_13": {
       "inputs": {
-        "logos-nix": "logos-nix_52",
+        "logos-nix": "logos-nix_62",
+        "logos-package": "logos-package_7",
         "nixpkgs": [
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "lastModified": 1788740724,
+        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
         "type": "github"
       },
       "original": {
@@ -16314,7 +16226,7 @@
     },
     "logos-module_130": {
       "inputs": {
-        "logos-nix": "logos-nix_627",
+        "logos-nix": "logos-nix_625",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16322,6 +16234,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16343,7 +16256,7 @@
     },
     "logos-module_131": {
       "inputs": {
-        "logos-nix": "logos-nix_629",
+        "logos-nix": "logos-nix_627",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16351,7 +16264,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16381,6 +16294,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16411,37 +16325,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_134": {
-      "inputs": {
-        "logos-nix": "logos-nix_639",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
@@ -16464,9 +16347,9 @@
         "type": "github"
       }
     },
-    "logos-module_135": {
+    "logos-module_134": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_640",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16497,9 +16380,9 @@
         "type": "github"
       }
     },
-    "logos-module_136": {
+    "logos-module_135": {
       "inputs": {
-        "logos-nix": "logos-nix_646",
+        "logos-nix": "logos-nix_642",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16512,6 +16395,40 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_136": {
+      "inputs": {
+        "logos-nix": "logos-nix_644",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16545,6 +16462,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16567,7 +16485,7 @@
     },
     "logos-module_138": {
       "inputs": {
-        "logos-nix": "logos-nix_652",
+        "logos-nix": "logos-nix_650",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16579,7 +16497,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16602,7 +16520,7 @@
     },
     "logos-module_139": {
       "inputs": {
-        "logos-nix": "logos-nix_654",
+        "logos-nix": "logos-nix_652",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16614,7 +16532,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16638,20 +16556,21 @@
     "logos-module_14": {
       "inputs": {
         "logos-nix": "logos-nix_66",
-        "logos-package": "logos-package_7",
         "nixpkgs": [
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1788740724,
-        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
         "owner": "logos-co",
         "repo": "logos-module",
-        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
         "type": "github"
       },
       "original": {
@@ -16662,7 +16581,7 @@
     },
     "logos-module_140": {
       "inputs": {
-        "logos-nix": "logos-nix_656",
+        "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16672,10 +16591,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16697,7 +16612,7 @@
     },
     "logos-module_141": {
       "inputs": {
-        "logos-nix": "logos-nix_671",
+        "logos-nix": "logos-nix_675",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16707,6 +16622,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16728,7 +16644,7 @@
     },
     "logos-module_142": {
       "inputs": {
-        "logos-nix": "logos-nix_679",
+        "logos-nix": "logos-nix_680",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16737,7 +16653,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16760,38 +16675,7 @@
     },
     "logos-module_143": {
       "inputs": {
-        "logos-nix": "logos-nix_684",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_144": {
-      "inputs": {
-        "logos-nix": "logos-nix_687",
+        "logos-nix": "logos-nix_683",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16820,9 +16704,9 @@
         "type": "github"
       }
     },
-    "logos-module_145": {
+    "logos-module_144": {
       "inputs": {
-        "logos-nix": "logos-nix_689",
+        "logos-nix": "logos-nix_685",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16831,6 +16715,34 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_145": {
+      "inputs": {
+        "logos-nix": "logos-nix_704",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16859,6 +16771,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16881,13 +16794,11 @@
     },
     "logos-module_147": {
       "inputs": {
-        "logos-nix": "logos-nix_712",
+        "logos-nix": "logos-nix_711",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16910,34 +16821,7 @@
     },
     "logos-module_148": {
       "inputs": {
-        "logos-nix": "logos-nix_715",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_149": {
-      "inputs": {
-        "logos-nix": "logos-nix_720",
+        "logos-nix": "logos-nix_716",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16962,35 +16846,9 @@
         "type": "github"
       }
     },
-    "logos-module_15": {
+    "logos-module_149": {
       "inputs": {
-        "logos-nix": "logos-nix_70",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_150": {
-      "inputs": {
-        "logos-nix": "logos-nix_722",
+        "logos-nix": "logos-nix_718",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -17015,9 +16873,36 @@
         "type": "github"
       }
     },
-    "logos-module_151": {
+    "logos-module_15": {
       "inputs": {
-        "logos-nix": "logos-nix_736",
+        "logos-nix": "logos-nix_68",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_150": {
+      "inputs": {
+        "logos-nix": "logos-nix_732",
         "nixpkgs": [
           "logos-plugin-qt",
           "logos-module",
@@ -17041,12 +16926,12 @@
     },
     "logos-module_16": {
       "inputs": {
-        "logos-nix": "logos-nix_72",
+        "logos-nix": "logos-nix_70",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17073,6 +16958,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17100,8 +16986,9 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17123,14 +17010,15 @@
     },
     "logos-module_19": {
       "inputs": {
-        "logos-nix": "logos-nix_82",
+        "logos-nix": "logos-nix_83",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17178,7 +17066,7 @@
     },
     "logos-module_20": {
       "inputs": {
-        "logos-nix": "logos-nix_87",
+        "logos-nix": "logos-nix_85",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17187,6 +17075,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17208,7 +17097,7 @@
     },
     "logos-module_21": {
       "inputs": {
-        "logos-nix": "logos-nix_89",
+        "logos-nix": "logos-nix_87",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17217,7 +17106,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17248,6 +17137,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17270,39 +17160,7 @@
     },
     "logos-module_23": {
       "inputs": {
-        "logos-nix": "logos-nix_95",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_24": {
-      "inputs": {
-        "logos-nix": "logos-nix_97",
+        "logos-nix": "logos-nix_93",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17332,9 +17190,9 @@
         "type": "github"
       }
     },
-    "logos-module_25": {
+    "logos-module_24": {
       "inputs": {
-        "logos-nix": "logos-nix_99",
+        "logos-nix": "logos-nix_95",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17364,9 +17222,9 @@
         "type": "github"
       }
     },
-    "logos-module_26": {
+    "logos-module_25": {
       "inputs": {
-        "logos-nix": "logos-nix_114",
+        "logos-nix": "logos-nix_110",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -17392,15 +17250,43 @@
         "type": "github"
       }
     },
-    "logos-module_27": {
+    "logos-module_26": {
       "inputs": {
-        "logos-nix": "logos-nix_122",
+        "logos-nix": "logos-nix_118",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_27": {
+      "inputs": {
+        "logos-nix": "logos-nix_123",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17423,12 +17309,12 @@
     },
     "logos-module_28": {
       "inputs": {
-        "logos-nix": "logos-nix_127",
+        "logos-nix": "logos-nix_126",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17451,12 +17337,12 @@
     },
     "logos-module_29": {
       "inputs": {
-        "logos-nix": "logos-nix_130",
+        "logos-nix": "logos-nix_128",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17505,35 +17391,7 @@
     },
     "logos-module_30": {
       "inputs": {
-        "logos-nix": "logos-nix_132",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_31": {
-      "inputs": {
-        "logos-nix": "logos-nix_147",
+        "logos-nix": "logos-nix_143",
         "logos-package": "logos-package_15",
         "nixpkgs": [
           "logos-module",
@@ -17555,9 +17413,9 @@
         "type": "github"
       }
     },
-    "logos-module_32": {
+    "logos-module_31": {
       "inputs": {
-        "logos-nix": "logos-nix_150",
+        "logos-nix": "logos-nix_146",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-module",
@@ -17579,9 +17437,9 @@
         "type": "github"
       }
     },
-    "logos-module_33": {
+    "logos-module_32": {
       "inputs": {
-        "logos-nix": "logos-nix_155",
+        "logos-nix": "logos-nix_151",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-qt-sdk",
@@ -17605,9 +17463,9 @@
         "type": "github"
       }
     },
-    "logos-module_34": {
+    "logos-module_33": {
       "inputs": {
-        "logos-nix": "logos-nix_158",
+        "logos-nix": "logos-nix_154",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -17630,13 +17488,39 @@
         "type": "github"
       }
     },
-    "logos-module_35": {
+    "logos-module_34": {
       "inputs": {
-        "logos-nix": "logos-nix_160",
+        "logos-nix": "logos-nix_156",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_35": {
+      "inputs": {
+        "logos-nix": "logos-nix_158",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17662,6 +17546,7 @@
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17688,33 +17573,6 @@
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_38": {
-      "inputs": {
-        "logos-nix": "logos-nix_170",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
@@ -17737,9 +17595,9 @@
         "type": "github"
       }
     },
-    "logos-module_39": {
+    "logos-module_38": {
       "inputs": {
-        "logos-nix": "logos-nix_175",
+        "logos-nix": "logos-nix_171",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -17747,6 +17605,36 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_173",
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17795,7 +17683,7 @@
     },
     "logos-module_40": {
       "inputs": {
-        "logos-nix": "logos-nix_177",
+        "logos-nix": "logos-nix_175",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -17803,7 +17691,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17833,6 +17721,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17855,7 +17744,7 @@
     },
     "logos-module_42": {
       "inputs": {
-        "logos-nix": "logos-nix_183",
+        "logos-nix": "logos-nix_181",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -17863,7 +17752,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17886,7 +17775,7 @@
     },
     "logos-module_43": {
       "inputs": {
-        "logos-nix": "logos-nix_185",
+        "logos-nix": "logos-nix_183",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -17894,7 +17783,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -17917,16 +17806,12 @@
     },
     "logos-module_44": {
       "inputs": {
-        "logos-nix": "logos-nix_187",
+        "logos-nix": "logos-nix_198",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17948,12 +17833,13 @@
     },
     "logos-module_45": {
       "inputs": {
-        "logos-nix": "logos-nix_202",
+        "logos-nix": "logos-nix_206",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17975,12 +17861,11 @@
     },
     "logos-module_46": {
       "inputs": {
-        "logos-nix": "logos-nix_210",
+        "logos-nix": "logos-nix_211",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18003,34 +17888,7 @@
     },
     "logos-module_47": {
       "inputs": {
-        "logos-nix": "logos-nix_215",
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_218",
+        "logos-nix": "logos-nix_214",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -18055,14 +17913,39 @@
         "type": "github"
       }
     },
-    "logos-module_49": {
+    "logos-module_48": {
       "inputs": {
-        "logos-nix": "logos-nix_220",
+        "logos-nix": "logos-nix_216",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_49": {
+      "inputs": {
+        "logos-nix": "logos-nix_233",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18111,10 +17994,11 @@
     },
     "logos-module_50": {
       "inputs": {
-        "logos-nix": "logos-nix_237",
+        "logos-nix": "logos-nix_235",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18136,11 +18020,11 @@
     },
     "logos-module_51": {
       "inputs": {
-        "logos-nix": "logos-nix_239",
+        "logos-nix": "logos-nix_237",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18166,6 +18050,7 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18188,12 +18073,13 @@
     },
     "logos-module_53": {
       "inputs": {
-        "logos-nix": "logos-nix_245",
+        "logos-nix": "logos-nix_246",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18215,35 +18101,7 @@
     },
     "logos-module_54": {
       "inputs": {
-        "logos-nix": "logos-nix_250",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_255",
+        "logos-nix": "logos-nix_251",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18271,9 +18129,9 @@
         "type": "github"
       }
     },
-    "logos-module_56": {
+    "logos-module_55": {
       "inputs": {
-        "logos-nix": "logos-nix_258",
+        "logos-nix": "logos-nix_254",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18300,9 +18158,9 @@
         "type": "github"
       }
     },
-    "logos-module_57": {
+    "logos-module_56": {
       "inputs": {
-        "logos-nix": "logos-nix_260",
+        "logos-nix": "logos-nix_256",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18311,6 +18169,36 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_258",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18340,6 +18228,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18362,63 +18251,7 @@
     },
     "logos-module_59": {
       "inputs": {
-        "logos-nix": "logos-nix_266",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_6": {
-      "inputs": {
-        "logos-nix": "logos-nix_32",
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_60": {
-      "inputs": {
-        "logos-nix": "logos-nix_268",
+        "logos-nix": "logos-nix_264",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18447,9 +18280,34 @@
         "type": "github"
       }
     },
-    "logos-module_61": {
+    "logos-module_6": {
       "inputs": {
-        "logos-nix": "logos-nix_270",
+        "logos-nix": "logos-nix_31",
+        "nixpkgs": [
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_60": {
+      "inputs": {
+        "logos-nix": "logos-nix_266",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18478,6 +18336,33 @@
         "type": "github"
       }
     },
+    "logos-module_61": {
+      "inputs": {
+        "logos-nix": "logos-nix_281",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_62": {
       "inputs": {
         "logos-nix": "logos-nix_285",
@@ -18486,6 +18371,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18507,7 +18394,7 @@
     },
     "logos-module_63": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_287",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18515,6 +18402,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18536,7 +18424,7 @@
     },
     "logos-module_64": {
       "inputs": {
-        "logos-nix": "logos-nix_291",
+        "logos-nix": "logos-nix_289",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18544,7 +18432,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18574,6 +18462,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18604,37 +18493,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_301",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
@@ -18657,9 +18515,9 @@
         "type": "github"
       }
     },
-    "logos-module_68": {
+    "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_302",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18690,9 +18548,9 @@
         "type": "github"
       }
     },
-    "logos-module_69": {
+    "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_308",
+        "logos-nix": "logos-nix_304",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18724,14 +18582,47 @@
         "type": "github"
       }
     },
+    "logos-module_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_306",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_7": {
       "inputs": {
-        "logos-nix": "logos-nix_37",
+        "logos-nix": "logos-nix_36",
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18765,6 +18656,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18787,7 +18679,7 @@
     },
     "logos-module_71": {
       "inputs": {
-        "logos-nix": "logos-nix_314",
+        "logos-nix": "logos-nix_312",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18799,7 +18691,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18822,7 +18714,7 @@
     },
     "logos-module_72": {
       "inputs": {
-        "logos-nix": "logos-nix_316",
+        "logos-nix": "logos-nix_314",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18834,7 +18726,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18857,7 +18749,7 @@
     },
     "logos-module_73": {
       "inputs": {
-        "logos-nix": "logos-nix_318",
+        "logos-nix": "logos-nix_329",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18867,10 +18759,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18892,7 +18780,7 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_333",
+        "logos-nix": "logos-nix_337",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18902,6 +18790,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18923,7 +18812,7 @@
     },
     "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_341",
+        "logos-nix": "logos-nix_342",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18932,7 +18821,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18955,38 +18843,7 @@
     },
     "logos-module_76": {
       "inputs": {
-        "logos-nix": "logos-nix_346",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_349",
+        "logos-nix": "logos-nix_345",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19015,9 +18872,9 @@
         "type": "github"
       }
     },
-    "logos-module_78": {
+    "logos-module_77": {
       "inputs": {
-        "logos-nix": "logos-nix_351",
+        "logos-nix": "logos-nix_347",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19026,6 +18883,34 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_78": {
+      "inputs": {
+        "logos-nix": "logos-nix_366",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19054,6 +18939,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19076,11 +18962,12 @@
     },
     "logos-module_8": {
       "inputs": {
-        "logos-nix": "logos-nix_40",
+        "logos-nix": "logos-nix_38",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19102,13 +18989,11 @@
     },
     "logos-module_80": {
       "inputs": {
-        "logos-nix": "logos-nix_374",
+        "logos-nix": "logos-nix_373",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19131,34 +19016,7 @@
     },
     "logos-module_81": {
       "inputs": {
-        "logos-nix": "logos-nix_377",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_82": {
-      "inputs": {
-        "logos-nix": "logos-nix_382",
+        "logos-nix": "logos-nix_378",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19183,9 +19041,9 @@
         "type": "github"
       }
     },
-    "logos-module_83": {
+    "logos-module_82": {
       "inputs": {
-        "logos-nix": "logos-nix_384",
+        "logos-nix": "logos-nix_380",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -19210,9 +19068,9 @@
         "type": "github"
       }
     },
-    "logos-module_84": {
+    "logos-module_83": {
       "inputs": {
-        "logos-nix": "logos-nix_409",
+        "logos-nix": "logos-nix_405",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19235,13 +19093,39 @@
         "type": "github"
       }
     },
-    "logos-module_85": {
+    "logos-module_84": {
       "inputs": {
-        "logos-nix": "logos-nix_411",
+        "logos-nix": "logos-nix_407",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_85": {
+      "inputs": {
+        "logos-nix": "logos-nix_409",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19267,6 +19151,7 @@
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19289,12 +19174,13 @@
     },
     "logos-module_87": {
       "inputs": {
-        "logos-nix": "logos-nix_417",
+        "logos-nix": "logos-nix_418",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19316,35 +19202,7 @@
     },
     "logos-module_88": {
       "inputs": {
-        "logos-nix": "logos-nix_422",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_89": {
-      "inputs": {
-        "logos-nix": "logos-nix_427",
+        "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19372,14 +19230,43 @@
         "type": "github"
       }
     },
+    "logos-module_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_426",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_9": {
       "inputs": {
-        "logos-nix": "logos-nix_42",
+        "logos-nix": "logos-nix_40",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19401,7 +19288,7 @@
     },
     "logos-module_90": {
       "inputs": {
-        "logos-nix": "logos-nix_430",
+        "logos-nix": "logos-nix_428",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19409,6 +19296,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19430,7 +19318,7 @@
     },
     "logos-module_91": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": "logos-nix_430",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19438,7 +19326,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19468,6 +19356,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19490,38 +19379,7 @@
     },
     "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_438",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_94": {
-      "inputs": {
-        "logos-nix": "logos-nix_440",
+        "logos-nix": "logos-nix_436",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19550,9 +19408,9 @@
         "type": "github"
       }
     },
-    "logos-module_95": {
+    "logos-module_94": {
       "inputs": {
-        "logos-nix": "logos-nix_442",
+        "logos-nix": "logos-nix_438",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19581,6 +19439,33 @@
         "type": "github"
       }
     },
+    "logos-module_95": {
+      "inputs": {
+        "logos-nix": "logos-nix_453",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_96": {
       "inputs": {
         "logos-nix": "logos-nix_457",
@@ -19589,6 +19474,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19610,7 +19497,7 @@
     },
     "logos-module_97": {
       "inputs": {
-        "logos-nix": "logos-nix_461",
+        "logos-nix": "logos-nix_459",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19618,6 +19505,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19639,7 +19527,7 @@
     },
     "logos-module_98": {
       "inputs": {
-        "logos-nix": "logos-nix_463",
+        "logos-nix": "logos-nix_461",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19647,7 +19535,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19677,6 +19565,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19865,15 +19754,14 @@
     },
     "logos-nix_102": {
       "inputs": {
-        "nixpkgs": "nixpkgs_102",
-        "nixpkgs-windows": "nixpkgs-windows_98"
+        "nixpkgs": "nixpkgs_102"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19884,15 +19772,14 @@
     },
     "logos-nix_103": {
       "inputs": {
-        "nixpkgs": "nixpkgs_103",
-        "nixpkgs-windows": "nixpkgs-windows_99"
+        "nixpkgs": "nixpkgs_103"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -19904,7 +19791,7 @@
     "logos-nix_104": {
       "inputs": {
         "nixpkgs": "nixpkgs_104",
-        "nixpkgs-windows": "nixpkgs-windows_100"
+        "nixpkgs-windows": "nixpkgs-windows_98"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19923,7 +19810,7 @@
     "logos-nix_105": {
       "inputs": {
         "nixpkgs": "nixpkgs_105",
-        "nixpkgs-windows": "nixpkgs-windows_101"
+        "nixpkgs-windows": "nixpkgs-windows_99"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -19941,14 +19828,15 @@
     },
     "logos-nix_106": {
       "inputs": {
-        "nixpkgs": "nixpkgs_106"
+        "nixpkgs": "nixpkgs_106",
+        "nixpkgs-windows": "nixpkgs-windows_100"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -19959,14 +19847,15 @@
     },
     "logos-nix_107": {
       "inputs": {
-        "nixpkgs": "nixpkgs_107"
+        "nixpkgs": "nixpkgs_107",
+        "nixpkgs-windows": "nixpkgs-windows_101"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20129,15 +20018,14 @@
     },
     "logos-nix_115": {
       "inputs": {
-        "nixpkgs": "nixpkgs_115",
-        "nixpkgs-windows": "nixpkgs-windows_109"
+        "nixpkgs": "nixpkgs_115"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20148,15 +20036,14 @@
     },
     "logos-nix_116": {
       "inputs": {
-        "nixpkgs": "nixpkgs_116",
-        "nixpkgs-windows": "nixpkgs-windows_110"
+        "nixpkgs": "nixpkgs_116"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20168,7 +20055,7 @@
     "logos-nix_117": {
       "inputs": {
         "nixpkgs": "nixpkgs_117",
-        "nixpkgs-windows": "nixpkgs-windows_111"
+        "nixpkgs-windows": "nixpkgs-windows_109"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20187,7 +20074,7 @@
     "logos-nix_118": {
       "inputs": {
         "nixpkgs": "nixpkgs_118",
-        "nixpkgs-windows": "nixpkgs-windows_112"
+        "nixpkgs-windows": "nixpkgs-windows_110"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20205,14 +20092,15 @@
     },
     "logos-nix_119": {
       "inputs": {
-        "nixpkgs": "nixpkgs_119"
+        "nixpkgs": "nixpkgs_119",
+        "nixpkgs-windows": "nixpkgs-windows_111"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20242,14 +20130,15 @@
     },
     "logos-nix_120": {
       "inputs": {
-        "nixpkgs": "nixpkgs_120"
+        "nixpkgs": "nixpkgs_120",
+        "nixpkgs-windows": "nixpkgs-windows_112"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20283,11 +20172,11 @@
         "nixpkgs-windows": "nixpkgs-windows_114"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -20317,15 +20206,14 @@
     },
     "logos-nix_124": {
       "inputs": {
-        "nixpkgs": "nixpkgs_124",
-        "nixpkgs-windows": "nixpkgs-windows_116"
+        "nixpkgs": "nixpkgs_124"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20337,7 +20225,7 @@
     "logos-nix_125": {
       "inputs": {
         "nixpkgs": "nixpkgs_125",
-        "nixpkgs-windows": "nixpkgs-windows_117"
+        "nixpkgs-windows": "nixpkgs-windows_116"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20356,14 +20244,14 @@
     "logos-nix_126": {
       "inputs": {
         "nixpkgs": "nixpkgs_126",
-        "nixpkgs-windows": "nixpkgs-windows_118"
+        "nixpkgs-windows": "nixpkgs-windows_117"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20375,7 +20263,7 @@
     "logos-nix_127": {
       "inputs": {
         "nixpkgs": "nixpkgs_127",
-        "nixpkgs-windows": "nixpkgs-windows_119"
+        "nixpkgs-windows": "nixpkgs-windows_118"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20393,14 +20281,15 @@
     },
     "logos-nix_128": {
       "inputs": {
-        "nixpkgs": "nixpkgs_128"
+        "nixpkgs": "nixpkgs_128",
+        "nixpkgs-windows": "nixpkgs-windows_119"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20544,15 +20433,14 @@
     },
     "logos-nix_135": {
       "inputs": {
-        "nixpkgs": "nixpkgs_135",
-        "nixpkgs-windows": "nixpkgs-windows_126"
+        "nixpkgs": "nixpkgs_135"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20563,15 +20451,14 @@
     },
     "logos-nix_136": {
       "inputs": {
-        "nixpkgs": "nixpkgs_136",
-        "nixpkgs-windows": "nixpkgs-windows_127"
+        "nixpkgs": "nixpkgs_136"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -20583,7 +20470,7 @@
     "logos-nix_137": {
       "inputs": {
         "nixpkgs": "nixpkgs_137",
-        "nixpkgs-windows": "nixpkgs-windows_128"
+        "nixpkgs-windows": "nixpkgs-windows_126"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20602,7 +20489,7 @@
     "logos-nix_138": {
       "inputs": {
         "nixpkgs": "nixpkgs_138",
-        "nixpkgs-windows": "nixpkgs-windows_129"
+        "nixpkgs-windows": "nixpkgs-windows_127"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -20620,14 +20507,15 @@
     },
     "logos-nix_139": {
       "inputs": {
-        "nixpkgs": "nixpkgs_139"
+        "nixpkgs": "nixpkgs_139",
+        "nixpkgs-windows": "nixpkgs-windows_128"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20657,14 +20545,15 @@
     },
     "logos-nix_140": {
       "inputs": {
-        "nixpkgs": "nixpkgs_140"
+        "nixpkgs": "nixpkgs_140",
+        "nixpkgs-windows": "nixpkgs-windows_129"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20679,11 +20568,11 @@
         "nixpkgs-windows": "nixpkgs-windows_130"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -20755,11 +20644,11 @@
         "nixpkgs-windows": "nixpkgs-windows_134"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -20812,11 +20701,11 @@
         "nixpkgs-windows": "nixpkgs-windows_137"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -20907,11 +20796,11 @@
         "nixpkgs-windows": "nixpkgs-windows_141"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21230,11 +21119,11 @@
         "nixpkgs-windows": "nixpkgs-windows_157"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -21325,11 +21214,11 @@
         "nixpkgs-windows": "nixpkgs-windows_161"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21701,15 +21590,14 @@
     },
     "logos-nix_190": {
       "inputs": {
-        "nixpkgs": "nixpkgs_190",
-        "nixpkgs-windows": "nixpkgs-windows_179"
+        "nixpkgs": "nixpkgs_190"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21720,15 +21608,14 @@
     },
     "logos-nix_191": {
       "inputs": {
-        "nixpkgs": "nixpkgs_191",
-        "nixpkgs-windows": "nixpkgs-windows_180"
+        "nixpkgs": "nixpkgs_191"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -21740,7 +21627,7 @@
     "logos-nix_192": {
       "inputs": {
         "nixpkgs": "nixpkgs_192",
-        "nixpkgs-windows": "nixpkgs-windows_181"
+        "nixpkgs-windows": "nixpkgs-windows_179"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21759,7 +21646,7 @@
     "logos-nix_193": {
       "inputs": {
         "nixpkgs": "nixpkgs_193",
-        "nixpkgs-windows": "nixpkgs-windows_182"
+        "nixpkgs-windows": "nixpkgs-windows_180"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -21777,14 +21664,15 @@
     },
     "logos-nix_194": {
       "inputs": {
-        "nixpkgs": "nixpkgs_194"
+        "nixpkgs": "nixpkgs_194",
+        "nixpkgs-windows": "nixpkgs-windows_181"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21795,14 +21683,15 @@
     },
     "logos-nix_195": {
       "inputs": {
-        "nixpkgs": "nixpkgs_195"
+        "nixpkgs": "nixpkgs_195",
+        "nixpkgs-windows": "nixpkgs-windows_182"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -21984,15 +21873,14 @@
     },
     "logos-nix_203": {
       "inputs": {
-        "nixpkgs": "nixpkgs_203",
-        "nixpkgs-windows": "nixpkgs-windows_190"
+        "nixpkgs": "nixpkgs_203"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22003,15 +21891,14 @@
     },
     "logos-nix_204": {
       "inputs": {
-        "nixpkgs": "nixpkgs_204",
-        "nixpkgs-windows": "nixpkgs-windows_191"
+        "nixpkgs": "nixpkgs_204"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22023,7 +21910,7 @@
     "logos-nix_205": {
       "inputs": {
         "nixpkgs": "nixpkgs_205",
-        "nixpkgs-windows": "nixpkgs-windows_192"
+        "nixpkgs-windows": "nixpkgs-windows_190"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22042,7 +21929,7 @@
     "logos-nix_206": {
       "inputs": {
         "nixpkgs": "nixpkgs_206",
-        "nixpkgs-windows": "nixpkgs-windows_193"
+        "nixpkgs-windows": "nixpkgs-windows_191"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22060,14 +21947,15 @@
     },
     "logos-nix_207": {
       "inputs": {
-        "nixpkgs": "nixpkgs_207"
+        "nixpkgs": "nixpkgs_207",
+        "nixpkgs-windows": "nixpkgs-windows_192"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22078,14 +21966,15 @@
     },
     "logos-nix_208": {
       "inputs": {
-        "nixpkgs": "nixpkgs_208"
+        "nixpkgs": "nixpkgs_208",
+        "nixpkgs-windows": "nixpkgs-windows_193"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22137,11 +22026,11 @@
         "nixpkgs-windows": "nixpkgs-windows_195"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -22171,15 +22060,14 @@
     },
     "logos-nix_212": {
       "inputs": {
-        "nixpkgs": "nixpkgs_212",
-        "nixpkgs-windows": "nixpkgs-windows_197"
+        "nixpkgs": "nixpkgs_212"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22191,7 +22079,7 @@
     "logos-nix_213": {
       "inputs": {
         "nixpkgs": "nixpkgs_213",
-        "nixpkgs-windows": "nixpkgs-windows_198"
+        "nixpkgs-windows": "nixpkgs-windows_197"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22210,14 +22098,14 @@
     "logos-nix_214": {
       "inputs": {
         "nixpkgs": "nixpkgs_214",
-        "nixpkgs-windows": "nixpkgs-windows_199"
+        "nixpkgs-windows": "nixpkgs-windows_198"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22229,7 +22117,7 @@
     "logos-nix_215": {
       "inputs": {
         "nixpkgs": "nixpkgs_215",
-        "nixpkgs-windows": "nixpkgs-windows_200"
+        "nixpkgs-windows": "nixpkgs-windows_199"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22247,14 +22135,15 @@
     },
     "logos-nix_216": {
       "inputs": {
-        "nixpkgs": "nixpkgs_216"
+        "nixpkgs": "nixpkgs_216",
+        "nixpkgs-windows": "nixpkgs-windows_200"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22397,15 +22286,14 @@
     },
     "logos-nix_223": {
       "inputs": {
-        "nixpkgs": "nixpkgs_223",
-        "nixpkgs-windows": "nixpkgs-windows_207"
+        "nixpkgs": "nixpkgs_223"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22416,15 +22304,14 @@
     },
     "logos-nix_224": {
       "inputs": {
-        "nixpkgs": "nixpkgs_224",
-        "nixpkgs-windows": "nixpkgs-windows_208"
+        "nixpkgs": "nixpkgs_224"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -22436,7 +22323,7 @@
     "logos-nix_225": {
       "inputs": {
         "nixpkgs": "nixpkgs_225",
-        "nixpkgs-windows": "nixpkgs-windows_209"
+        "nixpkgs-windows": "nixpkgs-windows_207"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22455,7 +22342,7 @@
     "logos-nix_226": {
       "inputs": {
         "nixpkgs": "nixpkgs_226",
-        "nixpkgs-windows": "nixpkgs-windows_210"
+        "nixpkgs-windows": "nixpkgs-windows_208"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -22473,14 +22360,15 @@
     },
     "logos-nix_227": {
       "inputs": {
-        "nixpkgs": "nixpkgs_227"
+        "nixpkgs": "nixpkgs_227",
+        "nixpkgs-windows": "nixpkgs-windows_209"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22491,14 +22379,15 @@
     },
     "logos-nix_228": {
       "inputs": {
-        "nixpkgs": "nixpkgs_228"
+        "nixpkgs": "nixpkgs_228",
+        "nixpkgs-windows": "nixpkgs-windows_210"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22513,11 +22402,11 @@
         "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1788961777,
+        "narHash": "sha256-p3bCNBLWks0Z7OoJaBhkTPpXtfgX59rtUefcbC59gM8=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "5378de595fa5d200d3e2f950b9a3a4c193170528",
         "type": "github"
       },
       "original": {
@@ -22608,11 +22497,11 @@
         "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
-        "lastModified": 1788961777,
-        "narHash": "sha256-p3bCNBLWks0Z7OoJaBhkTPpXtfgX59rtUefcbC59gM8=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "5378de595fa5d200d3e2f950b9a3a4c193170528",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22627,11 +22516,11 @@
         "nixpkgs-windows": "nixpkgs-windows_216"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -22703,11 +22592,11 @@
         "nixpkgs-windows": "nixpkgs-windows_220"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -22912,11 +22801,11 @@
         "nixpkgs-windows": "nixpkgs-windows_230"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23007,11 +22896,11 @@
         "nixpkgs-windows": "nixpkgs-windows_234"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23064,11 +22953,11 @@
         "nixpkgs-windows": "nixpkgs-windows_237"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23140,11 +23029,11 @@
         "nixpkgs-windows": "nixpkgs-windows_241"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23387,11 +23276,11 @@
         "nixpkgs-windows": "nixpkgs-windows_252"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23406,11 +23295,11 @@
         "nixpkgs-windows": "nixpkgs-windows_253"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23440,7 +23329,43 @@
     },
     "logos-nix_273": {
       "inputs": {
-        "nixpkgs": "nixpkgs_273",
+        "nixpkgs": "nixpkgs_273"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_274": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_274"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_275": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_275",
         "nixpkgs-windows": "nixpkgs-windows_255"
       },
       "locked": {
@@ -23457,48 +23382,10 @@
         "type": "github"
       }
     },
-    "logos-nix_274": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_274",
-        "nixpkgs-windows": "nixpkgs-windows_256"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_275": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_275",
-        "nixpkgs-windows": "nixpkgs-windows_257"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_276": {
       "inputs": {
         "nixpkgs": "nixpkgs_276",
-        "nixpkgs-windows": "nixpkgs-windows_258"
+        "nixpkgs-windows": "nixpkgs-windows_256"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23516,14 +23403,15 @@
     },
     "logos-nix_277": {
       "inputs": {
-        "nixpkgs": "nixpkgs_277"
+        "nixpkgs": "nixpkgs_277",
+        "nixpkgs-windows": "nixpkgs-windows_257"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23534,14 +23422,15 @@
     },
     "logos-nix_278": {
       "inputs": {
-        "nixpkgs": "nixpkgs_278"
+        "nixpkgs": "nixpkgs_278",
+        "nixpkgs-windows": "nixpkgs-windows_258"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -23974,11 +23863,11 @@
         "nixpkgs-windows": "nixpkgs-windows_279"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24088,11 +23977,11 @@
         "nixpkgs-windows": "nixpkgs-windows_283"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24464,15 +24353,14 @@
     },
     "logos-nix_321": {
       "inputs": {
-        "nixpkgs": "nixpkgs_321",
-        "nixpkgs-windows": "nixpkgs-windows_301"
+        "nixpkgs": "nixpkgs_321"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24483,15 +24371,14 @@
     },
     "logos-nix_322": {
       "inputs": {
-        "nixpkgs": "nixpkgs_322",
-        "nixpkgs-windows": "nixpkgs-windows_302"
+        "nixpkgs": "nixpkgs_322"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24503,7 +24390,7 @@
     "logos-nix_323": {
       "inputs": {
         "nixpkgs": "nixpkgs_323",
-        "nixpkgs-windows": "nixpkgs-windows_303"
+        "nixpkgs-windows": "nixpkgs-windows_301"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24522,7 +24409,7 @@
     "logos-nix_324": {
       "inputs": {
         "nixpkgs": "nixpkgs_324",
-        "nixpkgs-windows": "nixpkgs-windows_304"
+        "nixpkgs-windows": "nixpkgs-windows_302"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24540,14 +24427,15 @@
     },
     "logos-nix_325": {
       "inputs": {
-        "nixpkgs": "nixpkgs_325"
+        "nixpkgs": "nixpkgs_325",
+        "nixpkgs-windows": "nixpkgs-windows_303"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24558,14 +24446,15 @@
     },
     "logos-nix_326": {
       "inputs": {
-        "nixpkgs": "nixpkgs_326"
+        "nixpkgs": "nixpkgs_326",
+        "nixpkgs-windows": "nixpkgs-windows_304"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24637,11 +24526,11 @@
         "nixpkgs-windows": "nixpkgs-windows_31"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24728,15 +24617,14 @@
     },
     "logos-nix_334": {
       "inputs": {
-        "nixpkgs": "nixpkgs_334",
-        "nixpkgs-windows": "nixpkgs-windows_312"
+        "nixpkgs": "nixpkgs_334"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24747,15 +24635,14 @@
     },
     "logos-nix_335": {
       "inputs": {
-        "nixpkgs": "nixpkgs_335",
-        "nixpkgs-windows": "nixpkgs-windows_313"
+        "nixpkgs": "nixpkgs_335"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24767,7 +24654,7 @@
     "logos-nix_336": {
       "inputs": {
         "nixpkgs": "nixpkgs_336",
-        "nixpkgs-windows": "nixpkgs-windows_314"
+        "nixpkgs-windows": "nixpkgs-windows_312"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24786,7 +24673,7 @@
     "logos-nix_337": {
       "inputs": {
         "nixpkgs": "nixpkgs_337",
-        "nixpkgs-windows": "nixpkgs-windows_315"
+        "nixpkgs-windows": "nixpkgs-windows_313"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24804,14 +24691,15 @@
     },
     "logos-nix_338": {
       "inputs": {
-        "nixpkgs": "nixpkgs_338"
+        "nixpkgs": "nixpkgs_338",
+        "nixpkgs-windows": "nixpkgs-windows_314"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24822,14 +24710,15 @@
     },
     "logos-nix_339": {
       "inputs": {
-        "nixpkgs": "nixpkgs_339"
+        "nixpkgs": "nixpkgs_339",
+        "nixpkgs-windows": "nixpkgs-windows_315"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24844,11 +24733,11 @@
         "nixpkgs-windows": "nixpkgs-windows_32"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24882,11 +24771,11 @@
         "nixpkgs-windows": "nixpkgs-windows_317"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24916,15 +24805,14 @@
     },
     "logos-nix_343": {
       "inputs": {
-        "nixpkgs": "nixpkgs_343",
-        "nixpkgs-windows": "nixpkgs-windows_319"
+        "nixpkgs": "nixpkgs_343"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24936,7 +24824,7 @@
     "logos-nix_344": {
       "inputs": {
         "nixpkgs": "nixpkgs_344",
-        "nixpkgs-windows": "nixpkgs-windows_320"
+        "nixpkgs-windows": "nixpkgs-windows_319"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24955,14 +24843,14 @@
     "logos-nix_345": {
       "inputs": {
         "nixpkgs": "nixpkgs_345",
-        "nixpkgs-windows": "nixpkgs-windows_321"
+        "nixpkgs-windows": "nixpkgs-windows_320"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -24974,7 +24862,7 @@
     "logos-nix_346": {
       "inputs": {
         "nixpkgs": "nixpkgs_346",
-        "nixpkgs-windows": "nixpkgs-windows_322"
+        "nixpkgs-windows": "nixpkgs-windows_321"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24992,14 +24880,15 @@
     },
     "logos-nix_347": {
       "inputs": {
-        "nixpkgs": "nixpkgs_347"
+        "nixpkgs": "nixpkgs_347",
+        "nixpkgs-windows": "nixpkgs-windows_322"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25143,15 +25032,14 @@
     },
     "logos-nix_354": {
       "inputs": {
-        "nixpkgs": "nixpkgs_354",
-        "nixpkgs-windows": "nixpkgs-windows_329"
+        "nixpkgs": "nixpkgs_354"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25162,15 +25050,14 @@
     },
     "logos-nix_355": {
       "inputs": {
-        "nixpkgs": "nixpkgs_355",
-        "nixpkgs-windows": "nixpkgs-windows_330"
+        "nixpkgs": "nixpkgs_355"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25182,7 +25069,7 @@
     "logos-nix_356": {
       "inputs": {
         "nixpkgs": "nixpkgs_356",
-        "nixpkgs-windows": "nixpkgs-windows_331"
+        "nixpkgs-windows": "nixpkgs-windows_329"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25201,7 +25088,7 @@
     "logos-nix_357": {
       "inputs": {
         "nixpkgs": "nixpkgs_357",
-        "nixpkgs-windows": "nixpkgs-windows_332"
+        "nixpkgs-windows": "nixpkgs-windows_330"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25219,14 +25106,15 @@
     },
     "logos-nix_358": {
       "inputs": {
-        "nixpkgs": "nixpkgs_358"
+        "nixpkgs": "nixpkgs_358",
+        "nixpkgs-windows": "nixpkgs-windows_331"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25237,14 +25125,15 @@
     },
     "logos-nix_359": {
       "inputs": {
-        "nixpkgs": "nixpkgs_359"
+        "nixpkgs": "nixpkgs_359",
+        "nixpkgs-windows": "nixpkgs-windows_332"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25278,11 +25167,11 @@
         "nixpkgs-windows": "nixpkgs-windows_333"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25297,11 +25186,11 @@
         "nixpkgs-windows": "nixpkgs-windows_334"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25331,7 +25220,43 @@
     },
     "logos-nix_363": {
       "inputs": {
-        "nixpkgs": "nixpkgs_363",
+        "nixpkgs": "nixpkgs_363"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_364": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_364"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_365": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_365",
         "nixpkgs-windows": "nixpkgs-windows_336"
       },
       "locked": {
@@ -25348,48 +25273,10 @@
         "type": "github"
       }
     },
-    "logos-nix_364": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_364",
-        "nixpkgs-windows": "nixpkgs-windows_337"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_365": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_365",
-        "nixpkgs-windows": "nixpkgs-windows_338"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_366": {
       "inputs": {
         "nixpkgs": "nixpkgs_366",
-        "nixpkgs-windows": "nixpkgs-windows_339"
+        "nixpkgs-windows": "nixpkgs-windows_337"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25407,14 +25294,15 @@
     },
     "logos-nix_367": {
       "inputs": {
-        "nixpkgs": "nixpkgs_367"
+        "nixpkgs": "nixpkgs_367",
+        "nixpkgs-windows": "nixpkgs-windows_338"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25425,14 +25313,15 @@
     },
     "logos-nix_368": {
       "inputs": {
-        "nixpkgs": "nixpkgs_368"
+        "nixpkgs": "nixpkgs_368",
+        "nixpkgs-windows": "nixpkgs-windows_339"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25466,11 +25355,11 @@
         "nixpkgs-windows": "nixpkgs-windows_35"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25523,11 +25412,11 @@
         "nixpkgs-windows": "nixpkgs-windows_343"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25595,15 +25484,14 @@
     },
     "logos-nix_376": {
       "inputs": {
-        "nixpkgs": "nixpkgs_376",
-        "nixpkgs-windows": "nixpkgs-windows_347"
+        "nixpkgs": "nixpkgs_376"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25615,7 +25503,7 @@
     "logos-nix_377": {
       "inputs": {
         "nixpkgs": "nixpkgs_377",
-        "nixpkgs-windows": "nixpkgs-windows_348"
+        "nixpkgs-windows": "nixpkgs-windows_347"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25634,7 +25522,7 @@
     "logos-nix_378": {
       "inputs": {
         "nixpkgs": "nixpkgs_378",
-        "nixpkgs-windows": "nixpkgs-windows_349"
+        "nixpkgs-windows": "nixpkgs-windows_348"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25653,7 +25541,7 @@
     "logos-nix_379": {
       "inputs": {
         "nixpkgs": "nixpkgs_379",
-        "nixpkgs-windows": "nixpkgs-windows_350"
+        "nixpkgs-windows": "nixpkgs-windows_349"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25690,14 +25578,15 @@
     },
     "logos-nix_380": {
       "inputs": {
-        "nixpkgs": "nixpkgs_380"
+        "nixpkgs": "nixpkgs_380",
+        "nixpkgs-windows": "nixpkgs-windows_350"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25769,11 +25658,11 @@
         "nixpkgs-windows": "nixpkgs-windows_354"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25788,11 +25677,11 @@
         "nixpkgs-windows": "nixpkgs-windows_355"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25822,15 +25711,14 @@
     },
     "logos-nix_387": {
       "inputs": {
-        "nixpkgs": "nixpkgs_387",
-        "nixpkgs-windows": "nixpkgs-windows_357"
+        "nixpkgs": "nixpkgs_387"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25841,15 +25729,14 @@
     },
     "logos-nix_388": {
       "inputs": {
-        "nixpkgs": "nixpkgs_388",
-        "nixpkgs-windows": "nixpkgs-windows_358"
+        "nixpkgs": "nixpkgs_388"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -25861,14 +25748,14 @@
     "logos-nix_389": {
       "inputs": {
         "nixpkgs": "nixpkgs_389",
-        "nixpkgs-windows": "nixpkgs-windows_359"
+        "nixpkgs-windows": "nixpkgs-windows_357"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25899,7 +25786,7 @@
     "logos-nix_390": {
       "inputs": {
         "nixpkgs": "nixpkgs_390",
-        "nixpkgs-windows": "nixpkgs-windows_360"
+        "nixpkgs-windows": "nixpkgs-windows_358"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25917,14 +25804,15 @@
     },
     "logos-nix_391": {
       "inputs": {
-        "nixpkgs": "nixpkgs_391"
+        "nixpkgs": "nixpkgs_391",
+        "nixpkgs-windows": "nixpkgs-windows_359"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25935,14 +25823,15 @@
     },
     "logos-nix_392": {
       "inputs": {
-        "nixpkgs": "nixpkgs_392"
+        "nixpkgs": "nixpkgs_392",
+        "nixpkgs-windows": "nixpkgs-windows_360"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -25957,11 +25846,11 @@
         "nixpkgs-windows": "nixpkgs-windows_361"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25991,7 +25880,43 @@
     },
     "logos-nix_395": {
       "inputs": {
-        "nixpkgs": "nixpkgs_395",
+        "nixpkgs": "nixpkgs_395"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_396": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_396"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_397": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_397",
         "nixpkgs-windows": "nixpkgs-windows_363"
       },
       "locked": {
@@ -26008,29 +25933,10 @@
         "type": "github"
       }
     },
-    "logos-nix_396": {
+    "logos-nix_398": {
       "inputs": {
-        "nixpkgs": "nixpkgs_396",
+        "nixpkgs": "nixpkgs_398",
         "nixpkgs-windows": "nixpkgs-windows_364"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_397": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_397",
-        "nixpkgs-windows": "nixpkgs-windows_365"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -26046,10 +25952,10 @@
         "type": "github"
       }
     },
-    "logos-nix_398": {
+    "logos-nix_399": {
       "inputs": {
-        "nixpkgs": "nixpkgs_398",
-        "nixpkgs-windows": "nixpkgs-windows_366"
+        "nixpkgs": "nixpkgs_399",
+        "nixpkgs-windows": "nixpkgs-windows_365"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26057,24 +25963,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_399": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_399"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26126,6 +26014,24 @@
         "nixpkgs": "nixpkgs_400"
       },
       "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_401": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_401"
+      },
+      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -26139,10 +26045,10 @@
         "type": "github"
       }
     },
-    "logos-nix_401": {
+    "logos-nix_402": {
       "inputs": {
-        "nixpkgs": "nixpkgs_401",
-        "nixpkgs-windows": "nixpkgs-windows_367"
+        "nixpkgs": "nixpkgs_402",
+        "nixpkgs-windows": "nixpkgs-windows_366"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26158,29 +26064,10 @@
         "type": "github"
       }
     },
-    "logos-nix_402": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_402",
-        "nixpkgs-windows": "nixpkgs-windows_368"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_403": {
       "inputs": {
         "nixpkgs": "nixpkgs_403",
-        "nixpkgs-windows": "nixpkgs-windows_369"
+        "nixpkgs-windows": "nixpkgs-windows_367"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26198,14 +26085,15 @@
     },
     "logos-nix_404": {
       "inputs": {
-        "nixpkgs": "nixpkgs_404"
+        "nixpkgs": "nixpkgs_404",
+        "nixpkgs-windows": "nixpkgs-windows_368"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26216,14 +26104,15 @@
     },
     "logos-nix_405": {
       "inputs": {
-        "nixpkgs": "nixpkgs_405"
+        "nixpkgs": "nixpkgs_405",
+        "nixpkgs-windows": "nixpkgs-windows_369"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26238,11 +26127,11 @@
         "nixpkgs-windows": "nixpkgs-windows_370"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26314,11 +26203,11 @@
         "nixpkgs-windows": "nixpkgs-windows_39"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26333,11 +26222,11 @@
         "nixpkgs-windows": "nixpkgs-windows_374"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26542,11 +26431,11 @@
         "nixpkgs-windows": "nixpkgs-windows_384"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26618,11 +26507,11 @@
         "nixpkgs-windows": "nixpkgs-windows_388"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26675,11 +26564,11 @@
         "nixpkgs-windows": "nixpkgs-windows_391"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26770,11 +26659,11 @@
         "nixpkgs-windows": "nixpkgs-windows_395"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -26998,11 +26887,11 @@
         "nixpkgs-windows": "nixpkgs-windows_406"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27017,11 +26906,11 @@
         "nixpkgs-windows": "nixpkgs-windows_407"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27051,7 +26940,43 @@
     },
     "logos-nix_445": {
       "inputs": {
-        "nixpkgs": "nixpkgs_445",
+        "nixpkgs": "nixpkgs_445"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_446": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_446"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_447": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_447",
         "nixpkgs-windows": "nixpkgs-windows_409"
       },
       "locked": {
@@ -27068,48 +26993,10 @@
         "type": "github"
       }
     },
-    "logos-nix_446": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_446",
-        "nixpkgs-windows": "nixpkgs-windows_410"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_447": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_447",
-        "nixpkgs-windows": "nixpkgs-windows_411"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_448": {
       "inputs": {
         "nixpkgs": "nixpkgs_448",
-        "nixpkgs-windows": "nixpkgs-windows_412"
+        "nixpkgs-windows": "nixpkgs-windows_410"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27127,14 +27014,15 @@
     },
     "logos-nix_449": {
       "inputs": {
-        "nixpkgs": "nixpkgs_449"
+        "nixpkgs": "nixpkgs_449",
+        "nixpkgs-windows": "nixpkgs-windows_411"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27164,14 +27052,15 @@
     },
     "logos-nix_450": {
       "inputs": {
-        "nixpkgs": "nixpkgs_450"
+        "nixpkgs": "nixpkgs_450",
+        "nixpkgs-windows": "nixpkgs-windows_412"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27604,11 +27493,11 @@
         "nixpkgs-windows": "nixpkgs-windows_433"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27680,11 +27569,11 @@
         "nixpkgs-windows": "nixpkgs-windows_437"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28056,15 +27945,14 @@
     },
     "logos-nix_493": {
       "inputs": {
-        "nixpkgs": "nixpkgs_493",
-        "nixpkgs-windows": "nixpkgs-windows_455"
+        "nixpkgs": "nixpkgs_493"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28075,15 +27963,14 @@
     },
     "logos-nix_494": {
       "inputs": {
-        "nixpkgs": "nixpkgs_494",
-        "nixpkgs-windows": "nixpkgs-windows_456"
+        "nixpkgs": "nixpkgs_494"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28095,7 +27982,7 @@
     "logos-nix_495": {
       "inputs": {
         "nixpkgs": "nixpkgs_495",
-        "nixpkgs-windows": "nixpkgs-windows_457"
+        "nixpkgs-windows": "nixpkgs-windows_455"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28114,7 +28001,7 @@
     "logos-nix_496": {
       "inputs": {
         "nixpkgs": "nixpkgs_496",
-        "nixpkgs-windows": "nixpkgs-windows_458"
+        "nixpkgs-windows": "nixpkgs-windows_456"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28132,14 +28019,15 @@
     },
     "logos-nix_497": {
       "inputs": {
-        "nixpkgs": "nixpkgs_497"
+        "nixpkgs": "nixpkgs_497",
+        "nixpkgs-windows": "nixpkgs-windows_457"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28150,14 +28038,15 @@
     },
     "logos-nix_498": {
       "inputs": {
-        "nixpkgs": "nixpkgs_498"
+        "nixpkgs": "nixpkgs_498",
+        "nixpkgs-windows": "nixpkgs-windows_458"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28339,15 +28228,14 @@
     },
     "logos-nix_506": {
       "inputs": {
-        "nixpkgs": "nixpkgs_506",
-        "nixpkgs-windows": "nixpkgs-windows_466"
+        "nixpkgs": "nixpkgs_506"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28358,15 +28246,14 @@
     },
     "logos-nix_507": {
       "inputs": {
-        "nixpkgs": "nixpkgs_507",
-        "nixpkgs-windows": "nixpkgs-windows_467"
+        "nixpkgs": "nixpkgs_507"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28378,7 +28265,7 @@
     "logos-nix_508": {
       "inputs": {
         "nixpkgs": "nixpkgs_508",
-        "nixpkgs-windows": "nixpkgs-windows_468"
+        "nixpkgs-windows": "nixpkgs-windows_466"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28397,7 +28284,7 @@
     "logos-nix_509": {
       "inputs": {
         "nixpkgs": "nixpkgs_509",
-        "nixpkgs-windows": "nixpkgs-windows_469"
+        "nixpkgs-windows": "nixpkgs-windows_467"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28434,14 +28321,15 @@
     },
     "logos-nix_510": {
       "inputs": {
-        "nixpkgs": "nixpkgs_510"
+        "nixpkgs": "nixpkgs_510",
+        "nixpkgs-windows": "nixpkgs-windows_468"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28452,14 +28340,15 @@
     },
     "logos-nix_511": {
       "inputs": {
-        "nixpkgs": "nixpkgs_511"
+        "nixpkgs": "nixpkgs_511",
+        "nixpkgs-windows": "nixpkgs-windows_469"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28493,11 +28382,11 @@
         "nixpkgs-windows": "nixpkgs-windows_471"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28527,15 +28416,14 @@
     },
     "logos-nix_515": {
       "inputs": {
-        "nixpkgs": "nixpkgs_515",
-        "nixpkgs-windows": "nixpkgs-windows_473"
+        "nixpkgs": "nixpkgs_515"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28547,7 +28435,7 @@
     "logos-nix_516": {
       "inputs": {
         "nixpkgs": "nixpkgs_516",
-        "nixpkgs-windows": "nixpkgs-windows_474"
+        "nixpkgs-windows": "nixpkgs-windows_473"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28566,14 +28454,14 @@
     "logos-nix_517": {
       "inputs": {
         "nixpkgs": "nixpkgs_517",
-        "nixpkgs-windows": "nixpkgs-windows_475"
+        "nixpkgs-windows": "nixpkgs-windows_474"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28585,7 +28473,7 @@
     "logos-nix_518": {
       "inputs": {
         "nixpkgs": "nixpkgs_518",
-        "nixpkgs-windows": "nixpkgs-windows_476"
+        "nixpkgs-windows": "nixpkgs-windows_475"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28603,14 +28491,15 @@
     },
     "logos-nix_519": {
       "inputs": {
-        "nixpkgs": "nixpkgs_519"
+        "nixpkgs": "nixpkgs_519",
+        "nixpkgs-windows": "nixpkgs-windows_476"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28625,11 +28514,11 @@
         "nixpkgs-windows": "nixpkgs-windows_50"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28754,15 +28643,14 @@
     },
     "logos-nix_526": {
       "inputs": {
-        "nixpkgs": "nixpkgs_526",
-        "nixpkgs-windows": "nixpkgs-windows_483"
+        "nixpkgs": "nixpkgs_526"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28773,15 +28661,14 @@
     },
     "logos-nix_527": {
       "inputs": {
-        "nixpkgs": "nixpkgs_527",
-        "nixpkgs-windows": "nixpkgs-windows_484"
+        "nixpkgs": "nixpkgs_527"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28793,7 +28680,7 @@
     "logos-nix_528": {
       "inputs": {
         "nixpkgs": "nixpkgs_528",
-        "nixpkgs-windows": "nixpkgs-windows_485"
+        "nixpkgs-windows": "nixpkgs-windows_483"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28812,7 +28699,7 @@
     "logos-nix_529": {
       "inputs": {
         "nixpkgs": "nixpkgs_529",
-        "nixpkgs-windows": "nixpkgs-windows_486"
+        "nixpkgs-windows": "nixpkgs-windows_484"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28834,6 +28721,25 @@
         "nixpkgs-windows": "nixpkgs-windows_51"
       },
       "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_530": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_530",
+        "nixpkgs-windows": "nixpkgs-windows_485"
+      },
+      "locked": {
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
@@ -28847,34 +28753,17 @@
         "type": "github"
       }
     },
-    "logos-nix_530": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_530"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_531": {
       "inputs": {
-        "nixpkgs": "nixpkgs_531"
+        "nixpkgs": "nixpkgs_531",
+        "nixpkgs-windows": "nixpkgs-windows_486"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28889,11 +28778,11 @@
         "nixpkgs-windows": "nixpkgs-windows_487"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28908,11 +28797,11 @@
         "nixpkgs-windows": "nixpkgs-windows_488"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28942,7 +28831,43 @@
     },
     "logos-nix_535": {
       "inputs": {
-        "nixpkgs": "nixpkgs_535",
+        "nixpkgs": "nixpkgs_535"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_536": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_536"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_537": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_537",
         "nixpkgs-windows": "nixpkgs-windows_490"
       },
       "locked": {
@@ -28959,48 +28884,10 @@
         "type": "github"
       }
     },
-    "logos-nix_536": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_536",
-        "nixpkgs-windows": "nixpkgs-windows_491"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_537": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_537",
-        "nixpkgs-windows": "nixpkgs-windows_492"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_538": {
       "inputs": {
         "nixpkgs": "nixpkgs_538",
-        "nixpkgs-windows": "nixpkgs-windows_493"
+        "nixpkgs-windows": "nixpkgs-windows_491"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29018,14 +28905,15 @@
     },
     "logos-nix_539": {
       "inputs": {
-        "nixpkgs": "nixpkgs_539"
+        "nixpkgs": "nixpkgs_539",
+        "nixpkgs-windows": "nixpkgs-windows_492"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29055,14 +28943,15 @@
     },
     "logos-nix_540": {
       "inputs": {
-        "nixpkgs": "nixpkgs_540"
+        "nixpkgs": "nixpkgs_540",
+        "nixpkgs-windows": "nixpkgs-windows_493"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29134,11 +29023,11 @@
         "nixpkgs-windows": "nixpkgs-windows_497"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29206,15 +29095,14 @@
     },
     "logos-nix_548": {
       "inputs": {
-        "nixpkgs": "nixpkgs_548",
-        "nixpkgs-windows": "nixpkgs-windows_501"
+        "nixpkgs": "nixpkgs_548"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29226,7 +29114,7 @@
     "logos-nix_549": {
       "inputs": {
         "nixpkgs": "nixpkgs_549",
-        "nixpkgs-windows": "nixpkgs-windows_502"
+        "nixpkgs-windows": "nixpkgs-windows_501"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29244,15 +29132,14 @@
     },
     "logos-nix_55": {
       "inputs": {
-        "nixpkgs": "nixpkgs_55",
-        "nixpkgs-windows": "nixpkgs-windows_53"
+        "nixpkgs": "nixpkgs_55"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -29264,7 +29151,7 @@
     "logos-nix_550": {
       "inputs": {
         "nixpkgs": "nixpkgs_550",
-        "nixpkgs-windows": "nixpkgs-windows_503"
+        "nixpkgs-windows": "nixpkgs-windows_502"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29283,7 +29170,7 @@
     "logos-nix_551": {
       "inputs": {
         "nixpkgs": "nixpkgs_551",
-        "nixpkgs-windows": "nixpkgs-windows_504"
+        "nixpkgs-windows": "nixpkgs-windows_503"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29301,14 +29188,15 @@
     },
     "logos-nix_552": {
       "inputs": {
-        "nixpkgs": "nixpkgs_552"
+        "nixpkgs": "nixpkgs_552",
+        "nixpkgs-windows": "nixpkgs-windows_504"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29380,11 +29268,11 @@
         "nixpkgs-windows": "nixpkgs-windows_508"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29399,11 +29287,11 @@
         "nixpkgs-windows": "nixpkgs-windows_509"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29433,7 +29321,61 @@
     },
     "logos-nix_559": {
       "inputs": {
-        "nixpkgs": "nixpkgs_559",
+        "nixpkgs": "nixpkgs_559"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_56": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_56"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_560": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_560"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_561": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_561",
         "nixpkgs-windows": "nixpkgs-windows_511"
       },
       "locked": {
@@ -29450,67 +29392,10 @@
         "type": "github"
       }
     },
-    "logos-nix_56": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_56",
-        "nixpkgs-windows": "nixpkgs-windows_54"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_560": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_560",
-        "nixpkgs-windows": "nixpkgs-windows_512"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_561": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_561",
-        "nixpkgs-windows": "nixpkgs-windows_513"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_562": {
       "inputs": {
         "nixpkgs": "nixpkgs_562",
-        "nixpkgs-windows": "nixpkgs-windows_514"
+        "nixpkgs-windows": "nixpkgs-windows_512"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29528,14 +29413,15 @@
     },
     "logos-nix_563": {
       "inputs": {
-        "nixpkgs": "nixpkgs_563"
+        "nixpkgs": "nixpkgs_563",
+        "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29546,14 +29432,15 @@
     },
     "logos-nix_564": {
       "inputs": {
-        "nixpkgs": "nixpkgs_564"
+        "nixpkgs": "nixpkgs_564",
+        "nixpkgs-windows": "nixpkgs-windows_514"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29568,11 +29455,11 @@
         "nixpkgs-windows": "nixpkgs-windows_515"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29602,7 +29489,43 @@
     },
     "logos-nix_567": {
       "inputs": {
-        "nixpkgs": "nixpkgs_567",
+        "nixpkgs": "nixpkgs_567"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_568": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_568"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_569": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_569",
         "nixpkgs-windows": "nixpkgs-windows_517"
       },
       "locked": {
@@ -29619,10 +29542,10 @@
         "type": "github"
       }
     },
-    "logos-nix_568": {
+    "logos-nix_57": {
       "inputs": {
-        "nixpkgs": "nixpkgs_568",
-        "nixpkgs-windows": "nixpkgs-windows_518"
+        "nixpkgs": "nixpkgs_57",
+        "nixpkgs-windows": "nixpkgs-windows_53"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29638,48 +29561,10 @@
         "type": "github"
       }
     },
-    "logos-nix_569": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_569",
-        "nixpkgs-windows": "nixpkgs-windows_519"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_57": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_57",
-        "nixpkgs-windows": "nixpkgs-windows_55"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_570": {
       "inputs": {
         "nixpkgs": "nixpkgs_570",
-        "nixpkgs-windows": "nixpkgs-windows_520"
+        "nixpkgs-windows": "nixpkgs-windows_518"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29697,14 +29582,15 @@
     },
     "logos-nix_571": {
       "inputs": {
-        "nixpkgs": "nixpkgs_571"
+        "nixpkgs": "nixpkgs_571",
+        "nixpkgs-windows": "nixpkgs-windows_519"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29715,14 +29601,15 @@
     },
     "logos-nix_572": {
       "inputs": {
-        "nixpkgs": "nixpkgs_572"
+        "nixpkgs": "nixpkgs_572",
+        "nixpkgs-windows": "nixpkgs-windows_520"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29737,11 +29624,11 @@
         "nixpkgs-windows": "nixpkgs-windows_521"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29813,11 +29700,11 @@
         "nixpkgs-windows": "nixpkgs-windows_525"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29867,7 +29754,7 @@
     "logos-nix_58": {
       "inputs": {
         "nixpkgs": "nixpkgs_58",
-        "nixpkgs-windows": "nixpkgs-windows_56"
+        "nixpkgs-windows": "nixpkgs-windows_54"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30003,11 +29890,11 @@
         "nixpkgs-windows": "nixpkgs-windows_534"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30075,14 +29962,15 @@
     },
     "logos-nix_59": {
       "inputs": {
-        "nixpkgs": "nixpkgs_59"
+        "nixpkgs": "nixpkgs_59",
+        "nixpkgs-windows": "nixpkgs-windows_55"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30097,11 +29985,11 @@
         "nixpkgs-windows": "nixpkgs-windows_538"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30154,11 +30042,11 @@
         "nixpkgs-windows": "nixpkgs-windows_541"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30230,11 +30118,11 @@
         "nixpkgs-windows": "nixpkgs-windows_545"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30302,14 +30190,15 @@
     },
     "logos-nix_60": {
       "inputs": {
-        "nixpkgs": "nixpkgs_60"
+        "nixpkgs": "nixpkgs_60",
+        "nixpkgs-windows": "nixpkgs-windows_56"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30476,11 +30365,11 @@
         "nixpkgs-windows": "nixpkgs-windows_556"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30495,11 +30384,11 @@
         "nixpkgs-windows": "nixpkgs-windows_557"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30548,7 +30437,43 @@
     },
     "logos-nix_611": {
       "inputs": {
-        "nixpkgs": "nixpkgs_611",
+        "nixpkgs": "nixpkgs_611"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_612": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_612"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_613": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_613",
         "nixpkgs-windows": "nixpkgs-windows_559"
       },
       "locked": {
@@ -30565,48 +30490,10 @@
         "type": "github"
       }
     },
-    "logos-nix_612": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_612",
-        "nixpkgs-windows": "nixpkgs-windows_560"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_613": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_613",
-        "nixpkgs-windows": "nixpkgs-windows_561"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_614": {
       "inputs": {
         "nixpkgs": "nixpkgs_614",
-        "nixpkgs-windows": "nixpkgs-windows_562"
+        "nixpkgs-windows": "nixpkgs-windows_560"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30624,14 +30511,15 @@
     },
     "logos-nix_615": {
       "inputs": {
-        "nixpkgs": "nixpkgs_615"
+        "nixpkgs": "nixpkgs_615",
+        "nixpkgs-windows": "nixpkgs-windows_561"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30642,14 +30530,15 @@
     },
     "logos-nix_616": {
       "inputs": {
-        "nixpkgs": "nixpkgs_616"
+        "nixpkgs": "nixpkgs_616",
+        "nixpkgs-windows": "nixpkgs-windows_562"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31082,11 +30971,11 @@
         "nixpkgs-windows": "nixpkgs-windows_583"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31177,11 +31066,11 @@
         "nixpkgs-windows": "nixpkgs-windows_587"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31534,15 +31423,14 @@
     },
     "logos-nix_659": {
       "inputs": {
-        "nixpkgs": "nixpkgs_659",
-        "nixpkgs-windows": "nixpkgs-windows_605"
+        "nixpkgs": "nixpkgs_659"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31572,15 +31460,14 @@
     },
     "logos-nix_660": {
       "inputs": {
-        "nixpkgs": "nixpkgs_660",
-        "nixpkgs-windows": "nixpkgs-windows_606"
+        "nixpkgs": "nixpkgs_660"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31592,7 +31479,7 @@
     "logos-nix_661": {
       "inputs": {
         "nixpkgs": "nixpkgs_661",
-        "nixpkgs-windows": "nixpkgs-windows_607"
+        "nixpkgs-windows": "nixpkgs-windows_605"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31611,7 +31498,7 @@
     "logos-nix_662": {
       "inputs": {
         "nixpkgs": "nixpkgs_662",
-        "nixpkgs-windows": "nixpkgs-windows_608"
+        "nixpkgs-windows": "nixpkgs-windows_606"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31629,14 +31516,15 @@
     },
     "logos-nix_663": {
       "inputs": {
-        "nixpkgs": "nixpkgs_663"
+        "nixpkgs": "nixpkgs_663",
+        "nixpkgs-windows": "nixpkgs-windows_607"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31647,14 +31535,15 @@
     },
     "logos-nix_664": {
       "inputs": {
-        "nixpkgs": "nixpkgs_664"
+        "nixpkgs": "nixpkgs_664",
+        "nixpkgs-windows": "nixpkgs-windows_608"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31817,15 +31706,14 @@
     },
     "logos-nix_672": {
       "inputs": {
-        "nixpkgs": "nixpkgs_672",
-        "nixpkgs-windows": "nixpkgs-windows_616"
+        "nixpkgs": "nixpkgs_672"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31836,15 +31724,14 @@
     },
     "logos-nix_673": {
       "inputs": {
-        "nixpkgs": "nixpkgs_673",
-        "nixpkgs-windows": "nixpkgs-windows_617"
+        "nixpkgs": "nixpkgs_673"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31856,7 +31743,7 @@
     "logos-nix_674": {
       "inputs": {
         "nixpkgs": "nixpkgs_674",
-        "nixpkgs-windows": "nixpkgs-windows_618"
+        "nixpkgs-windows": "nixpkgs-windows_616"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31875,7 +31762,7 @@
     "logos-nix_675": {
       "inputs": {
         "nixpkgs": "nixpkgs_675",
-        "nixpkgs-windows": "nixpkgs-windows_619"
+        "nixpkgs-windows": "nixpkgs-windows_617"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31893,14 +31780,15 @@
     },
     "logos-nix_676": {
       "inputs": {
-        "nixpkgs": "nixpkgs_676"
+        "nixpkgs": "nixpkgs_676",
+        "nixpkgs-windows": "nixpkgs-windows_618"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31911,14 +31799,15 @@
     },
     "logos-nix_677": {
       "inputs": {
-        "nixpkgs": "nixpkgs_677"
+        "nixpkgs": "nixpkgs_677",
+        "nixpkgs-windows": "nixpkgs-windows_619"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31952,11 +31841,11 @@
         "nixpkgs-windows": "nixpkgs-windows_621"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32005,15 +31894,14 @@
     },
     "logos-nix_681": {
       "inputs": {
-        "nixpkgs": "nixpkgs_681",
-        "nixpkgs-windows": "nixpkgs-windows_623"
+        "nixpkgs": "nixpkgs_681"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32025,7 +31913,7 @@
     "logos-nix_682": {
       "inputs": {
         "nixpkgs": "nixpkgs_682",
-        "nixpkgs-windows": "nixpkgs-windows_624"
+        "nixpkgs-windows": "nixpkgs-windows_623"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32044,14 +31932,14 @@
     "logos-nix_683": {
       "inputs": {
         "nixpkgs": "nixpkgs_683",
-        "nixpkgs-windows": "nixpkgs-windows_625"
+        "nixpkgs-windows": "nixpkgs-windows_624"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32063,7 +31951,7 @@
     "logos-nix_684": {
       "inputs": {
         "nixpkgs": "nixpkgs_684",
-        "nixpkgs-windows": "nixpkgs-windows_626"
+        "nixpkgs-windows": "nixpkgs-windows_625"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32081,14 +31969,15 @@
     },
     "logos-nix_685": {
       "inputs": {
-        "nixpkgs": "nixpkgs_685"
+        "nixpkgs": "nixpkgs_685",
+        "nixpkgs-windows": "nixpkgs-windows_626"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32232,15 +32121,14 @@
     },
     "logos-nix_692": {
       "inputs": {
-        "nixpkgs": "nixpkgs_692",
-        "nixpkgs-windows": "nixpkgs-windows_633"
+        "nixpkgs": "nixpkgs_692"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32251,15 +32139,14 @@
     },
     "logos-nix_693": {
       "inputs": {
-        "nixpkgs": "nixpkgs_693",
-        "nixpkgs-windows": "nixpkgs-windows_634"
+        "nixpkgs": "nixpkgs_693"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32271,7 +32158,7 @@
     "logos-nix_694": {
       "inputs": {
         "nixpkgs": "nixpkgs_694",
-        "nixpkgs-windows": "nixpkgs-windows_635"
+        "nixpkgs-windows": "nixpkgs-windows_633"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32290,7 +32177,7 @@
     "logos-nix_695": {
       "inputs": {
         "nixpkgs": "nixpkgs_695",
-        "nixpkgs-windows": "nixpkgs-windows_636"
+        "nixpkgs-windows": "nixpkgs-windows_634"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32308,14 +32195,15 @@
     },
     "logos-nix_696": {
       "inputs": {
-        "nixpkgs": "nixpkgs_696"
+        "nixpkgs": "nixpkgs_696",
+        "nixpkgs-windows": "nixpkgs-windows_635"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32326,14 +32214,15 @@
     },
     "logos-nix_697": {
       "inputs": {
-        "nixpkgs": "nixpkgs_697"
+        "nixpkgs": "nixpkgs_697",
+        "nixpkgs-windows": "nixpkgs-windows_636"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32348,11 +32237,11 @@
         "nixpkgs-windows": "nixpkgs-windows_637"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32367,11 +32256,11 @@
         "nixpkgs-windows": "nixpkgs-windows_638"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32439,7 +32328,43 @@
     },
     "logos-nix_701": {
       "inputs": {
-        "nixpkgs": "nixpkgs_701",
+        "nixpkgs": "nixpkgs_701"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_702": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_702"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_703": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_703",
         "nixpkgs-windows": "nixpkgs-windows_640"
       },
       "locked": {
@@ -32456,48 +32381,10 @@
         "type": "github"
       }
     },
-    "logos-nix_702": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_702",
-        "nixpkgs-windows": "nixpkgs-windows_641"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_703": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_703",
-        "nixpkgs-windows": "nixpkgs-windows_642"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_704": {
       "inputs": {
         "nixpkgs": "nixpkgs_704",
-        "nixpkgs-windows": "nixpkgs-windows_643"
+        "nixpkgs-windows": "nixpkgs-windows_641"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32515,14 +32402,15 @@
     },
     "logos-nix_705": {
       "inputs": {
-        "nixpkgs": "nixpkgs_705"
+        "nixpkgs": "nixpkgs_705",
+        "nixpkgs-windows": "nixpkgs-windows_642"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32533,14 +32421,15 @@
     },
     "logos-nix_706": {
       "inputs": {
-        "nixpkgs": "nixpkgs_706"
+        "nixpkgs": "nixpkgs_706",
+        "nixpkgs-windows": "nixpkgs-windows_643"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32631,11 +32520,11 @@
         "nixpkgs-windows": "nixpkgs-windows_647"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32703,15 +32592,14 @@
     },
     "logos-nix_714": {
       "inputs": {
-        "nixpkgs": "nixpkgs_714",
-        "nixpkgs-windows": "nixpkgs-windows_651"
+        "nixpkgs": "nixpkgs_714"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32723,7 +32611,7 @@
     "logos-nix_715": {
       "inputs": {
         "nixpkgs": "nixpkgs_715",
-        "nixpkgs-windows": "nixpkgs-windows_652"
+        "nixpkgs-windows": "nixpkgs-windows_651"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32742,7 +32630,7 @@
     "logos-nix_716": {
       "inputs": {
         "nixpkgs": "nixpkgs_716",
-        "nixpkgs-windows": "nixpkgs-windows_653"
+        "nixpkgs-windows": "nixpkgs-windows_652"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32761,7 +32649,7 @@
     "logos-nix_717": {
       "inputs": {
         "nixpkgs": "nixpkgs_717",
-        "nixpkgs-windows": "nixpkgs-windows_654"
+        "nixpkgs-windows": "nixpkgs-windows_653"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32779,14 +32667,15 @@
     },
     "logos-nix_718": {
       "inputs": {
-        "nixpkgs": "nixpkgs_718"
+        "nixpkgs": "nixpkgs_718",
+        "nixpkgs-windows": "nixpkgs-windows_654"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32877,11 +32766,11 @@
         "nixpkgs-windows": "nixpkgs-windows_658"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32896,11 +32785,11 @@
         "nixpkgs-windows": "nixpkgs-windows_659"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32930,7 +32819,43 @@
     },
     "logos-nix_725": {
       "inputs": {
-        "nixpkgs": "nixpkgs_725",
+        "nixpkgs": "nixpkgs_725"
+      },
+      "locked": {
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_726": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_726"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_727": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_727",
         "nixpkgs-windows": "nixpkgs-windows_661"
       },
       "locked": {
@@ -32947,48 +32872,10 @@
         "type": "github"
       }
     },
-    "logos-nix_726": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_726",
-        "nixpkgs-windows": "nixpkgs-windows_662"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_727": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_727",
-        "nixpkgs-windows": "nixpkgs-windows_663"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_728": {
       "inputs": {
         "nixpkgs": "nixpkgs_728",
-        "nixpkgs-windows": "nixpkgs-windows_664"
+        "nixpkgs-windows": "nixpkgs-windows_662"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33006,14 +32893,15 @@
     },
     "logos-nix_729": {
       "inputs": {
-        "nixpkgs": "nixpkgs_729"
+        "nixpkgs": "nixpkgs_729",
+        "nixpkgs-windows": "nixpkgs-windows_663"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33043,14 +32931,15 @@
     },
     "logos-nix_730": {
       "inputs": {
-        "nixpkgs": "nixpkgs_730"
+        "nixpkgs": "nixpkgs_730",
+        "nixpkgs-windows": "nixpkgs-windows_664"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33137,15 +33026,14 @@
     },
     "logos-nix_735": {
       "inputs": {
-        "nixpkgs": "nixpkgs_735",
-        "nixpkgs-windows": "nixpkgs-windows_669"
+        "nixpkgs": "nixpkgs_735"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -33157,14 +33045,14 @@
     "logos-nix_736": {
       "inputs": {
         "nixpkgs": "nixpkgs_736",
-        "nixpkgs-windows": "nixpkgs-windows_670"
+        "nixpkgs-windows": "nixpkgs-windows_669"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
         "type": "github"
       },
       "original": {
@@ -33176,7 +33064,7 @@
     "logos-nix_737": {
       "inputs": {
         "nixpkgs": "nixpkgs_737",
-        "nixpkgs-windows": "nixpkgs-windows_671"
+        "nixpkgs-windows": "nixpkgs-windows_670"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33194,15 +33082,14 @@
     },
     "logos-nix_738": {
       "inputs": {
-        "nixpkgs": "nixpkgs_738",
-        "nixpkgs-windows": "nixpkgs-windows_672"
+        "nixpkgs": "nixpkgs_738"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -33251,7 +33138,7 @@
     "logos-nix_740": {
       "inputs": {
         "nixpkgs": "nixpkgs_740",
-        "nixpkgs-windows": "nixpkgs-windows_673"
+        "nixpkgs-windows": "nixpkgs-windows_671"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33270,6 +33157,44 @@
     "logos-nix_741": {
       "inputs": {
         "nixpkgs": "nixpkgs_741",
+        "nixpkgs-windows": "nixpkgs-windows_672"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_742": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_742",
+        "nixpkgs-windows": "nixpkgs-windows_673"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_743": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_743",
         "nixpkgs-windows": "nixpkgs-windows_674"
       },
       "locked": {
@@ -33286,9 +33211,9 @@
         "type": "github"
       }
     },
-    "logos-nix_742": {
+    "logos-nix_744": {
       "inputs": {
-        "nixpkgs": "nixpkgs_742"
+        "nixpkgs": "nixpkgs_744"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33304,9 +33229,9 @@
         "type": "github"
       }
     },
-    "logos-nix_743": {
+    "logos-nix_745": {
       "inputs": {
-        "nixpkgs": "nixpkgs_743"
+        "nixpkgs": "nixpkgs_745"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -33322,9 +33247,9 @@
         "type": "github"
       }
     },
-    "logos-nix_744": {
+    "logos-nix_746": {
       "inputs": {
-        "nixpkgs": "nixpkgs_744",
+        "nixpkgs": "nixpkgs_746",
         "nixpkgs-windows": "nixpkgs-windows_675"
       },
       "locked": {
@@ -33341,48 +33266,10 @@
         "type": "github"
       }
     },
-    "logos-nix_745": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_745",
-        "nixpkgs-windows": "nixpkgs-windows_676"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_746": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_746",
-        "nixpkgs-windows": "nixpkgs-windows_677"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_747": {
       "inputs": {
         "nixpkgs": "nixpkgs_747",
-        "nixpkgs-windows": "nixpkgs-windows_678"
+        "nixpkgs-windows": "nixpkgs-windows_676"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33400,14 +33287,15 @@
     },
     "logos-nix_748": {
       "inputs": {
-        "nixpkgs": "nixpkgs_748"
+        "nixpkgs": "nixpkgs_748",
+        "nixpkgs-windows": "nixpkgs-windows_677"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33418,14 +33306,15 @@
     },
     "logos-nix_749": {
       "inputs": {
-        "nixpkgs": "nixpkgs_749"
+        "nixpkgs": "nixpkgs_749",
+        "nixpkgs-windows": "nixpkgs-windows_678"
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33455,83 +33344,7 @@
     },
     "logos-nix_750": {
       "inputs": {
-        "nixpkgs": "nixpkgs_750",
-        "nixpkgs-windows": "nixpkgs-windows_679"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_751": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_751",
-        "nixpkgs-windows": "nixpkgs-windows_680"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_752": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_752",
-        "nixpkgs-windows": "nixpkgs-windows_681"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_753": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_753",
-        "nixpkgs-windows": "nixpkgs-windows_682"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_754": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_754"
+        "nixpkgs": "nixpkgs_750"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -33648,11 +33461,11 @@
         "nixpkgs-windows": "nixpkgs-windows_76"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -33724,11 +33537,11 @@
         "nixpkgs-windows": "nixpkgs-windows_80"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34069,7 +33882,7 @@
     },
     "logos-package-downloader": {
       "inputs": {
-        "logos-nix": "logos-nix_397",
+        "logos-nix": "logos-nix_393",
         "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_61",
@@ -34188,7 +34001,7 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-        "logos-nix": "logos-nix_323",
+        "logos-nix": "logos-nix_319",
         "logos-package": "logos-package_28",
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_46",
@@ -34225,7 +34038,7 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-        "logos-nix": "logos-nix_336",
+        "logos-nix": "logos-nix_332",
         "logos-package": "logos-package_30",
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_49",
@@ -34259,7 +34072,7 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-        "logos-nix": "logos-nix_356",
+        "logos-nix": "logos-nix_352",
         "logos-package": "logos-package_32",
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_52",
@@ -34292,7 +34105,7 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-        "logos-nix": "logos-nix_365",
+        "logos-nix": "logos-nix_361",
         "logos-package": "logos-package_34",
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_55",
@@ -34322,7 +34135,7 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-        "logos-nix": "logos-nix_389",
+        "logos-nix": "logos-nix_385",
         "logos-package": "logos-package_36",
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_58",
@@ -34351,7 +34164,7 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-        "logos-nix": "logos-nix_402",
+        "logos-nix": "logos-nix_398",
         "logos-package": "logos-package_39",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_63",
@@ -34377,7 +34190,7 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-        "logos-nix": "logos-nix_447",
+        "logos-nix": "logos-nix_443",
         "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_68",
@@ -34410,7 +34223,7 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-        "logos-nix": "logos-nix_495",
+        "logos-nix": "logos-nix_491",
         "logos-package": "logos-package_44",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_74",
@@ -34447,7 +34260,7 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-        "logos-nix": "logos-nix_508",
+        "logos-nix": "logos-nix_504",
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_77",
@@ -34481,7 +34294,7 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-        "logos-nix": "logos-nix_528",
+        "logos-nix": "logos-nix_524",
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_80",
@@ -34514,7 +34327,7 @@
     },
     "logos-package-manager_2": {
       "inputs": {
-        "logos-nix": "logos-nix_57",
+        "logos-nix": "logos-nix_53",
         "logos-package": "logos-package_5",
         "nix-bundle-appimage": "nix-bundle-appimage_5",
         "nix-bundle-dir": "nix-bundle-dir_10",
@@ -34544,7 +34357,7 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-        "logos-nix": "logos-nix_537",
+        "logos-nix": "logos-nix_533",
         "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_83",
@@ -34574,7 +34387,7 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-        "logos-nix": "logos-nix_561",
+        "logos-nix": "logos-nix_557",
         "logos-package": "logos-package_52",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_86",
@@ -34603,7 +34416,7 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-        "logos-nix": "logos-nix_569",
+        "logos-nix": "logos-nix_565",
         "logos-package": "logos-package_54",
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_89",
@@ -34630,7 +34443,7 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-        "logos-nix": "logos-nix_613",
+        "logos-nix": "logos-nix_609",
         "logos-package": "logos-package_56",
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_94",
@@ -34663,7 +34476,7 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-        "logos-nix": "logos-nix_661",
+        "logos-nix": "logos-nix_657",
         "logos-package": "logos-package_59",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_100",
@@ -34700,7 +34513,7 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-        "logos-nix": "logos-nix_674",
+        "logos-nix": "logos-nix_670",
         "logos-package": "logos-package_61",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
         "nix-bundle-dir": "nix-bundle-dir_103",
@@ -34734,7 +34547,7 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-        "logos-nix": "logos-nix_694",
+        "logos-nix": "logos-nix_690",
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
         "nix-bundle-dir": "nix-bundle-dir_106",
@@ -34767,7 +34580,7 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-        "logos-nix": "logos-nix_703",
+        "logos-nix": "logos-nix_699",
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_47",
         "nix-bundle-dir": "nix-bundle-dir_109",
@@ -34797,7 +34610,7 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-        "logos-nix": "logos-nix_727",
+        "logos-nix": "logos-nix_723",
         "logos-package": "logos-package_67",
         "nix-bundle-appimage": "nix-bundle-appimage_48",
         "nix-bundle-dir": "nix-bundle-dir_112",
@@ -34826,7 +34639,7 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-        "logos-nix": "logos-nix_746",
+        "logos-nix": "logos-nix_742",
         "logos-package": "logos-package_70",
         "nix-bundle-appimage": "nix-bundle-appimage_50",
         "nix-bundle-dir": "nix-bundle-dir_117",
@@ -34853,7 +34666,7 @@
     },
     "logos-package-manager_3": {
       "inputs": {
-        "logos-nix": "logos-nix_104",
+        "logos-nix": "logos-nix_100",
         "logos-package": "logos-package_9",
         "nix-bundle-appimage": "nix-bundle-appimage_8",
         "nix-bundle-dir": "nix-bundle-dir_16",
@@ -34887,7 +34700,7 @@
     },
     "logos-package-manager_4": {
       "inputs": {
-        "logos-nix": "logos-nix_117",
+        "logos-nix": "logos-nix_113",
         "logos-package": "logos-package_11",
         "nix-bundle-appimage": "nix-bundle-appimage_9",
         "nix-bundle-dir": "nix-bundle-dir_19",
@@ -34918,7 +34731,7 @@
     },
     "logos-package-manager_5": {
       "inputs": {
-        "logos-nix": "logos-nix_137",
+        "logos-nix": "logos-nix_133",
         "logos-package": "logos-package_13",
         "nix-bundle-appimage": "nix-bundle-appimage_10",
         "nix-bundle-dir": "nix-bundle-dir_22",
@@ -34948,7 +34761,7 @@
     },
     "logos-package-manager_6": {
       "inputs": {
-        "logos-nix": "logos-nix_192",
+        "logos-nix": "logos-nix_188",
         "logos-package": "logos-package_17",
         "nix-bundle-appimage": "nix-bundle-appimage_13",
         "nix-bundle-dir": "nix-bundle-dir_28",
@@ -34981,7 +34794,7 @@
     },
     "logos-package-manager_7": {
       "inputs": {
-        "logos-nix": "logos-nix_205",
+        "logos-nix": "logos-nix_201",
         "logos-package": "logos-package_19",
         "nix-bundle-appimage": "nix-bundle-appimage_14",
         "nix-bundle-dir": "nix-bundle-dir_31",
@@ -35011,7 +34824,7 @@
     },
     "logos-package-manager_8": {
       "inputs": {
-        "logos-nix": "logos-nix_225",
+        "logos-nix": "logos-nix_221",
         "logos-package": "logos-package_21",
         "nix-bundle-appimage": "nix-bundle-appimage_15",
         "nix-bundle-dir": "nix-bundle-dir_34",
@@ -35040,7 +34853,7 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-        "logos-nix": "logos-nix_275",
+        "logos-nix": "logos-nix_271",
         "logos-package": "logos-package_25",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_40",
@@ -35073,7 +34886,7 @@
     },
     "logos-package_10": {
       "inputs": {
-        "logos-nix": "logos-nix_110",
+        "logos-nix": "logos-nix_106",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35105,7 +34918,7 @@
     },
     "logos-package_11": {
       "inputs": {
-        "logos-nix": "logos-nix_118",
+        "logos-nix": "logos-nix_114",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35134,7 +34947,7 @@
     },
     "logos-package_12": {
       "inputs": {
-        "logos-nix": "logos-nix_134",
+        "logos-nix": "logos-nix_130",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35161,7 +34974,7 @@
     },
     "logos-package_13": {
       "inputs": {
-        "logos-nix": "logos-nix_138",
+        "logos-nix": "logos-nix_134",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35189,7 +35002,7 @@
     },
     "logos-package_14": {
       "inputs": {
-        "logos-nix": "logos-nix_143",
+        "logos-nix": "logos-nix_139",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -35244,7 +35057,7 @@
     },
     "logos-package_16": {
       "inputs": {
-        "logos-nix": "logos-nix_189",
+        "logos-nix": "logos-nix_185",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35274,7 +35087,7 @@
     },
     "logos-package_17": {
       "inputs": {
-        "logos-nix": "logos-nix_193",
+        "logos-nix": "logos-nix_189",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35305,7 +35118,7 @@
     },
     "logos-package_18": {
       "inputs": {
-        "logos-nix": "logos-nix_198",
+        "logos-nix": "logos-nix_194",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35336,7 +35149,7 @@
     },
     "logos-package_19": {
       "inputs": {
-        "logos-nix": "logos-nix_206",
+        "logos-nix": "logos-nix_202",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35391,7 +35204,7 @@
     },
     "logos-package_20": {
       "inputs": {
-        "logos-nix": "logos-nix_222",
+        "logos-nix": "logos-nix_218",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35417,7 +35230,7 @@
     },
     "logos-package_21": {
       "inputs": {
-        "logos-nix": "logos-nix_226",
+        "logos-nix": "logos-nix_222",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35444,7 +35257,7 @@
     },
     "logos-package_22": {
       "inputs": {
-        "logos-nix": "logos-nix_231",
+        "logos-nix": "logos-nix_227",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -35471,7 +35284,7 @@
     },
     "logos-package_23": {
       "inputs": {
-        "logos-nix": "logos-nix_234",
+        "logos-nix": "logos-nix_230",
         "nixpkgs": [
           "logos-package",
           "logos-nix",
@@ -35494,7 +35307,7 @@
     },
     "logos-package_24": {
       "inputs": {
-        "logos-nix": "logos-nix_272",
+        "logos-nix": "logos-nix_268",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35524,7 +35337,7 @@
     },
     "logos-package_25": {
       "inputs": {
-        "logos-nix": "logos-nix_276",
+        "logos-nix": "logos-nix_272",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35555,7 +35368,7 @@
     },
     "logos-package_26": {
       "inputs": {
-        "logos-nix": "logos-nix_281",
+        "logos-nix": "logos-nix_277",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35586,7 +35399,7 @@
     },
     "logos-package_27": {
       "inputs": {
-        "logos-nix": "logos-nix_320",
+        "logos-nix": "logos-nix_316",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35620,7 +35433,7 @@
     },
     "logos-package_28": {
       "inputs": {
-        "logos-nix": "logos-nix_324",
+        "logos-nix": "logos-nix_320",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35655,7 +35468,7 @@
     },
     "logos-package_29": {
       "inputs": {
-        "logos-nix": "logos-nix_329",
+        "logos-nix": "logos-nix_325",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35717,7 +35530,7 @@
     },
     "logos-package_30": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
+        "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35749,7 +35562,7 @@
     },
     "logos-package_31": {
       "inputs": {
-        "logos-nix": "logos-nix_353",
+        "logos-nix": "logos-nix_349",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35779,7 +35592,7 @@
     },
     "logos-package_32": {
       "inputs": {
-        "logos-nix": "logos-nix_357",
+        "logos-nix": "logos-nix_353",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35810,7 +35623,7 @@
     },
     "logos-package_33": {
       "inputs": {
-        "logos-nix": "logos-nix_362",
+        "logos-nix": "logos-nix_358",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35841,7 +35654,7 @@
     },
     "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
+        "logos-nix": "logos-nix_362",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35869,7 +35682,7 @@
     },
     "logos-package_35": {
       "inputs": {
-        "logos-nix": "logos-nix_386",
+        "logos-nix": "logos-nix_382",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35895,7 +35708,7 @@
     },
     "logos-package_36": {
       "inputs": {
-        "logos-nix": "logos-nix_390",
+        "logos-nix": "logos-nix_386",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35922,7 +35735,7 @@
     },
     "logos-package_37": {
       "inputs": {
-        "logos-nix": "logos-nix_395",
+        "logos-nix": "logos-nix_391",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35949,7 +35762,7 @@
     },
     "logos-package_38": {
       "inputs": {
-        "logos-nix": "logos-nix_398",
+        "logos-nix": "logos-nix_394",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -35974,7 +35787,7 @@
     },
     "logos-package_39": {
       "inputs": {
-        "logos-nix": "logos-nix_403",
+        "logos-nix": "logos-nix_399",
         "nixpkgs": [
           "logos-package-manager",
           "logos-package",
@@ -35998,7 +35811,7 @@
     },
     "logos-package_4": {
       "inputs": {
-        "logos-nix": "logos-nix_54",
+        "logos-nix": "logos-nix_50",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36025,7 +35838,7 @@
     },
     "logos-package_40": {
       "inputs": {
-        "logos-nix": "logos-nix_444",
+        "logos-nix": "logos-nix_440",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36055,7 +35868,7 @@
     },
     "logos-package_41": {
       "inputs": {
-        "logos-nix": "logos-nix_448",
+        "logos-nix": "logos-nix_444",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36086,7 +35899,7 @@
     },
     "logos-package_42": {
       "inputs": {
-        "logos-nix": "logos-nix_453",
+        "logos-nix": "logos-nix_449",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36117,7 +35930,7 @@
     },
     "logos-package_43": {
       "inputs": {
-        "logos-nix": "logos-nix_492",
+        "logos-nix": "logos-nix_488",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36151,7 +35964,7 @@
     },
     "logos-package_44": {
       "inputs": {
-        "logos-nix": "logos-nix_496",
+        "logos-nix": "logos-nix_492",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36186,7 +35999,7 @@
     },
     "logos-package_45": {
       "inputs": {
-        "logos-nix": "logos-nix_501",
+        "logos-nix": "logos-nix_497",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36221,7 +36034,7 @@
     },
     "logos-package_46": {
       "inputs": {
-        "logos-nix": "logos-nix_509",
+        "logos-nix": "logos-nix_505",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36253,7 +36066,7 @@
     },
     "logos-package_47": {
       "inputs": {
-        "logos-nix": "logos-nix_525",
+        "logos-nix": "logos-nix_521",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36283,7 +36096,7 @@
     },
     "logos-package_48": {
       "inputs": {
-        "logos-nix": "logos-nix_529",
+        "logos-nix": "logos-nix_525",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36314,7 +36127,7 @@
     },
     "logos-package_49": {
       "inputs": {
-        "logos-nix": "logos-nix_534",
+        "logos-nix": "logos-nix_530",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36345,7 +36158,7 @@
     },
     "logos-package_5": {
       "inputs": {
-        "logos-nix": "logos-nix_58",
+        "logos-nix": "logos-nix_54",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36373,7 +36186,7 @@
     },
     "logos-package_50": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
+        "logos-nix": "logos-nix_534",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36401,7 +36214,7 @@
     },
     "logos-package_51": {
       "inputs": {
-        "logos-nix": "logos-nix_558",
+        "logos-nix": "logos-nix_554",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36427,7 +36240,7 @@
     },
     "logos-package_52": {
       "inputs": {
-        "logos-nix": "logos-nix_562",
+        "logos-nix": "logos-nix_558",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36454,7 +36267,7 @@
     },
     "logos-package_53": {
       "inputs": {
-        "logos-nix": "logos-nix_567",
+        "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36481,7 +36294,7 @@
     },
     "logos-package_54": {
       "inputs": {
-        "logos-nix": "logos-nix_570",
+        "logos-nix": "logos-nix_566",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -36506,7 +36319,7 @@
     },
     "logos-package_55": {
       "inputs": {
-        "logos-nix": "logos-nix_610",
+        "logos-nix": "logos-nix_606",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36536,7 +36349,7 @@
     },
     "logos-package_56": {
       "inputs": {
-        "logos-nix": "logos-nix_614",
+        "logos-nix": "logos-nix_610",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36567,7 +36380,7 @@
     },
     "logos-package_57": {
       "inputs": {
-        "logos-nix": "logos-nix_619",
+        "logos-nix": "logos-nix_615",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36598,7 +36411,7 @@
     },
     "logos-package_58": {
       "inputs": {
-        "logos-nix": "logos-nix_658",
+        "logos-nix": "logos-nix_654",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36632,7 +36445,7 @@
     },
     "logos-package_59": {
       "inputs": {
-        "logos-nix": "logos-nix_662",
+        "logos-nix": "logos-nix_658",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36667,7 +36480,7 @@
     },
     "logos-package_6": {
       "inputs": {
-        "logos-nix": "logos-nix_63",
+        "logos-nix": "logos-nix_59",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -36695,7 +36508,7 @@
     },
     "logos-package_60": {
       "inputs": {
-        "logos-nix": "logos-nix_667",
+        "logos-nix": "logos-nix_663",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36730,7 +36543,7 @@
     },
     "logos-package_61": {
       "inputs": {
-        "logos-nix": "logos-nix_675",
+        "logos-nix": "logos-nix_671",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36762,7 +36575,7 @@
     },
     "logos-package_62": {
       "inputs": {
-        "logos-nix": "logos-nix_691",
+        "logos-nix": "logos-nix_687",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36792,7 +36605,7 @@
     },
     "logos-package_63": {
       "inputs": {
-        "logos-nix": "logos-nix_695",
+        "logos-nix": "logos-nix_691",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36823,7 +36636,7 @@
     },
     "logos-package_64": {
       "inputs": {
-        "logos-nix": "logos-nix_700",
+        "logos-nix": "logos-nix_696",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36854,7 +36667,7 @@
     },
     "logos-package_65": {
       "inputs": {
-        "logos-nix": "logos-nix_704",
+        "logos-nix": "logos-nix_700",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36882,7 +36695,7 @@
     },
     "logos-package_66": {
       "inputs": {
-        "logos-nix": "logos-nix_724",
+        "logos-nix": "logos-nix_720",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36908,7 +36721,7 @@
     },
     "logos-package_67": {
       "inputs": {
-        "logos-nix": "logos-nix_728",
+        "logos-nix": "logos-nix_724",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36935,7 +36748,7 @@
     },
     "logos-package_68": {
       "inputs": {
-        "logos-nix": "logos-nix_733",
+        "logos-nix": "logos-nix_729",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36962,7 +36775,7 @@
     },
     "logos-package_69": {
       "inputs": {
-        "logos-nix": "logos-nix_735",
+        "logos-nix": "logos-nix_731",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-package",
@@ -37015,7 +36828,7 @@
     },
     "logos-package_70": {
       "inputs": {
-        "logos-nix": "logos-nix_747",
+        "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -37040,7 +36853,7 @@
     },
     "logos-package_71": {
       "inputs": {
-        "logos-nix": "logos-nix_752",
+        "logos-nix": "logos-nix_748",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -37065,7 +36878,7 @@
     },
     "logos-package_8": {
       "inputs": {
-        "logos-nix": "logos-nix_101",
+        "logos-nix": "logos-nix_97",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37096,7 +36909,7 @@
     },
     "logos-package_9": {
       "inputs": {
-        "logos-nix": "logos-nix_105",
+        "logos-nix": "logos-nix_101",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37160,9 +36973,9 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_95",
-        "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_309",
+        "logos-lidl": "logos-lidl_93",
+        "logos-module": "logos-module_68",
+        "logos-nix": "logos-nix_305",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37208,9 +37021,9 @@
     },
     "logos-plugin-core_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_119",
-        "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_412",
+        "logos-lidl": "logos-lidl_117",
+        "logos-module": "logos-module_84",
+        "logos-nix": "logos-nix_408",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37240,9 +37053,9 @@
     },
     "logos-plugin-core_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_127",
-        "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_433",
+        "logos-lidl": "logos-lidl_125",
+        "logos-module": "logos-module_90",
+        "logos-nix": "logos-nix_429",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37280,9 +37093,9 @@
     },
     "logos-plugin-core_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_137",
-        "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_464",
+        "logos-lidl": "logos-lidl_135",
+        "logos-module": "logos-module_97",
+        "logos-nix": "logos-nix_460",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37320,9 +37133,9 @@
     },
     "logos-plugin-core_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_143",
-        "logos-module": "logos-module_103",
-        "logos-nix": "logos-nix_481",
+        "logos-lidl": "logos-lidl_141",
+        "logos-module": "logos-module_102",
+        "logos-nix": "logos-nix_477",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37368,9 +37181,9 @@
     },
     "logos-plugin-core_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_167",
-        "logos-module": "logos-module_119",
-        "logos-nix": "logos-nix_579",
+        "logos-lidl": "logos-lidl_165",
+        "logos-module": "logos-module_118",
+        "logos-nix": "logos-nix_575",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37400,9 +37213,9 @@
     },
     "logos-plugin-core_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_175",
-        "logos-module": "logos-module_124",
-        "logos-nix": "logos-nix_599",
+        "logos-lidl": "logos-lidl_173",
+        "logos-module": "logos-module_123",
+        "logos-nix": "logos-nix_595",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37440,9 +37253,9 @@
     },
     "logos-plugin-core_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_185",
-        "logos-module": "logos-module_131",
-        "logos-nix": "logos-nix_630",
+        "logos-lidl": "logos-lidl_183",
+        "logos-module": "logos-module_130",
+        "logos-nix": "logos-nix_626",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37480,9 +37293,9 @@
     },
     "logos-plugin-core_18": {
       "inputs": {
-        "logos-lidl": "logos-lidl_191",
-        "logos-module": "logos-module_136",
-        "logos-nix": "logos-nix_647",
+        "logos-lidl": "logos-lidl_189",
+        "logos-module": "logos-module_135",
+        "logos-nix": "logos-nix_643",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37528,9 +37341,9 @@
     },
     "logos-plugin-core_2": {
       "inputs": {
-        "logos-lidl": "logos-lidl_14",
-        "logos-module": "logos-module_9",
-        "logos-nix": "logos-nix_43",
+        "logos-lidl": "logos-lidl_12",
+        "logos-module": "logos-module_8",
+        "logos-nix": "logos-nix_39",
         "logos-protocol": [
           "logos-liblogos",
           "logos-capability-module",
@@ -37562,9 +37375,9 @@
     },
     "logos-plugin-core_3": {
       "inputs": {
-        "logos-lidl": "logos-lidl_23",
-        "logos-module": "logos-module_16",
-        "logos-nix": "logos-nix_73",
+        "logos-lidl": "logos-lidl_21",
+        "logos-module": "logos-module_15",
+        "logos-nix": "logos-nix_69",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37596,9 +37409,9 @@
     },
     "logos-plugin-core_4": {
       "inputs": {
-        "logos-lidl": "logos-lidl_29",
-        "logos-module": "logos-module_21",
-        "logos-nix": "logos-nix_90",
+        "logos-lidl": "logos-lidl_27",
+        "logos-module": "logos-module_20",
+        "logos-nix": "logos-nix_86",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37638,9 +37451,9 @@
     },
     "logos-plugin-core_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_48",
-        "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_161",
+        "logos-lidl": "logos-lidl_46",
+        "logos-module": "logos-module_34",
+        "logos-nix": "logos-nix_157",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -37670,9 +37483,9 @@
     },
     "logos-plugin-core_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_54",
-        "logos-module": "logos-module_40",
-        "logos-nix": "logos-nix_178",
+        "logos-lidl": "logos-lidl_52",
+        "logos-module": "logos-module_39",
+        "logos-nix": "logos-nix_174",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -37710,9 +37523,9 @@
     },
     "logos-plugin-core_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_71",
-        "logos-module": "logos-module_51",
-        "logos-nix": "logos-nix_240",
+        "logos-lidl": "logos-lidl_69",
+        "logos-module": "logos-module_50",
+        "logos-nix": "logos-nix_236",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37742,9 +37555,9 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_79",
-        "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_261",
+        "logos-lidl": "logos-lidl_77",
+        "logos-module": "logos-module_56",
+        "logos-nix": "logos-nix_257",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37782,9 +37595,9 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_89",
-        "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_292",
+        "logos-lidl": "logos-lidl_87",
+        "logos-module": "logos-module_63",
+        "logos-nix": "logos-nix_288",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37854,33 +37667,27 @@
     },
     "logos-plugin-qt_10": {
       "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_18",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_28",
+        "logos-module": "logos-module_21",
+        "logos-nix": "logos-nix_88",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -37902,9 +37709,29 @@
     },
     "logos-plugin-qt_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_30",
+        "logos-lidl": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_22",
-        "logos-nix": "logos-nix_92",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -37913,6 +37740,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -37923,6 +37751,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -37944,17 +37773,7 @@
     },
     "logos-plugin-qt_12": {
       "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_31",
         "logos-module": "logos-module_23",
         "logos-nix": [
           "logos-liblogos",
@@ -37964,7 +37783,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -37975,7 +37794,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -37986,9 +37805,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -38008,7 +37825,7 @@
     },
     "logos-plugin-qt_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_33",
+        "logos-lidl": "logos-lidl_34",
         "logos-module": "logos-module_24",
         "logos-nix": [
           "logos-liblogos",
@@ -38018,7 +37835,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38029,7 +37846,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38040,7 +37857,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -38061,16 +37878,13 @@
     "logos-plugin-qt_14": {
       "inputs": {
         "logos-lidl": "logos-lidl_36",
-        "logos-module": "logos-module_25",
+        "logos-module": "logos-module_26",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38079,9 +37893,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38090,18 +37901,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -38119,7 +37927,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38127,7 +37934,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38135,7 +37941,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "nixpkgs"
         ]
       },
@@ -38155,48 +37960,8 @@
     },
     "logos-plugin-qt_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_40",
+        "logos-lidl": "logos-lidl_39",
         "logos-module": "logos-module_28",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_17": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_41",
-        "logos-module": "logos-module_29",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -38233,10 +37998,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_18": {
+    "logos-plugin-qt_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_44",
-        "logos-module": "logos-module_30",
+        "logos-lidl": "logos-lidl_42",
+        "logos-module": "logos-module_29",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -38273,14 +38038,14 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_19": {
+    "logos-plugin-qt_18": {
       "inputs": {
         "logos-lidl": [
           "logos-module-loader-qt",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_33",
+        "logos-module": "logos-module_32",
         "logos-nix": [
           "logos-module-loader-qt",
           "logos-qt-sdk",
@@ -38305,6 +38070,38 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_19": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_47",
+        "logos-module": "logos-module_35",
+        "logos-nix": "logos-nix_159",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {
@@ -38352,45 +38149,13 @@
     },
     "logos-plugin-qt_20": {
       "inputs": {
-        "logos-lidl": "logos-lidl_49",
-        "logos-module": "logos-module_36",
-        "logos-nix": "logos-nix_163",
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_21": {
-      "inputs": {
         "logos-lidl": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_37",
+        "logos-module": "logos-module_36",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38407,6 +38172,46 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_21": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_53",
+        "logos-module": "logos-module_40",
+        "logos-nix": "logos-nix_176",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -38428,9 +38233,27 @@
     },
     "logos-plugin-qt_22": {
       "inputs": {
-        "logos-lidl": "logos-lidl_55",
+        "logos-lidl": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_41",
-        "logos-nix": "logos-nix_180",
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38438,6 +38261,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38447,6 +38271,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -38468,16 +38293,7 @@
     },
     "logos-plugin-qt_23": {
       "inputs": {
-        "logos-lidl": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_56",
         "logos-module": "logos-module_42",
         "logos-nix": [
           "logos-modules-state-module",
@@ -38486,7 +38302,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38496,7 +38312,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38506,9 +38322,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -38528,7 +38342,7 @@
     },
     "logos-plugin-qt_24": {
       "inputs": {
-        "logos-lidl": "logos-lidl_58",
+        "logos-lidl": "logos-lidl_59",
         "logos-module": "logos-module_43",
         "logos-nix": [
           "logos-modules-state-module",
@@ -38537,7 +38351,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38547,7 +38361,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38557,7 +38371,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -38578,15 +38392,12 @@
     "logos-plugin-qt_25": {
       "inputs": {
         "logos-lidl": "logos-lidl_61",
-        "logos-module": "logos-module_44",
+        "logos-module": "logos-module_45",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -38594,9 +38405,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -38604,18 +38412,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -38632,21 +38437,18 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "nixpkgs"
         ]
       },
@@ -38666,45 +38468,8 @@
     },
     "logos-plugin-qt_27": {
       "inputs": {
-        "logos-lidl": "logos-lidl_65",
+        "logos-lidl": "logos-lidl_64",
         "logos-module": "logos-module_47",
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_28": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_66",
-        "logos-module": "logos-module_48",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38738,10 +38503,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_29": {
+    "logos-plugin-qt_28": {
       "inputs": {
-        "logos-lidl": "logos-lidl_69",
-        "logos-module": "logos-module_49",
+        "logos-lidl": "logos-lidl_67",
+        "logos-module": "logos-module_48",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -38767,6 +38532,38 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "ef11c2108af67d9539fb54c6895a58a46b84e89c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_29": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_70",
+        "logos-module": "logos-module_51",
+        "logos-nix": "logos-nix_238",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -38814,45 +38611,13 @@
     },
     "logos-plugin-qt_30": {
       "inputs": {
-        "logos-lidl": "logos-lidl_72",
-        "logos-module": "logos-module_52",
-        "logos-nix": "logos-nix_242",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_31": {
-      "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_53",
+        "logos-module": "logos-module_52",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38868,6 +38633,62 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_31": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_54",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -38890,65 +38711,9 @@
     },
     "logos-plugin-qt_32": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_55",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_33": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_80",
-        "logos-module": "logos-module_58",
-        "logos-nix": "logos-nix_263",
+        "logos-lidl": "logos-lidl_78",
+        "logos-module": "logos-module_57",
+        "logos-nix": "logos-nix_259",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38984,7 +38749,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_34": {
+    "logos-plugin-qt_33": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -38996,7 +38761,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_59",
+        "logos-module": "logos-module_58",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39044,10 +38809,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_35": {
+    "logos-plugin-qt_34": {
       "inputs": {
-        "logos-lidl": "logos-lidl_83",
-        "logos-module": "logos-module_60",
+        "logos-lidl": "logos-lidl_81",
+        "logos-module": "logos-module_59",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39093,10 +38858,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_36": {
+    "logos-plugin-qt_35": {
       "inputs": {
-        "logos-lidl": "logos-lidl_86",
-        "logos-module": "logos-module_61",
+        "logos-lidl": "logos-lidl_84",
+        "logos-module": "logos-module_60",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39142,11 +38907,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_37": {
+    "logos-plugin-qt_36": {
       "inputs": {
-        "logos-lidl": "logos-lidl_90",
-        "logos-module": "logos-module_65",
-        "logos-nix": "logos-nix_294",
+        "logos-lidl": "logos-lidl_88",
+        "logos-module": "logos-module_64",
+        "logos-nix": "logos-nix_290",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39182,7 +38947,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_38": {
+    "logos-plugin-qt_37": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -39194,7 +38959,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_66",
+        "logos-module": "logos-module_65",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39223,6 +38988,54 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_38": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_94",
+        "logos-module": "logos-module_69",
+        "logos-nix": "logos-nix_307",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -39244,9 +39057,35 @@
     },
     "logos-plugin-qt_39": {
       "inputs": {
-        "logos-lidl": "logos-lidl_96",
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_70",
-        "logos-nix": "logos-nix_311",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39258,6 +39097,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39271,6 +39111,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -39292,40 +39133,30 @@
     },
     "logos-plugin-qt_4": {
       "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_7",
-        "logos-nix": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_13",
+        "logos-module": "logos-module_9",
+        "logos-nix": "logos-nix_41",
         "logos-protocol": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1788890168,
-        "narHash": "sha256-gx8vxNsAU591M11YA5NFbhmCgE6FVaFsVWVvC57/Rk4=",
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1a0e399ef238ef3dbed367249f13a87029ca7fc1",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
         "type": "github"
       },
       "original": {
@@ -39336,20 +39167,7 @@
     },
     "logos-plugin-qt_40": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_97",
         "logos-module": "logos-module_71",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39362,7 +39180,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39376,7 +39194,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39390,9 +39208,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -39412,7 +39228,7 @@
     },
     "logos-plugin-qt_41": {
       "inputs": {
-        "logos-lidl": "logos-lidl_99",
+        "logos-lidl": "logos-lidl_100",
         "logos-module": "logos-module_72",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39425,7 +39241,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39439,7 +39255,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39453,7 +39269,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -39474,7 +39290,7 @@
     "logos-plugin-qt_42": {
       "inputs": {
         "logos-lidl": "logos-lidl_102",
-        "logos-module": "logos-module_73",
+        "logos-module": "logos-module_74",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39484,9 +39300,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39498,9 +39311,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39512,18 +39322,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -39544,7 +39351,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39555,7 +39361,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39566,7 +39371,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "nixpkgs"
         ]
       },
@@ -39586,57 +39390,8 @@
     },
     "logos-plugin-qt_44": {
       "inputs": {
-        "logos-lidl": "logos-lidl_106",
+        "logos-lidl": "logos-lidl_105",
         "logos-module": "logos-module_76",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_45": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_107",
-        "logos-module": "logos-module_77",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39682,10 +39437,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_46": {
+    "logos-plugin-qt_45": {
       "inputs": {
-        "logos-lidl": "logos-lidl_110",
-        "logos-module": "logos-module_78",
+        "logos-lidl": "logos-lidl_108",
+        "logos-module": "logos-module_77",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39731,12 +39486,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_47": {
+    "logos-plugin-qt_46": {
       "inputs": {
-        "logos-lidl": "logos-lidl_111",
-        "logos-module": "logos-module_79",
-        "logos-nix": "logos-nix_371",
-        "logos-protocol": "logos-protocol_58",
+        "logos-lidl": "logos-lidl_109",
+        "logos-module": "logos-module_78",
+        "logos-nix": "logos-nix_367",
+        "logos-protocol": "logos-protocol_57",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39761,7 +39516,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_48": {
+    "logos-plugin-qt_47": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -39771,7 +39526,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_80",
+        "logos-module": "logos-module_79",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39813,12 +39568,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_49": {
+    "logos-plugin-qt_48": {
       "inputs": {
-        "logos-lidl": "logos-lidl_113",
-        "logos-module": "logos-module_81",
-        "logos-nix": "logos-nix_378",
-        "logos-protocol": "logos-protocol_61",
+        "logos-lidl": "logos-lidl_111",
+        "logos-module": "logos-module_80",
+        "logos-nix": "logos-nix_374",
+        "logos-protocol": "logos-protocol_60",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39842,44 +39597,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_5": {
+    "logos-plugin-qt_49": {
       "inputs": {
-        "logos-lidl": "logos-lidl_15",
-        "logos-module": "logos-module_10",
-        "logos-nix": "logos-nix_45",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_50": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_114",
-        "logos-module": "logos-module_82",
+        "logos-lidl": "logos-lidl_112",
+        "logos-module": "logos-module_81",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39913,10 +39634,58 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_51": {
+    "logos-plugin-qt_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_117",
-        "logos-module": "logos-module_83",
+        "logos-lidl": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_10",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_50": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_115",
+        "logos-module": "logos-module_82",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39950,11 +39719,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_52": {
+    "logos-plugin-qt_51": {
       "inputs": {
-        "logos-lidl": "logos-lidl_120",
-        "logos-module": "logos-module_86",
-        "logos-nix": "logos-nix_414",
+        "logos-lidl": "logos-lidl_118",
+        "logos-module": "logos-module_85",
+        "logos-nix": "logos-nix_410",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -39982,7 +39751,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_53": {
+    "logos-plugin-qt_52": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -39990,7 +39759,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_87",
+        "logos-module": "logos-module_86",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40006,6 +39775,62 @@
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_53": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_88",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -40028,65 +39853,9 @@
     },
     "logos-plugin-qt_54": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_89",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_55": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_128",
-        "logos-module": "logos-module_92",
-        "logos-nix": "logos-nix_435",
+        "logos-lidl": "logos-lidl_126",
+        "logos-module": "logos-module_91",
+        "logos-nix": "logos-nix_431",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40122,7 +39891,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_56": {
+    "logos-plugin-qt_55": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
@@ -40134,7 +39903,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_93",
+        "logos-module": "logos-module_92",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40182,10 +39951,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_57": {
+    "logos-plugin-qt_56": {
       "inputs": {
-        "logos-lidl": "logos-lidl_131",
-        "logos-module": "logos-module_94",
+        "logos-lidl": "logos-lidl_129",
+        "logos-module": "logos-module_93",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40231,10 +40000,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_58": {
+    "logos-plugin-qt_57": {
       "inputs": {
-        "logos-lidl": "logos-lidl_134",
-        "logos-module": "logos-module_95",
+        "logos-lidl": "logos-lidl_132",
+        "logos-module": "logos-module_94",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40280,11 +40049,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_59": {
+    "logos-plugin-qt_58": {
       "inputs": {
-        "logos-lidl": "logos-lidl_138",
-        "logos-module": "logos-module_99",
-        "logos-nix": "logos-nix_466",
+        "logos-lidl": "logos-lidl_136",
+        "logos-module": "logos-module_98",
+        "logos-nix": "logos-nix_462",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40320,33 +40089,45 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_6": {
+    "logos-plugin-qt_59": {
       "inputs": {
         "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_11",
+        "logos-module": "logos-module_99",
         "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -40355,11 +40136,51 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_6": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_16",
+        "logos-module": "logos-module_11",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -40370,27 +40191,9 @@
     },
     "logos-plugin-qt_60": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_100",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
+        "logos-lidl": "logos-lidl_142",
+        "logos-module": "logos-module_103",
+        "logos-nix": "logos-nix_479",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40398,7 +40201,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40408,7 +40214,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -40430,9 +40239,35 @@
     },
     "logos-plugin-qt_61": {
       "inputs": {
-        "logos-lidl": "logos-lidl_144",
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_104",
-        "logos-nix": "logos-nix_483",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40444,6 +40279,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40457,6 +40293,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -40478,20 +40315,7 @@
     },
     "logos-plugin-qt_62": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_145",
         "logos-module": "logos-module_105",
         "logos-nix": [
           "logos-package-manager-module",
@@ -40504,7 +40328,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40518,7 +40342,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40532,9 +40356,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -40554,7 +40376,7 @@
     },
     "logos-plugin-qt_63": {
       "inputs": {
-        "logos-lidl": "logos-lidl_147",
+        "logos-lidl": "logos-lidl_148",
         "logos-module": "logos-module_106",
         "logos-nix": [
           "logos-package-manager-module",
@@ -40567,7 +40389,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40581,7 +40403,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40595,7 +40417,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -40616,7 +40438,7 @@
     "logos-plugin-qt_64": {
       "inputs": {
         "logos-lidl": "logos-lidl_150",
-        "logos-module": "logos-module_107",
+        "logos-module": "logos-module_108",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40626,9 +40448,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40640,9 +40459,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40654,18 +40470,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -40686,7 +40499,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40697,7 +40509,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40708,7 +40519,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "nixpkgs"
         ]
       },
@@ -40728,57 +40538,8 @@
     },
     "logos-plugin-qt_66": {
       "inputs": {
-        "logos-lidl": "logos-lidl_154",
+        "logos-lidl": "logos-lidl_153",
         "logos-module": "logos-module_110",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_67": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_155",
-        "logos-module": "logos-module_111",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40824,10 +40585,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_68": {
+    "logos-plugin-qt_67": {
       "inputs": {
-        "logos-lidl": "logos-lidl_158",
-        "logos-module": "logos-module_112",
+        "logos-lidl": "logos-lidl_156",
+        "logos-module": "logos-module_111",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40873,12 +40634,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_69": {
+    "logos-plugin-qt_68": {
       "inputs": {
-        "logos-lidl": "logos-lidl_159",
-        "logos-module": "logos-module_113",
-        "logos-nix": "logos-nix_543",
-        "logos-protocol": "logos-protocol_87",
+        "logos-lidl": "logos-lidl_157",
+        "logos-module": "logos-module_112",
+        "logos-nix": "logos-nix_539",
+        "logos-protocol": "logos-protocol_86",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40895,6 +40656,58 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_69": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_113",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -40905,79 +40718,27 @@
     },
     "logos-plugin-qt_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_18",
+        "logos-lidl": "logos-lidl_19",
         "logos-module": "logos-module_12",
         "logos-nix": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_70": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_114",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -40995,12 +40756,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_71": {
+    "logos-plugin-qt_70": {
       "inputs": {
-        "logos-lidl": "logos-lidl_161",
-        "logos-module": "logos-module_115",
-        "logos-nix": "logos-nix_550",
-        "logos-protocol": "logos-protocol_90",
+        "logos-lidl": "logos-lidl_159",
+        "logos-module": "logos-module_114",
+        "logos-nix": "logos-nix_546",
+        "logos-protocol": "logos-protocol_89",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41024,10 +40785,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_72": {
+    "logos-plugin-qt_71": {
       "inputs": {
-        "logos-lidl": "logos-lidl_162",
-        "logos-module": "logos-module_116",
+        "logos-lidl": "logos-lidl_160",
+        "logos-module": "logos-module_115",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41061,10 +40822,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_73": {
+    "logos-plugin-qt_72": {
       "inputs": {
-        "logos-lidl": "logos-lidl_165",
-        "logos-module": "logos-module_117",
+        "logos-lidl": "logos-lidl_163",
+        "logos-module": "logos-module_116",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -41098,11 +40859,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_74": {
+    "logos-plugin-qt_73": {
       "inputs": {
-        "logos-lidl": "logos-lidl_168",
-        "logos-module": "logos-module_120",
-        "logos-nix": "logos-nix_581",
+        "logos-lidl": "logos-lidl_166",
+        "logos-module": "logos-module_119",
+        "logos-nix": "logos-nix_577",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41130,7 +40891,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_75": {
+    "logos-plugin-qt_74": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41141,7 +40902,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_122",
+        "logos-module": "logos-module_121",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41186,11 +40947,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_76": {
+    "logos-plugin-qt_75": {
       "inputs": {
-        "logos-lidl": "logos-lidl_176",
-        "logos-module": "logos-module_125",
-        "logos-nix": "logos-nix_601",
+        "logos-lidl": "logos-lidl_174",
+        "logos-module": "logos-module_124",
+        "logos-nix": "logos-nix_597",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41226,7 +40987,7 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_77": {
+    "logos-plugin-qt_76": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41238,7 +40999,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_126",
+        "logos-module": "logos-module_125",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41286,10 +41047,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_78": {
+    "logos-plugin-qt_77": {
       "inputs": {
-        "logos-lidl": "logos-lidl_179",
-        "logos-module": "logos-module_127",
+        "logos-lidl": "logos-lidl_177",
+        "logos-module": "logos-module_126",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41335,100 +41096,60 @@
         "type": "github"
       }
     },
+    "logos-plugin-qt_78": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_180",
+        "logos-module": "logos-module_127",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
     "logos-plugin-qt_79": {
       "inputs": {
-        "logos-lidl": "logos-lidl_182",
-        "logos-module": "logos-module_128",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_8": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_21",
-        "logos-module": "logos-module_13",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_80": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_186",
-        "logos-module": "logos-module_132",
-        "logos-nix": "logos-nix_632",
+        "logos-lidl": "logos-lidl_184",
+        "logos-module": "logos-module_131",
+        "logos-nix": "logos-nix_628",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41464,7 +41185,41 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_81": {
+    "logos-plugin-qt_8": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_22",
+        "logos-module": "logos-module_16",
+        "logos-nix": "logos-nix_71",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_80": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41476,7 +41231,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_133",
+        "logos-module": "logos-module_132",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41505,6 +41260,54 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_81": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_190",
+        "logos-module": "logos-module_136",
+        "logos-nix": "logos-nix_645",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -41526,9 +41329,35 @@
     },
     "logos-plugin-qt_82": {
       "inputs": {
-        "logos-lidl": "logos-lidl_192",
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
         "logos-module": "logos-module_137",
-        "logos-nix": "logos-nix_649",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41540,6 +41369,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41553,6 +41383,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -41574,20 +41405,7 @@
     },
     "logos-plugin-qt_83": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_193",
         "logos-module": "logos-module_138",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -41600,7 +41418,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41614,7 +41432,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41628,9 +41446,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -41650,7 +41466,7 @@
     },
     "logos-plugin-qt_84": {
       "inputs": {
-        "logos-lidl": "logos-lidl_195",
+        "logos-lidl": "logos-lidl_196",
         "logos-module": "logos-module_139",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -41663,7 +41479,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41677,7 +41493,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41691,7 +41507,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
@@ -41712,7 +41528,7 @@
     "logos-plugin-qt_85": {
       "inputs": {
         "logos-lidl": "logos-lidl_198",
-        "logos-module": "logos-module_140",
+        "logos-module": "logos-module_141",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41722,9 +41538,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41736,9 +41549,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41750,18 +41560,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -41782,7 +41589,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -41793,7 +41599,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -41804,7 +41609,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
           "nixpkgs"
         ]
       },
@@ -41824,57 +41628,8 @@
     },
     "logos-plugin-qt_87": {
       "inputs": {
-        "logos-lidl": "logos-lidl_202",
+        "logos-lidl": "logos-lidl_201",
         "logos-module": "logos-module_143",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_88": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_203",
-        "logos-module": "logos-module_144",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41920,10 +41675,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_89": {
+    "logos-plugin-qt_88": {
       "inputs": {
-        "logos-lidl": "logos-lidl_206",
-        "logos-module": "logos-module_145",
+        "logos-lidl": "logos-lidl_204",
+        "logos-module": "logos-module_144",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41969,46 +41724,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_9": {
+    "logos-plugin-qt_89": {
       "inputs": {
-        "logos-lidl": "logos-lidl_24",
-        "logos-module": "logos-module_17",
-        "logos-nix": "logos-nix_75",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_90": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_207",
-        "logos-module": "logos-module_146",
-        "logos-nix": "logos-nix_709",
-        "logos-protocol": "logos-protocol_116",
+        "logos-lidl": "logos-lidl_205",
+        "logos-module": "logos-module_145",
+        "logos-nix": "logos-nix_705",
+        "logos-protocol": "logos-protocol_115",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42033,7 +41754,55 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_91": {
+    "logos-plugin-qt_9": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_17",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_90": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -42043,7 +41812,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_147",
+        "logos-module": "logos-module_146",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42085,12 +41854,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_92": {
+    "logos-plugin-qt_91": {
       "inputs": {
-        "logos-lidl": "logos-lidl_209",
-        "logos-module": "logos-module_148",
-        "logos-nix": "logos-nix_716",
-        "logos-protocol": "logos-protocol_119",
+        "logos-lidl": "logos-lidl_207",
+        "logos-module": "logos-module_147",
+        "logos-nix": "logos-nix_712",
+        "logos-protocol": "logos-protocol_118",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42114,10 +41883,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_93": {
+    "logos-plugin-qt_92": {
       "inputs": {
-        "logos-lidl": "logos-lidl_210",
-        "logos-module": "logos-module_149",
+        "logos-lidl": "logos-lidl_208",
+        "logos-module": "logos-module_148",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42151,10 +41920,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_94": {
+    "logos-plugin-qt_93": {
       "inputs": {
-        "logos-lidl": "logos-lidl_213",
-        "logos-module": "logos-module_150",
+        "logos-lidl": "logos-lidl_211",
+        "logos-module": "logos-module_149",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42188,11 +41957,11 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_95": {
+    "logos-plugin-qt_94": {
       "inputs": {
-        "logos-lidl": "logos-lidl_214",
-        "logos-module": "logos-module_151",
-        "logos-nix": "logos-nix_737",
+        "logos-lidl": "logos-lidl_212",
+        "logos-module": "logos-module_150",
+        "logos-nix": "logos-nix_733",
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -42203,11 +41972,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788890168,
-        "narHash": "sha256-gx8vxNsAU591M11YA5NFbhmCgE6FVaFsVWVvC57/Rk4=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "1a0e399ef238ef3dbed367249f13a87029ca7fc1",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -42248,7 +42017,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -42256,48 +42024,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_100": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -42315,7 +42041,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_101": {
+    "logos-protocol_100": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42352,7 +42078,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_102": {
+    "logos-protocol_101": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42393,7 +42119,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_103": {
+    "logos-protocol_102": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42430,9 +42156,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_104": {
+    "logos-protocol_103": {
       "inputs": {
-        "logos-nix": "logos-nix_633",
+        "logos-nix": "logos-nix_629",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42440,6 +42166,45 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_104": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -42468,45 +42233,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_106": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
@@ -42539,9 +42265,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_107": {
+    "logos-protocol_106": {
       "inputs": {
-        "logos-nix": "logos-nix_650",
+        "logos-nix": "logos-nix_646",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42555,6 +42281,51 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_107": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -42585,51 +42356,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_109": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
@@ -42666,38 +42392,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_11": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_110": {
+    "logos-protocol_109": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42742,9 +42437,35 @@
         "type": "github"
       }
     },
-    "logos-protocol_111": {
+    "logos-protocol_11": {
       "inputs": {
-        "logos-nix": "logos-nix_680",
+        "logos-nix": "logos-nix_72",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_110": {
+      "inputs": {
+        "logos-nix": "logos-nix_676",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42773,7 +42494,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_112": {
+    "logos-protocol_111": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42810,7 +42531,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_113": {
+    "logos-protocol_112": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42847,7 +42568,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_114": {
+    "logos-protocol_113": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42888,7 +42609,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_115": {
+    "logos-protocol_114": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42925,7 +42646,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_116": {
+    "logos-protocol_115": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42960,14 +42681,49 @@
         "type": "github"
       }
     },
-    "logos-protocol_117": {
+    "logos-protocol_116": {
       "inputs": {
-        "logos-nix": "logos-nix_710",
+        "logos-nix": "logos-nix_706",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_117": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -42993,16 +42749,14 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43024,18 +42778,11 @@
     },
     "logos-protocol_119": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_713",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43057,11 +42804,18 @@
     },
     "logos-protocol_12": {
       "inputs": {
-        "logos-nix": "logos-nix_76",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43082,32 +42836,6 @@
       }
     },
     "logos-protocol_120": {
-      "inputs": {
-        "logos-nix": "logos-nix_717",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_121": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43136,7 +42864,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_122": {
+    "logos-protocol_121": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43169,7 +42897,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_123": {
+    "logos-protocol_122": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -43198,9 +42926,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_124": {
+    "logos-protocol_123": {
       "inputs": {
-        "logos-nix": "logos-nix_738",
+        "logos-nix": "logos-nix_734",
         "nixpkgs": [
           "logos-protocol",
           "logos-nix",
@@ -43208,11 +42936,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788891513,
-        "narHash": "sha256-C362bESdD153asRK+1T9bl/hu+Y2isvpCjv2iFzCY5c=",
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "9ba2f5a7e254a68f05d7dbfb87272334bb96679d",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
         "type": "github"
       },
       "original": {
@@ -43222,39 +42950,6 @@
       }
     },
     "logos-protocol_13": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_14": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -43289,9 +42984,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_15": {
+    "logos-protocol_14": {
       "inputs": {
-        "logos-nix": "logos-nix_93",
+        "logos-nix": "logos-nix_89",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -43302,6 +42997,45 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_15": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -43329,45 +43063,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_17": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
@@ -43401,7 +43096,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_18": {
+    "logos-protocol_17": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -43440,9 +43135,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_19": {
+    "logos-protocol_18": {
       "inputs": {
-        "logos-nix": "logos-nix_123",
+        "logos-nix": "logos-nix_119",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -43460,6 +43155,37 @@
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "2e3344acccfba14cf2bd51019c62b7290dad10ca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_19": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787324808,
+        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
         "type": "github"
       },
       "original": {
@@ -43505,37 +43231,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787324808,
-        "narHash": "sha256-ROPYPTwQm29E8Pl3W6xqj13xQNtnZARjRoGjOMF+wos=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "480f40ff6300e4500b437f5030883ac0c9b39f93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_21": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
@@ -43561,7 +43256,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_22": {
+    "logos-protocol_21": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -43596,7 +43291,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_23": {
+    "logos-protocol_22": {
       "inputs": {
         "logos-nix": [
           "logos-liblogos",
@@ -43627,9 +43322,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_24": {
+    "logos-protocol_23": {
       "inputs": {
-        "logos-nix": "logos-nix_153",
+        "logos-nix": "logos-nix_149",
         "nixpkgs": [
           "logos-module-loader-qt",
           "logos-protocol",
@@ -43651,9 +43346,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_25": {
+    "logos-protocol_24": {
       "inputs": {
-        "logos-nix": "logos-nix_164",
+        "logos-nix": "logos-nix_160",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -43676,7 +43371,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_26": {
+    "logos-protocol_25": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -43707,7 +43402,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_27": {
+    "logos-protocol_26": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -43740,9 +43435,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_28": {
+    "logos-protocol_27": {
       "inputs": {
-        "logos-nix": "logos-nix_181",
+        "logos-nix": "logos-nix_177",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -43752,6 +43447,43 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_28": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -43778,7 +43510,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -43788,16 +43521,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
         "type": "github"
       },
       "original": {
@@ -43845,47 +43581,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_31": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -43913,9 +43608,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_32": {
+    "logos-protocol_31": {
       "inputs": {
-        "logos-nix": "logos-nix_211",
+        "logos-nix": "logos-nix_207",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -43940,7 +43635,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_33": {
+    "logos-protocol_32": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -43969,7 +43664,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_34": {
+    "logos-protocol_33": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -43998,7 +43693,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_35": {
+    "logos-protocol_34": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -44031,7 +43726,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_36": {
+    "logos-protocol_35": {
       "inputs": {
         "logos-nix": [
           "logos-modules-state-module",
@@ -44060,9 +43755,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_37": {
+    "logos-protocol_36": {
       "inputs": {
-        "logos-nix": "logos-nix_243",
+        "logos-nix": "logos-nix_239",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44085,7 +43780,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_38": {
+    "logos-protocol_37": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44116,7 +43811,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_39": {
+    "logos-protocol_38": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44130,6 +43825,34 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_39": {
+      "inputs": {
+        "logos-nix": "logos-nix_249",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44184,35 +43907,7 @@
     },
     "logos-protocol_40": {
       "inputs": {
-        "logos-nix": "logos-nix_253",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_41": {
-      "inputs": {
-        "logos-nix": "logos-nix_264",
+        "logos-nix": "logos-nix_260",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44239,7 +43934,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_42": {
+    "logos-protocol_41": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44278,7 +43973,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_43": {
+    "logos-protocol_42": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44315,7 +44010,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_44": {
+    "logos-protocol_43": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44356,7 +44051,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_45": {
+    "logos-protocol_44": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44393,9 +44088,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_46": {
+    "logos-protocol_45": {
       "inputs": {
-        "logos-nix": "logos-nix_295",
+        "logos-nix": "logos-nix_291",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44403,6 +44098,45 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_46": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44423,45 +44157,6 @@
       }
     },
     "logos-protocol_47": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_48": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44502,9 +44197,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_49": {
+    "logos-protocol_48": {
       "inputs": {
-        "logos-nix": "logos-nix_312",
+        "logos-nix": "logos-nix_308",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44518,6 +44213,51 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_49": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -44577,51 +44317,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_51": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
@@ -44658,7 +44353,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_52": {
+    "logos-protocol_51": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44703,9 +44398,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_53": {
+    "logos-protocol_52": {
       "inputs": {
-        "logos-nix": "logos-nix_342",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44734,7 +44429,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_54": {
+    "logos-protocol_53": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44771,7 +44466,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_55": {
+    "logos-protocol_54": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44808,7 +44503,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_56": {
+    "logos-protocol_55": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44849,7 +44544,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_57": {
+    "logos-protocol_56": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44886,7 +44581,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_58": {
+    "logos-protocol_57": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44902,6 +44597,33 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_368",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44923,12 +44645,20 @@
     },
     "logos-protocol_59": {
       "inputs": {
-        "logos-nix": "logos-nix_372",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-qt-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44950,21 +44680,22 @@
     },
     "logos-protocol_6": {
       "inputs": {
-        "logos-nix": "logos-nix_35",
+        "logos-nix": "logos-nix_42",
         "nixpkgs": [
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1788891513,
-        "narHash": "sha256-C362bESdD153asRK+1T9bl/hu+Y2isvpCjv2iFzCY5c=",
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "9ba2f5a7e254a68f05d7dbfb87272334bb96679d",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
         "type": "github"
       },
       "original": {
@@ -44979,16 +44710,14 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -45010,18 +44739,11 @@
     },
     "logos-protocol_61": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_375",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -45042,32 +44764,6 @@
       }
     },
     "logos-protocol_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_379",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_63": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45096,7 +44792,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_64": {
+    "logos-protocol_63": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45129,7 +44825,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_65": {
+    "logos-protocol_64": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45158,9 +44854,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_66": {
+    "logos-protocol_65": {
       "inputs": {
-        "logos-nix": "logos-nix_415",
+        "logos-nix": "logos-nix_411",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45183,7 +44879,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_67": {
+    "logos-protocol_66": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45195,6 +44891,39 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_67": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -45216,40 +44945,7 @@
     },
     "logos-protocol_68": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_69": {
-      "inputs": {
-        "logos-nix": "logos-nix_425",
+        "logos-nix": "logos-nix_421",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45275,35 +44971,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_7": {
+    "logos-protocol_69": {
       "inputs": {
-        "logos-nix": "logos-nix_46",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_70": {
-      "inputs": {
-        "logos-nix": "logos-nix_436",
+        "logos-nix": "logos-nix_432",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45330,7 +45000,40 @@
         "type": "github"
       }
     },
-    "logos-protocol_71": {
+    "logos-protocol_7": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_70": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45369,7 +45072,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_72": {
+    "logos-protocol_71": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45406,7 +45109,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_73": {
+    "logos-protocol_72": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45447,7 +45150,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_74": {
+    "logos-protocol_73": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45484,9 +45187,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_75": {
+    "logos-protocol_74": {
       "inputs": {
-        "logos-nix": "logos-nix_467",
+        "logos-nix": "logos-nix_463",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45494,6 +45197,45 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_75": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -45522,45 +45264,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_77": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
@@ -45593,9 +45296,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_78": {
+    "logos-protocol_77": {
       "inputs": {
-        "logos-nix": "logos-nix_484",
+        "logos-nix": "logos-nix_480",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45609,6 +45312,51 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_78": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -45639,84 +45387,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_8": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_80": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
@@ -45753,7 +45423,38 @@
         "type": "github"
       }
     },
-    "logos-protocol_81": {
+    "logos-protocol_8": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_80": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45798,9 +45499,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_82": {
+    "logos-protocol_81": {
       "inputs": {
-        "logos-nix": "logos-nix_514",
+        "logos-nix": "logos-nix_510",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45829,7 +45530,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_83": {
+    "logos-protocol_82": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45866,7 +45567,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_84": {
+    "logos-protocol_83": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45903,7 +45604,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_85": {
+    "logos-protocol_84": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45944,7 +45645,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_86": {
+    "logos-protocol_85": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45981,7 +45682,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_87": {
+    "logos-protocol_86": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46016,14 +45717,49 @@
         "type": "github"
       }
     },
-    "logos-protocol_88": {
+    "logos-protocol_87": {
       "inputs": {
-        "logos-nix": "logos-nix_544",
+        "logos-nix": "logos-nix_540",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_88": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -46049,16 +45785,14 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
+          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -46084,23 +45818,27 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
         "type": "github"
       },
       "original": {
@@ -46111,18 +45849,11 @@
     },
     "logos-protocol_90": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_547",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-plugin-qt",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -46144,32 +45875,6 @@
     },
     "logos-protocol_91": {
       "inputs": {
-        "logos-nix": "logos-nix_551",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_92": {
-      "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46197,7 +45902,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_93": {
+    "logos-protocol_92": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46230,7 +45935,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_94": {
+    "logos-protocol_93": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -46259,9 +45964,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_95": {
+    "logos-protocol_94": {
       "inputs": {
-        "logos-nix": "logos-nix_582",
+        "logos-nix": "logos-nix_578",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46284,7 +45989,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_96": {
+    "logos-protocol_95": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -46315,7 +46020,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_97": {
+    "logos-protocol_96": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -46348,9 +46053,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_98": {
+    "logos-protocol_97": {
       "inputs": {
-        "logos-nix": "logos-nix_591",
+        "logos-nix": "logos-nix_587",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46376,9 +46081,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_99": {
+    "logos-protocol_98": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_598",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46405,9 +46110,48 @@
         "type": "github"
       }
     },
+    "logos-protocol_99": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-qt-mcp": {
       "inputs": {
-        "logos-nix": "logos-nix_128",
+        "logos-nix": "logos-nix_124",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -46434,7 +46178,7 @@
     },
     "logos-qt-mcp_2": {
       "inputs": {
-        "logos-nix": "logos-nix_216",
+        "logos-nix": "logos-nix_212",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -46460,7 +46204,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_343",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46490,7 +46234,7 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_376",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46516,7 +46260,7 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-        "logos-nix": "logos-nix_519",
+        "logos-nix": "logos-nix_515",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46546,7 +46290,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-        "logos-nix": "logos-nix_552",
+        "logos-nix": "logos-nix_548",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46572,7 +46316,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-        "logos-nix": "logos-nix_685",
+        "logos-nix": "logos-nix_681",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46602,7 +46346,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-        "logos-nix": "logos-nix_718",
+        "logos-nix": "logos-nix_714",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46628,7 +46372,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-        "logos-nix": "logos-nix_739",
+        "logos-nix": "logos-nix_735",
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -46693,65 +46437,12 @@
     "logos-qt-sdk_10": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_42",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_11": {
-      "inputs": {
-        "logos-cpp-sdk": [
           "logos-module-loader-qt",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_46",
-        "logos-nix": "logos-nix_154",
-        "logos-plugin-qt": "logos-plugin-qt_19",
+        "logos-lidl": "logos-lidl_44",
+        "logos-nix": "logos-nix_150",
+        "logos-plugin-qt": "logos-plugin-qt_18",
         "logos-protocol": [
           "logos-module-loader-qt",
           "logos-protocol"
@@ -46777,16 +46468,16 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_12": {
+    "logos-qt-sdk_11": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_50",
-        "logos-nix": "logos-nix_165",
-        "logos-plugin-qt": "logos-plugin-qt_21",
+        "logos-lidl": "logos-lidl_48",
+        "logos-nix": "logos-nix_161",
+        "logos-plugin-qt": "logos-plugin-qt_20",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -46814,7 +46505,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_13": {
+    "logos-qt-sdk_12": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -46825,9 +46516,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_56",
-        "logos-nix": "logos-nix_182",
-        "logos-plugin-qt": "logos-plugin-qt_23",
+        "logos-lidl": "logos-lidl_54",
+        "logos-nix": "logos-nix_178",
+        "logos-plugin-qt": "logos-plugin-qt_22",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -46863,7 +46554,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_14": {
+    "logos-qt-sdk_13": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -46875,7 +46566,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_59",
+        "logos-lidl": "logos-lidl_57",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -46931,7 +46622,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_15": {
+    "logos-qt-sdk_14": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -46940,8 +46631,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_64",
-        "logos-nix": "logos-nix_212",
+        "logos-lidl": "logos-lidl_62",
+        "logos-nix": "logos-nix_208",
         "logos-protocol": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -46973,7 +46664,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_16": {
+    "logos-qt-sdk_15": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-modules-state-module",
@@ -46981,7 +46672,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_67",
+        "logos-lidl": "logos-lidl_65",
         "logos-nix": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -47021,16 +46712,16 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_17": {
+    "logos-qt-sdk_16": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_73",
-        "logos-nix": "logos-nix_244",
-        "logos-plugin-qt": "logos-plugin-qt_31",
+        "logos-lidl": "logos-lidl_71",
+        "logos-nix": "logos-nix_240",
+        "logos-plugin-qt": "logos-plugin-qt_30",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47058,7 +46749,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_18": {
+    "logos-qt-sdk_17": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47068,9 +46759,9 @@
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_77",
-        "logos-nix": "logos-nix_254",
-        "logos-plugin-qt": "logos-plugin-qt_32",
+        "logos-lidl": "logos-lidl_75",
+        "logos-nix": "logos-nix_250",
+        "logos-plugin-qt": "logos-plugin-qt_31",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47104,7 +46795,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_19": {
+    "logos-qt-sdk_18": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47115,9 +46806,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_81",
-        "logos-nix": "logos-nix_265",
-        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-lidl": "logos-lidl_79",
+        "logos-nix": "logos-nix_261",
+        "logos-plugin-qt": "logos-plugin-qt_33",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47145,6 +46836,74 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_19": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_82",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -47208,81 +46967,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_84",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_21": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_91",
-        "logos-nix": "logos-nix_296",
-        "logos-plugin-qt": "logos-plugin-qt_38",
+        "logos-lidl": "logos-lidl_89",
+        "logos-nix": "logos-nix_292",
+        "logos-plugin-qt": "logos-plugin-qt_37",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47318,7 +47009,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_22": {
+    "logos-qt-sdk_21": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47333,9 +47024,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_97",
-        "logos-nix": "logos-nix_313",
-        "logos-plugin-qt": "logos-plugin-qt_40",
+        "logos-lidl": "logos-lidl_95",
+        "logos-nix": "logos-nix_309",
+        "logos-plugin-qt": "logos-plugin-qt_39",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47362,6 +47053,94 @@
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_22": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_98",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -47390,98 +47169,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_100",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_24": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_105",
-        "logos-nix": "logos-nix_343",
+        "logos-lidl": "logos-lidl_103",
+        "logos-nix": "logos-nix_339",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47521,7 +47212,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_25": {
+    "logos-qt-sdk_24": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47533,7 +47224,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_108",
+        "logos-lidl": "logos-lidl_106",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47589,13 +47280,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_26": {
+    "logos-qt-sdk_25": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
-        "logos-lidl": "logos-lidl_112",
-        "logos-nix": "logos-nix_373",
-        "logos-plugin-qt": "logos-plugin-qt_48",
-        "logos-protocol": "logos-protocol_60",
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
+        "logos-lidl": "logos-lidl_110",
+        "logos-nix": "logos-nix_369",
+        "logos-plugin-qt": "logos-plugin-qt_47",
+        "logos-protocol": "logos-protocol_59",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47620,7 +47311,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_27": {
+    "logos-qt-sdk_26": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47628,7 +47319,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_115",
+        "logos-lidl": "logos-lidl_113",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47660,6 +47351,43 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_27": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_119",
+        "logos-nix": "logos-nix_412",
+        "logos-plugin-qt": "logos-plugin-qt_52",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -47673,51 +47401,14 @@
         "logos-cpp-sdk": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_121",
-        "logos-nix": "logos-nix_416",
-        "logos-plugin-qt": "logos-plugin-qt_53",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_29": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_125",
-        "logos-nix": "logos-nix_426",
-        "logos-plugin-qt": "logos-plugin-qt_54",
+        "logos-lidl": "logos-lidl_123",
+        "logos-nix": "logos-nix_422",
+        "logos-plugin-qt": "logos-plugin-qt_53",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47751,44 +47442,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_3": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_12",
-        "logos-nix": "logos-nix_36",
-        "logos-plugin-qt": "logos-plugin-qt_4",
-        "logos-protocol": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788891524,
-        "narHash": "sha256-qIf/0a0lVYgiRK/QqsjhOgC9viEOy10UHdSj3PDnKeI=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "012d090568a8452972cc3b7e007cb3ecd03b7000",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_30": {
+    "logos-qt-sdk_29": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47799,9 +47453,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_129",
-        "logos-nix": "logos-nix_437",
-        "logos-plugin-qt": "logos-plugin-qt_56",
+        "logos-lidl": "logos-lidl_127",
+        "logos-nix": "logos-nix_433",
+        "logos-plugin-qt": "logos-plugin-qt_55",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47837,7 +47491,47 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_31": {
+    "logos-qt-sdk_3": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_14",
+        "logos-nix": "logos-nix_43",
+        "logos-plugin-qt": "logos-plugin-qt_5",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_30": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47849,7 +47543,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_132",
+        "logos-lidl": "logos-lidl_130",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47905,7 +47599,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_32": {
+    "logos-qt-sdk_31": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47916,9 +47610,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_139",
-        "logos-nix": "logos-nix_468",
-        "logos-plugin-qt": "logos-plugin-qt_60",
+        "logos-lidl": "logos-lidl_137",
+        "logos-nix": "logos-nix_464",
+        "logos-plugin-qt": "logos-plugin-qt_59",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47954,7 +47648,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_33": {
+    "logos-qt-sdk_32": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47969,9 +47663,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_145",
-        "logos-nix": "logos-nix_485",
-        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-lidl": "logos-lidl_143",
+        "logos-nix": "logos-nix_481",
+        "logos-plugin-qt": "logos-plugin-qt_61",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47998,6 +47692,94 @@
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_33": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_146",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -48026,98 +47808,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_148",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_35": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_153",
-        "logos-nix": "logos-nix_515",
+        "logos-lidl": "logos-lidl_151",
+        "logos-nix": "logos-nix_511",
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48157,7 +47851,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_36": {
+    "logos-qt-sdk_35": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48169,7 +47863,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_156",
+        "logos-lidl": "logos-lidl_154",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48225,13 +47919,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_37": {
+    "logos-qt-sdk_36": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
-        "logos-lidl": "logos-lidl_160",
-        "logos-nix": "logos-nix_545",
-        "logos-plugin-qt": "logos-plugin-qt_70",
-        "logos-protocol": "logos-protocol_89",
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-lidl": "logos-lidl_158",
+        "logos-nix": "logos-nix_541",
+        "logos-plugin-qt": "logos-plugin-qt_69",
+        "logos-protocol": "logos-protocol_88",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48256,7 +47950,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_38": {
+    "logos-qt-sdk_37": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -48264,7 +47958,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_163",
+        "logos-lidl": "logos-lidl_161",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48296,6 +47990,47 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_38": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_167",
+        "logos-nix": "logos-nix_579",
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -48309,95 +48044,14 @@
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_169",
-        "logos-nix": "logos-nix_583",
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_4": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_16",
-        "logos-nix": "logos-nix_47",
-        "logos-plugin-qt": "logos-plugin-qt_6",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_40": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_173",
-        "logos-nix": "logos-nix_592",
-        "logos-plugin-qt": "logos-plugin-qt_75",
+        "logos-lidl": "logos-lidl_171",
+        "logos-nix": "logos-nix_588",
+        "logos-plugin-qt": "logos-plugin-qt_74",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48431,7 +48085,60 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_41": {
+    "logos-qt-sdk_4": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_17",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_40": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48442,9 +48149,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_177",
-        "logos-nix": "logos-nix_603",
-        "logos-plugin-qt": "logos-plugin-qt_77",
+        "logos-lidl": "logos-lidl_175",
+        "logos-nix": "logos-nix_599",
+        "logos-plugin-qt": "logos-plugin-qt_76",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48480,7 +48187,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_42": {
+    "logos-qt-sdk_41": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48492,7 +48199,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_180",
+        "logos-lidl": "logos-lidl_178",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48548,7 +48255,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_43": {
+    "logos-qt-sdk_42": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48559,9 +48266,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_187",
-        "logos-nix": "logos-nix_634",
-        "logos-plugin-qt": "logos-plugin-qt_81",
+        "logos-lidl": "logos-lidl_185",
+        "logos-nix": "logos-nix_630",
+        "logos-plugin-qt": "logos-plugin-qt_80",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48597,7 +48304,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_44": {
+    "logos-qt-sdk_43": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48612,9 +48319,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_193",
-        "logos-nix": "logos-nix_651",
-        "logos-plugin-qt": "logos-plugin-qt_83",
+        "logos-lidl": "logos-lidl_191",
+        "logos-nix": "logos-nix_647",
+        "logos-plugin-qt": "logos-plugin-qt_82",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48641,6 +48348,94 @@
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_44": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_194",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -48669,98 +48464,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_196",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_46": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_201",
-        "logos-nix": "logos-nix_681",
+        "logos-lidl": "logos-lidl_199",
+        "logos-nix": "logos-nix_677",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48800,7 +48507,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_47": {
+    "logos-qt-sdk_46": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48812,7 +48519,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_204",
+        "logos-lidl": "logos-lidl_202",
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48868,13 +48575,13 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_48": {
+    "logos-qt-sdk_47": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_60",
-        "logos-lidl": "logos-lidl_208",
-        "logos-nix": "logos-nix_711",
-        "logos-plugin-qt": "logos-plugin-qt_91",
-        "logos-protocol": "logos-protocol_118",
+        "logos-cpp-sdk": "logos-cpp-sdk_59",
+        "logos-lidl": "logos-lidl_206",
+        "logos-nix": "logos-nix_707",
+        "logos-plugin-qt": "logos-plugin-qt_90",
+        "logos-protocol": "logos-protocol_117",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48899,114 +48606,61 @@
         "type": "github"
       }
     },
+    "logos-qt-sdk_48": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_209",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
     "logos-qt-sdk_49": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_211",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_5": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_19",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_50": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_215",
-        "logos-nix": "logos-nix_740",
+        "logos-lidl": "logos-lidl_213",
+        "logos-nix": "logos-nix_736",
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -49020,11 +48674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788886355,
-        "narHash": "sha256-EyG/0hSzNkEmNePt+aEdCx+UnQ+f4DShlzRuemllUow=",
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "2dd4be54f29803c813094c48cdd2eabdfb625ef5",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
         "type": "github"
       },
       "original": {
@@ -49033,7 +48687,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_6": {
+    "logos-qt-sdk_5": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -49041,9 +48695,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_25",
-        "logos-nix": "logos-nix_77",
-        "logos-plugin-qt": "logos-plugin-qt_10",
+        "logos-lidl": "logos-lidl_23",
+        "logos-nix": "logos-nix_73",
+        "logos-plugin-qt": "logos-plugin-qt_9",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49073,7 +48727,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_7": {
+    "logos-qt-sdk_6": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -49085,9 +48739,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_31",
-        "logos-nix": "logos-nix_94",
-        "logos-plugin-qt": "logos-plugin-qt_12",
+        "logos-lidl": "logos-lidl_29",
+        "logos-nix": "logos-nix_90",
+        "logos-plugin-qt": "logos-plugin-qt_11",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49125,7 +48779,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_8": {
+    "logos-qt-sdk_7": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -49138,7 +48792,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_34",
+        "logos-lidl": "logos-lidl_32",
         "logos-nix": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49198,7 +48852,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_9": {
+    "logos-qt-sdk_8": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -49208,8 +48862,8 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_39",
-        "logos-nix": "logos-nix_124",
+        "logos-lidl": "logos-lidl_37",
+        "logos-nix": "logos-nix_120",
         "logos-protocol": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49235,6 +48889,59 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "c6be61d0ba3f1c06c1a5ff7ad6d42f3eda254877",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_9": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_40",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -49286,7 +48993,7 @@
     },
     "logos-rust-sdk_10": {
       "inputs": {
-        "logos-lidl": "logos-lidl_98",
+        "logos-lidl": "logos-lidl_96",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -49358,7 +49065,7 @@
     },
     "logos-rust-sdk_11": {
       "inputs": {
-        "logos-lidl": "logos-lidl_122",
+        "logos-lidl": "logos-lidl_120",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49374,7 +49081,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_67",
+        "logos-protocol": "logos-protocol_66",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49399,7 +49106,7 @@
     },
     "logos-rust-sdk_12": {
       "inputs": {
-        "logos-lidl": "logos-lidl_130",
+        "logos-lidl": "logos-lidl_128",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49427,7 +49134,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_71",
+        "logos-protocol": "logos-protocol_70",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49456,7 +49163,7 @@
     },
     "logos-rust-sdk_13": {
       "inputs": {
-        "logos-lidl": "logos-lidl_140",
+        "logos-lidl": "logos-lidl_138",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49484,7 +49191,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_76",
+        "logos-protocol": "logos-protocol_75",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49513,7 +49220,7 @@
     },
     "logos-rust-sdk_14": {
       "inputs": {
-        "logos-lidl": "logos-lidl_146",
+        "logos-lidl": "logos-lidl_144",
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49585,7 +49292,7 @@
     },
     "logos-rust-sdk_15": {
       "inputs": {
-        "logos-lidl": "logos-lidl_170",
+        "logos-lidl": "logos-lidl_168",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49601,7 +49308,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_96",
+        "logos-protocol": "logos-protocol_95",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49626,7 +49333,7 @@
     },
     "logos-rust-sdk_16": {
       "inputs": {
-        "logos-lidl": "logos-lidl_178",
+        "logos-lidl": "logos-lidl_176",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49654,7 +49361,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_100",
+        "logos-protocol": "logos-protocol_99",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49683,7 +49390,7 @@
     },
     "logos-rust-sdk_17": {
       "inputs": {
-        "logos-lidl": "logos-lidl_188",
+        "logos-lidl": "logos-lidl_186",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49711,7 +49418,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_105",
+        "logos-protocol": "logos-protocol_104",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49740,7 +49447,7 @@
     },
     "logos-rust-sdk_18": {
       "inputs": {
-        "logos-lidl": "logos-lidl_194",
+        "logos-lidl": "logos-lidl_192",
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49812,7 +49519,7 @@
     },
     "logos-rust-sdk_2": {
       "inputs": {
-        "logos-lidl": "logos-lidl_17",
+        "logos-lidl": "logos-lidl_15",
         "logos-logoscore-cli": [
           "logos-liblogos",
           "logos-capability-module",
@@ -49831,7 +49538,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_8",
+        "logos-protocol": "logos-protocol_7",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -49857,7 +49564,7 @@
     },
     "logos-rust-sdk_3": {
       "inputs": {
-        "logos-lidl": "logos-lidl_26",
+        "logos-lidl": "logos-lidl_24",
         "logos-logoscore-cli": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49876,7 +49583,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_13",
+        "logos-protocol": "logos-protocol_12",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49902,7 +49609,7 @@
     },
     "logos-rust-sdk_4": {
       "inputs": {
-        "logos-lidl": "logos-lidl_32",
+        "logos-lidl": "logos-lidl_30",
         "logos-logoscore-cli": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -49962,7 +49669,7 @@
     },
     "logos-rust-sdk_5": {
       "inputs": {
-        "logos-lidl": "logos-lidl_51",
+        "logos-lidl": "logos-lidl_49",
         "logos-logoscore-cli": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -49978,7 +49685,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_26",
+        "logos-protocol": "logos-protocol_25",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -50003,7 +49710,7 @@
     },
     "logos-rust-sdk_6": {
       "inputs": {
-        "logos-lidl": "logos-lidl_57",
+        "logos-lidl": "logos-lidl_55",
         "logos-logoscore-cli": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -50059,7 +49766,7 @@
     },
     "logos-rust-sdk_7": {
       "inputs": {
-        "logos-lidl": "logos-lidl_74",
+        "logos-lidl": "logos-lidl_72",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50075,7 +49782,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_38",
+        "logos-protocol": "logos-protocol_37",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50100,7 +49807,7 @@
     },
     "logos-rust-sdk_8": {
       "inputs": {
-        "logos-lidl": "logos-lidl_82",
+        "logos-lidl": "logos-lidl_80",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50128,7 +49835,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_42",
+        "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50157,7 +49864,7 @@
     },
     "logos-rust-sdk_9": {
       "inputs": {
-        "logos-lidl": "logos-lidl_92",
+        "logos-lidl": "logos-lidl_90",
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50185,7 +49892,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-        "logos-protocol": "logos-protocol_47",
+        "logos-protocol": "logos-protocol_46",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50214,7 +49921,7 @@
     },
     "logos-standalone-app": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_8",
+        "logos-cpp-sdk": "logos-cpp-sdk_7",
         "logos-design-system": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -50222,9 +49929,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_2",
-        "logos-nix": "logos-nix_126",
-        "logos-plugin-qt": "logos-plugin-qt_16",
-        "logos-protocol": "logos-protocol_20",
+        "logos-nix": "logos-nix_122",
+        "logos-plugin-qt": "logos-plugin-qt_15",
+        "logos-protocol": "logos-protocol_19",
         "logos-qt-mcp": "logos-qt-mcp",
         "logos-view-module-runtime": [
           "logos-liblogos",
@@ -50257,16 +49964,16 @@
     },
     "logos-standalone-app_2": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_15",
+        "logos-cpp-sdk": "logos-cpp-sdk_14",
         "logos-design-system": [
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_3",
-        "logos-nix": "logos-nix_214",
-        "logos-plugin-qt": "logos-plugin-qt_27",
-        "logos-protocol": "logos-protocol_33",
+        "logos-nix": "logos-nix_210",
+        "logos-plugin-qt": "logos-plugin-qt_26",
+        "logos-protocol": "logos-protocol_32",
         "logos-qt-mcp": "logos-qt-mcp_2",
         "logos-view-module-runtime": [
           "logos-modules-state-module",
@@ -50297,16 +50004,16 @@
     },
     "logos-standalone-app_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-cpp-sdk": "logos-cpp-sdk_20",
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
-        "logos-nix": "logos-nix_376",
-        "logos-plugin-qt": "logos-plugin-qt_49",
-        "logos-protocol": "logos-protocol_62",
+        "logos-nix": "logos-nix_372",
+        "logos-plugin-qt": "logos-plugin-qt_48",
+        "logos-protocol": "logos-protocol_61",
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -50337,7 +50044,7 @@
     },
     "logos-standalone-app_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_27",
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50348,9 +50055,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
-        "logos-nix": "logos-nix_345",
-        "logos-plugin-qt": "logos-plugin-qt_44",
-        "logos-protocol": "logos-protocol_54",
+        "logos-nix": "logos-nix_341",
+        "logos-plugin-qt": "logos-plugin-qt_43",
+        "logos-protocol": "logos-protocol_53",
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -50389,16 +50096,16 @@
     },
     "logos-standalone-app_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_6",
-        "logos-nix": "logos-nix_548",
-        "logos-plugin-qt": "logos-plugin-qt_71",
-        "logos-protocol": "logos-protocol_91",
+        "logos-nix": "logos-nix_544",
+        "logos-plugin-qt": "logos-plugin-qt_70",
+        "logos-protocol": "logos-protocol_90",
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -50429,7 +50136,7 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50440,9 +50147,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_7",
-        "logos-nix": "logos-nix_517",
-        "logos-plugin-qt": "logos-plugin-qt_66",
-        "logos-protocol": "logos-protocol_83",
+        "logos-nix": "logos-nix_513",
+        "logos-plugin-qt": "logos-plugin-qt_65",
+        "logos-protocol": "logos-protocol_82",
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -50481,16 +50188,16 @@
     },
     "logos-standalone-app_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_8",
-        "logos-nix": "logos-nix_714",
-        "logos-plugin-qt": "logos-plugin-qt_92",
-        "logos-protocol": "logos-protocol_120",
+        "logos-nix": "logos-nix_710",
+        "logos-plugin-qt": "logos-plugin-qt_91",
+        "logos-protocol": "logos-protocol_119",
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -50521,7 +50228,7 @@
     },
     "logos-standalone-app_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_55",
+        "logos-cpp-sdk": "logos-cpp-sdk_54",
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50532,9 +50239,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_9",
-        "logos-nix": "logos-nix_683",
-        "logos-plugin-qt": "logos-plugin-qt_87",
-        "logos-protocol": "logos-protocol_112",
+        "logos-nix": "logos-nix_679",
+        "logos-plugin-qt": "logos-plugin-qt_86",
+        "logos-protocol": "logos-protocol_111",
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -50611,10 +50318,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_381",
-        "logos-plugin-qt": "logos-plugin-qt_50",
-        "logos-protocol": "logos-protocol_63",
-        "logos-qt-sdk": "logos-qt-sdk_27",
+        "logos-nix": "logos-nix_377",
+        "logos-plugin-qt": "logos-plugin-qt_49",
+        "logos-protocol": "logos-protocol_62",
+        "logos-qt-sdk": "logos-qt-sdk_26",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50648,10 +50355,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_439",
-        "logos-plugin-qt": "logos-plugin-qt_57",
-        "logos-protocol": "logos-protocol_72",
-        "logos-qt-sdk": "logos-qt-sdk_31",
+        "logos-nix": "logos-nix_435",
+        "logos-plugin-qt": "logos-plugin-qt_56",
+        "logos-protocol": "logos-protocol_71",
+        "logos-qt-sdk": "logos-qt-sdk_30",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50693,10 +50400,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_487",
-        "logos-plugin-qt": "logos-plugin-qt_63",
-        "logos-protocol": "logos-protocol_79",
-        "logos-qt-sdk": "logos-qt-sdk_34",
+        "logos-nix": "logos-nix_483",
+        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-protocol": "logos-protocol_78",
+        "logos-qt-sdk": "logos-qt-sdk_33",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50738,10 +50445,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_520",
-        "logos-plugin-qt": "logos-plugin-qt_67",
-        "logos-protocol": "logos-protocol_84",
-        "logos-qt-sdk": "logos-qt-sdk_36",
+        "logos-nix": "logos-nix_516",
+        "logos-plugin-qt": "logos-plugin-qt_66",
+        "logos-protocol": "logos-protocol_83",
+        "logos-qt-sdk": "logos-qt-sdk_35",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50775,10 +50482,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_553",
-        "logos-plugin-qt": "logos-plugin-qt_72",
-        "logos-protocol": "logos-protocol_92",
-        "logos-qt-sdk": "logos-qt-sdk_38",
+        "logos-nix": "logos-nix_549",
+        "logos-plugin-qt": "logos-plugin-qt_71",
+        "logos-protocol": "logos-protocol_91",
+        "logos-qt-sdk": "logos-qt-sdk_37",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50812,10 +50519,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_605",
-        "logos-plugin-qt": "logos-plugin-qt_78",
-        "logos-protocol": "logos-protocol_101",
-        "logos-qt-sdk": "logos-qt-sdk_42",
+        "logos-nix": "logos-nix_601",
+        "logos-plugin-qt": "logos-plugin-qt_77",
+        "logos-protocol": "logos-protocol_100",
+        "logos-qt-sdk": "logos-qt-sdk_41",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50857,10 +50564,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_653",
-        "logos-plugin-qt": "logos-plugin-qt_84",
-        "logos-protocol": "logos-protocol_108",
-        "logos-qt-sdk": "logos-qt-sdk_45",
+        "logos-nix": "logos-nix_649",
+        "logos-plugin-qt": "logos-plugin-qt_83",
+        "logos-protocol": "logos-protocol_107",
+        "logos-qt-sdk": "logos-qt-sdk_44",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50902,10 +50609,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_686",
-        "logos-plugin-qt": "logos-plugin-qt_88",
-        "logos-protocol": "logos-protocol_113",
-        "logos-qt-sdk": "logos-qt-sdk_47",
+        "logos-nix": "logos-nix_682",
+        "logos-plugin-qt": "logos-plugin-qt_87",
+        "logos-protocol": "logos-protocol_112",
+        "logos-qt-sdk": "logos-qt-sdk_46",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50939,10 +50646,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_719",
-        "logos-plugin-qt": "logos-plugin-qt_93",
-        "logos-protocol": "logos-protocol_121",
-        "logos-qt-sdk": "logos-qt-sdk_49",
+        "logos-nix": "logos-nix_715",
+        "logos-plugin-qt": "logos-plugin-qt_92",
+        "logos-protocol": "logos-protocol_120",
+        "logos-qt-sdk": "logos-qt-sdk_48",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50973,10 +50680,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_49",
-        "logos-plugin-qt": "logos-plugin-qt_7",
-        "logos-protocol": "logos-protocol_9",
-        "logos-qt-sdk": "logos-qt-sdk_5",
+        "logos-nix": "logos-nix_45",
+        "logos-plugin-qt": "logos-plugin-qt_6",
+        "logos-protocol": "logos-protocol_8",
+        "logos-qt-sdk": "logos-qt-sdk_4",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -51012,10 +50719,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_96",
-        "logos-plugin-qt": "logos-plugin-qt_13",
-        "logos-protocol": "logos-protocol_16",
-        "logos-qt-sdk": "logos-qt-sdk_8",
+        "logos-nix": "logos-nix_92",
+        "logos-plugin-qt": "logos-plugin-qt_12",
+        "logos-protocol": "logos-protocol_15",
+        "logos-qt-sdk": "logos-qt-sdk_7",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51051,10 +50758,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_129",
-        "logos-plugin-qt": "logos-plugin-qt_17",
-        "logos-protocol": "logos-protocol_21",
-        "logos-qt-sdk": "logos-qt-sdk_10",
+        "logos-nix": "logos-nix_125",
+        "logos-plugin-qt": "logos-plugin-qt_16",
+        "logos-protocol": "logos-protocol_20",
+        "logos-qt-sdk": "logos-qt-sdk_9",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51089,10 +50796,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_184",
-        "logos-plugin-qt": "logos-plugin-qt_24",
-        "logos-protocol": "logos-protocol_29",
-        "logos-qt-sdk": "logos-qt-sdk_14",
+        "logos-nix": "logos-nix_180",
+        "logos-plugin-qt": "logos-plugin-qt_23",
+        "logos-protocol": "logos-protocol_28",
+        "logos-qt-sdk": "logos-qt-sdk_13",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -51126,10 +50833,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_217",
-        "logos-plugin-qt": "logos-plugin-qt_28",
-        "logos-protocol": "logos-protocol_34",
-        "logos-qt-sdk": "logos-qt-sdk_16",
+        "logos-nix": "logos-nix_213",
+        "logos-plugin-qt": "logos-plugin-qt_27",
+        "logos-protocol": "logos-protocol_33",
+        "logos-qt-sdk": "logos-qt-sdk_15",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -51163,10 +50870,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_267",
-        "logos-plugin-qt": "logos-plugin-qt_35",
-        "logos-protocol": "logos-protocol_43",
-        "logos-qt-sdk": "logos-qt-sdk_20",
+        "logos-nix": "logos-nix_263",
+        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-protocol": "logos-protocol_42",
+        "logos-qt-sdk": "logos-qt-sdk_19",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51208,10 +50915,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_315",
-        "logos-plugin-qt": "logos-plugin-qt_41",
-        "logos-protocol": "logos-protocol_50",
-        "logos-qt-sdk": "logos-qt-sdk_23",
+        "logos-nix": "logos-nix_311",
+        "logos-plugin-qt": "logos-plugin-qt_40",
+        "logos-protocol": "logos-protocol_49",
+        "logos-qt-sdk": "logos-qt-sdk_22",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51253,10 +50960,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_348",
-        "logos-plugin-qt": "logos-plugin-qt_45",
-        "logos-protocol": "logos-protocol_55",
-        "logos-qt-sdk": "logos-qt-sdk_25",
+        "logos-nix": "logos-nix_344",
+        "logos-plugin-qt": "logos-plugin-qt_44",
+        "logos-protocol": "logos-protocol_54",
+        "logos-qt-sdk": "logos-qt-sdk_24",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51342,10 +51049,10 @@
     },
     "logos-view-module-runtime_10": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-nix": "logos-nix_383",
-        "logos-plugin-qt": "logos-plugin-qt_51",
-        "logos-protocol": "logos-protocol_65",
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
+        "logos-nix": "logos-nix_379",
+        "logos-plugin-qt": "logos-plugin-qt_50",
+        "logos-protocol": "logos-protocol_64",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51370,10 +51077,10 @@
     },
     "logos-view-module-runtime_11": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
-        "logos-nix": "logos-nix_441",
-        "logos-plugin-qt": "logos-plugin-qt_58",
-        "logos-protocol": "logos-protocol_74",
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-nix": "logos-nix_437",
+        "logos-plugin-qt": "logos-plugin-qt_57",
+        "logos-protocol": "logos-protocol_73",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51402,10 +51109,10 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
-        "logos-nix": "logos-nix_489",
-        "logos-plugin-qt": "logos-plugin-qt_64",
-        "logos-protocol": "logos-protocol_81",
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-nix": "logos-nix_485",
+        "logos-plugin-qt": "logos-plugin-qt_63",
+        "logos-protocol": "logos-protocol_80",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51438,10 +51145,10 @@
     },
     "logos-view-module-runtime_13": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
-        "logos-nix": "logos-nix_522",
-        "logos-plugin-qt": "logos-plugin-qt_68",
-        "logos-protocol": "logos-protocol_86",
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-nix": "logos-nix_518",
+        "logos-plugin-qt": "logos-plugin-qt_67",
+        "logos-protocol": "logos-protocol_85",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51470,10 +51177,10 @@
     },
     "logos-view-module-runtime_14": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-nix": "logos-nix_555",
-        "logos-plugin-qt": "logos-plugin-qt_73",
-        "logos-protocol": "logos-protocol_94",
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+        "logos-nix": "logos-nix_551",
+        "logos-plugin-qt": "logos-plugin-qt_72",
+        "logos-protocol": "logos-protocol_93",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51498,10 +51205,10 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_52",
-        "logos-nix": "logos-nix_607",
-        "logos-plugin-qt": "logos-plugin-qt_79",
-        "logos-protocol": "logos-protocol_103",
+        "logos-cpp-sdk": "logos-cpp-sdk_51",
+        "logos-nix": "logos-nix_603",
+        "logos-plugin-qt": "logos-plugin-qt_78",
+        "logos-protocol": "logos-protocol_102",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51530,10 +51237,10 @@
     },
     "logos-view-module-runtime_16": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_57",
-        "logos-nix": "logos-nix_655",
-        "logos-plugin-qt": "logos-plugin-qt_85",
-        "logos-protocol": "logos-protocol_110",
+        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-nix": "logos-nix_651",
+        "logos-plugin-qt": "logos-plugin-qt_84",
+        "logos-protocol": "logos-protocol_109",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51566,10 +51273,10 @@
     },
     "logos-view-module-runtime_17": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_59",
-        "logos-nix": "logos-nix_688",
-        "logos-plugin-qt": "logos-plugin-qt_89",
-        "logos-protocol": "logos-protocol_115",
+        "logos-cpp-sdk": "logos-cpp-sdk_58",
+        "logos-nix": "logos-nix_684",
+        "logos-plugin-qt": "logos-plugin-qt_88",
+        "logos-protocol": "logos-protocol_114",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51598,10 +51305,10 @@
     },
     "logos-view-module-runtime_18": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_61",
-        "logos-nix": "logos-nix_721",
-        "logos-plugin-qt": "logos-plugin-qt_94",
-        "logos-protocol": "logos-protocol_123",
+        "logos-cpp-sdk": "logos-cpp-sdk_60",
+        "logos-nix": "logos-nix_717",
+        "logos-plugin-qt": "logos-plugin-qt_93",
+        "logos-protocol": "logos-protocol_122",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51629,7 +51336,7 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-        "logos-nix": "logos-nix_741",
+        "logos-nix": "logos-nix_737",
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -51643,11 +51350,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789077450,
-        "narHash": "sha256-tOOJTW9zHAIDyEamDoMYGEiz9AI66kwdRPvF1SHGNwE=",
+        "lastModified": 1789108083,
+        "narHash": "sha256-GojrQymBMY/fy9ib9B7dR/OVfAR5tVLw4j4yuT7Q5yo=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "7eeae34241853b6c185e8e59d226b614cd0610c3",
+        "rev": "db31d118c0f57876e843cb8d946a5a4d8461f70d",
         "type": "github"
       },
       "original": {
@@ -51658,10 +51365,10 @@
     },
     "logos-view-module-runtime_2": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_6",
-        "logos-nix": "logos-nix_51",
-        "logos-plugin-qt": "logos-plugin-qt_8",
-        "logos-protocol": "logos-protocol_11",
+        "logos-cpp-sdk": "logos-cpp-sdk_5",
+        "logos-nix": "logos-nix_47",
+        "logos-plugin-qt": "logos-plugin-qt_7",
+        "logos-protocol": "logos-protocol_10",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -51687,10 +51394,10 @@
     },
     "logos-view-module-runtime_3": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_10",
-        "logos-nix": "logos-nix_98",
-        "logos-plugin-qt": "logos-plugin-qt_14",
-        "logos-protocol": "logos-protocol_18",
+        "logos-cpp-sdk": "logos-cpp-sdk_9",
+        "logos-nix": "logos-nix_94",
+        "logos-plugin-qt": "logos-plugin-qt_13",
+        "logos-protocol": "logos-protocol_17",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51720,10 +51427,10 @@
     },
     "logos-view-module-runtime_4": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_12",
-        "logos-nix": "logos-nix_131",
-        "logos-plugin-qt": "logos-plugin-qt_18",
-        "logos-protocol": "logos-protocol_23",
+        "logos-cpp-sdk": "logos-cpp-sdk_11",
+        "logos-nix": "logos-nix_127",
+        "logos-plugin-qt": "logos-plugin-qt_17",
+        "logos-protocol": "logos-protocol_22",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51749,10 +51456,10 @@
     },
     "logos-view-module-runtime_5": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_17",
-        "logos-nix": "logos-nix_186",
-        "logos-plugin-qt": "logos-plugin-qt_25",
-        "logos-protocol": "logos-protocol_31",
+        "logos-cpp-sdk": "logos-cpp-sdk_16",
+        "logos-nix": "logos-nix_182",
+        "logos-plugin-qt": "logos-plugin-qt_24",
+        "logos-protocol": "logos-protocol_30",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -51781,10 +51488,10 @@
     },
     "logos-view-module-runtime_6": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_19",
-        "logos-nix": "logos-nix_219",
-        "logos-plugin-qt": "logos-plugin-qt_29",
-        "logos-protocol": "logos-protocol_36",
+        "logos-cpp-sdk": "logos-cpp-sdk_18",
+        "logos-nix": "logos-nix_215",
+        "logos-plugin-qt": "logos-plugin-qt_28",
+        "logos-protocol": "logos-protocol_35",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -51809,10 +51516,10 @@
     },
     "logos-view-module-runtime_7": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_24",
-        "logos-nix": "logos-nix_269",
-        "logos-plugin-qt": "logos-plugin-qt_36",
-        "logos-protocol": "logos-protocol_45",
+        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-nix": "logos-nix_265",
+        "logos-plugin-qt": "logos-plugin-qt_35",
+        "logos-protocol": "logos-protocol_44",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51841,10 +51548,10 @@
     },
     "logos-view-module-runtime_8": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
-        "logos-nix": "logos-nix_317",
-        "logos-plugin-qt": "logos-plugin-qt_42",
-        "logos-protocol": "logos-protocol_52",
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-nix": "logos-nix_313",
+        "logos-plugin-qt": "logos-plugin-qt_41",
+        "logos-protocol": "logos-protocol_51",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51877,10 +51584,10 @@
     },
     "logos-view-module-runtime_9": {
       "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-nix": "logos-nix_350",
-        "logos-plugin-qt": "logos-plugin-qt_46",
-        "logos-protocol": "logos-protocol_57",
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-nix": "logos-nix_346",
+        "logos-plugin-qt": "logos-plugin-qt_45",
+        "logos-protocol": "logos-protocol_56",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52555,7 +52262,7 @@
     },
     "nix-bundle-appimage_10": {
       "inputs": {
-        "logos-nix": "logos-nix_139",
+        "logos-nix": "logos-nix_135",
         "nix-bundle-dir": "nix-bundle-dir_21",
         "nixpkgs": [
           "logos-liblogos",
@@ -52666,7 +52373,7 @@
     },
     "nix-bundle-appimage_13": {
       "inputs": {
-        "logos-nix": "logos-nix_194",
+        "logos-nix": "logos-nix_190",
         "nix-bundle-dir": "nix-bundle-dir_27",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -52698,7 +52405,7 @@
     },
     "nix-bundle-appimage_14": {
       "inputs": {
-        "logos-nix": "logos-nix_207",
+        "logos-nix": "logos-nix_203",
         "nix-bundle-dir": "nix-bundle-dir_30",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -52727,7 +52434,7 @@
     },
     "nix-bundle-appimage_15": {
       "inputs": {
-        "logos-nix": "logos-nix_227",
+        "logos-nix": "logos-nix_223",
         "nix-bundle-dir": "nix-bundle-dir_33",
         "nixpkgs": [
           "logos-modules-state-module",
@@ -52837,7 +52544,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-        "logos-nix": "logos-nix_277",
+        "logos-nix": "logos-nix_273",
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53003,7 +52710,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-        "logos-nix": "logos-nix_325",
+        "logos-nix": "logos-nix_321",
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53039,7 +52746,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-        "logos-nix": "logos-nix_338",
+        "logos-nix": "logos-nix_334",
         "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53072,7 +52779,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_354",
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53104,7 +52811,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-        "logos-nix": "logos-nix_367",
+        "logos-nix": "logos-nix_363",
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53133,7 +52840,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-        "logos-nix": "logos-nix_391",
+        "logos-nix": "logos-nix_387",
         "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53161,7 +52868,7 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-        "logos-nix": "logos-nix_399",
+        "logos-nix": "logos-nix_395",
         "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -53187,7 +52894,7 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-        "logos-nix": "logos-nix_404",
+        "logos-nix": "logos-nix_400",
         "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
           "logos-package-manager",
@@ -53323,7 +53030,7 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-        "logos-nix": "logos-nix_449",
+        "logos-nix": "logos-nix_445",
         "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53461,7 +53168,7 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-        "logos-nix": "logos-nix_497",
+        "logos-nix": "logos-nix_493",
         "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53497,7 +53204,7 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
+        "logos-nix": "logos-nix_506",
         "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53530,7 +53237,7 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-        "logos-nix": "logos-nix_530",
+        "logos-nix": "logos-nix_526",
         "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53562,7 +53269,7 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-        "logos-nix": "logos-nix_539",
+        "logos-nix": "logos-nix_535",
         "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53591,7 +53298,7 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-        "logos-nix": "logos-nix_563",
+        "logos-nix": "logos-nix_559",
         "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53619,7 +53326,7 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-        "logos-nix": "logos-nix_571",
+        "logos-nix": "logos-nix_567",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -53765,7 +53472,7 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-        "logos-nix": "logos-nix_615",
+        "logos-nix": "logos-nix_611",
         "nix-bundle-dir": "nix-bundle-dir_93",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -53903,7 +53610,7 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-        "logos-nix": "logos-nix_663",
+        "logos-nix": "logos-nix_659",
         "nix-bundle-dir": "nix-bundle-dir_99",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -53939,7 +53646,7 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-        "logos-nix": "logos-nix_676",
+        "logos-nix": "logos-nix_672",
         "nix-bundle-dir": "nix-bundle-dir_102",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -53972,7 +53679,7 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-        "logos-nix": "logos-nix_696",
+        "logos-nix": "logos-nix_692",
         "nix-bundle-dir": "nix-bundle-dir_105",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54004,7 +53711,7 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
-        "logos-nix": "logos-nix_705",
+        "logos-nix": "logos-nix_701",
         "nix-bundle-dir": "nix-bundle-dir_108",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54033,7 +53740,7 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
-        "logos-nix": "logos-nix_729",
+        "logos-nix": "logos-nix_725",
         "nix-bundle-dir": "nix-bundle-dir_111",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54061,7 +53768,7 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
-        "logos-nix": "logos-nix_742",
+        "logos-nix": "logos-nix_738",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "nix-bundle-appimage",
@@ -54085,7 +53792,7 @@
     },
     "nix-bundle-appimage_5": {
       "inputs": {
-        "logos-nix": "logos-nix_59",
+        "logos-nix": "logos-nix_55",
         "nix-bundle-dir": "nix-bundle-dir_9",
         "nixpkgs": [
           "logos-liblogos",
@@ -54114,7 +53821,7 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
-        "logos-nix": "logos-nix_748",
+        "logos-nix": "logos-nix_744",
         "nix-bundle-dir": "nix-bundle-dir_116",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -54228,7 +53935,7 @@
     },
     "nix-bundle-appimage_8": {
       "inputs": {
-        "logos-nix": "logos-nix_106",
+        "logos-nix": "logos-nix_102",
         "nix-bundle-dir": "nix-bundle-dir_15",
         "nixpkgs": [
           "logos-liblogos",
@@ -54261,7 +53968,7 @@
     },
     "nix-bundle-appimage_9": {
       "inputs": {
-        "logos-nix": "logos-nix_119",
+        "logos-nix": "logos-nix_115",
         "nix-bundle-dir": "nix-bundle-dir_18",
         "nixpkgs": [
           "logos-liblogos",
@@ -54320,7 +54027,7 @@
     },
     "nix-bundle-dir_10": {
       "inputs": {
-        "logos-nix": "logos-nix_61",
+        "logos-nix": "logos-nix_57",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -54348,7 +54055,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-        "logos-nix": "logos-nix_665",
+        "logos-nix": "logos-nix_661",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54383,7 +54090,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-        "logos-nix": "logos-nix_668",
+        "logos-nix": "logos-nix_664",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54418,7 +54125,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-        "logos-nix": "logos-nix_677",
+        "logos-nix": "logos-nix_673",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54449,7 +54156,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-        "logos-nix": "logos-nix_678",
+        "logos-nix": "logos-nix_674",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54481,7 +54188,7 @@
     },
     "nix-bundle-dir_104": {
       "inputs": {
-        "logos-nix": "logos-nix_692",
+        "logos-nix": "logos-nix_688",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54511,7 +54218,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-        "logos-nix": "logos-nix_697",
+        "logos-nix": "logos-nix_693",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54541,7 +54248,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-        "logos-nix": "logos-nix_698",
+        "logos-nix": "logos-nix_694",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54572,7 +54279,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-        "logos-nix": "logos-nix_701",
+        "logos-nix": "logos-nix_697",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54603,7 +54310,7 @@
     },
     "nix-bundle-dir_108": {
       "inputs": {
-        "logos-nix": "logos-nix_706",
+        "logos-nix": "logos-nix_702",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54630,7 +54337,7 @@
     },
     "nix-bundle-dir_109": {
       "inputs": {
-        "logos-nix": "logos-nix_707",
+        "logos-nix": "logos-nix_703",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54658,7 +54365,7 @@
     },
     "nix-bundle-dir_11": {
       "inputs": {
-        "logos-nix": "logos-nix_64",
+        "logos-nix": "logos-nix_60",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -54686,7 +54393,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-        "logos-nix": "logos-nix_725",
+        "logos-nix": "logos-nix_721",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54712,7 +54419,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
+        "logos-nix": "logos-nix_726",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54738,7 +54445,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-        "logos-nix": "logos-nix_731",
+        "logos-nix": "logos-nix_727",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54765,7 +54472,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_730",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54792,7 +54499,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-        "logos-nix": "logos-nix_743",
+        "logos-nix": "logos-nix_739",
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -54814,7 +54521,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-        "logos-nix": "logos-nix_744",
+        "logos-nix": "logos-nix_740",
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -54837,7 +54544,7 @@
     },
     "nix-bundle-dir_116": {
       "inputs": {
-        "logos-nix": "logos-nix_749",
+        "logos-nix": "logos-nix_745",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -54861,7 +54568,7 @@
     },
     "nix-bundle-dir_117": {
       "inputs": {
-        "logos-nix": "logos-nix_750",
+        "logos-nix": "logos-nix_746",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -54886,7 +54593,7 @@
     },
     "nix-bundle-dir_118": {
       "inputs": {
-        "logos-nix": "logos-nix_753",
+        "logos-nix": "logos-nix_749",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -54981,7 +54688,7 @@
     },
     "nix-bundle-dir_14": {
       "inputs": {
-        "logos-nix": "logos-nix_102",
+        "logos-nix": "logos-nix_98",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55012,7 +54719,7 @@
     },
     "nix-bundle-dir_15": {
       "inputs": {
-        "logos-nix": "logos-nix_107",
+        "logos-nix": "logos-nix_103",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55043,7 +54750,7 @@
     },
     "nix-bundle-dir_16": {
       "inputs": {
-        "logos-nix": "logos-nix_108",
+        "logos-nix": "logos-nix_104",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55075,7 +54782,7 @@
     },
     "nix-bundle-dir_17": {
       "inputs": {
-        "logos-nix": "logos-nix_111",
+        "logos-nix": "logos-nix_107",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55107,7 +54814,7 @@
     },
     "nix-bundle-dir_18": {
       "inputs": {
-        "logos-nix": "logos-nix_120",
+        "logos-nix": "logos-nix_116",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55135,7 +54842,7 @@
     },
     "nix-bundle-dir_19": {
       "inputs": {
-        "logos-nix": "logos-nix_121",
+        "logos-nix": "logos-nix_117",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55190,7 +54897,7 @@
     },
     "nix-bundle-dir_20": {
       "inputs": {
-        "logos-nix": "logos-nix_135",
+        "logos-nix": "logos-nix_131",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55217,7 +54924,7 @@
     },
     "nix-bundle-dir_21": {
       "inputs": {
-        "logos-nix": "logos-nix_140",
+        "logos-nix": "logos-nix_136",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55244,7 +54951,7 @@
     },
     "nix-bundle-dir_22": {
       "inputs": {
-        "logos-nix": "logos-nix_141",
+        "logos-nix": "logos-nix_137",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55272,7 +54979,7 @@
     },
     "nix-bundle-dir_23": {
       "inputs": {
-        "logos-nix": "logos-nix_144",
+        "logos-nix": "logos-nix_140",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -55366,7 +55073,7 @@
     },
     "nix-bundle-dir_26": {
       "inputs": {
-        "logos-nix": "logos-nix_190",
+        "logos-nix": "logos-nix_186",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55396,7 +55103,7 @@
     },
     "nix-bundle-dir_27": {
       "inputs": {
-        "logos-nix": "logos-nix_195",
+        "logos-nix": "logos-nix_191",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55426,7 +55133,7 @@
     },
     "nix-bundle-dir_28": {
       "inputs": {
-        "logos-nix": "logos-nix_196",
+        "logos-nix": "logos-nix_192",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55457,7 +55164,7 @@
     },
     "nix-bundle-dir_29": {
       "inputs": {
-        "logos-nix": "logos-nix_199",
+        "logos-nix": "logos-nix_195",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55514,7 +55221,7 @@
     },
     "nix-bundle-dir_30": {
       "inputs": {
-        "logos-nix": "logos-nix_208",
+        "logos-nix": "logos-nix_204",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55541,7 +55248,7 @@
     },
     "nix-bundle-dir_31": {
       "inputs": {
-        "logos-nix": "logos-nix_209",
+        "logos-nix": "logos-nix_205",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55569,7 +55276,7 @@
     },
     "nix-bundle-dir_32": {
       "inputs": {
-        "logos-nix": "logos-nix_223",
+        "logos-nix": "logos-nix_219",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55595,7 +55302,7 @@
     },
     "nix-bundle-dir_33": {
       "inputs": {
-        "logos-nix": "logos-nix_228",
+        "logos-nix": "logos-nix_224",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55621,7 +55328,7 @@
     },
     "nix-bundle-dir_34": {
       "inputs": {
-        "logos-nix": "logos-nix_229",
+        "logos-nix": "logos-nix_225",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55648,7 +55355,7 @@
     },
     "nix-bundle-dir_35": {
       "inputs": {
-        "logos-nix": "logos-nix_232",
+        "logos-nix": "logos-nix_228",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -55741,7 +55448,7 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-        "logos-nix": "logos-nix_273",
+        "logos-nix": "logos-nix_269",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55771,7 +55478,7 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-        "logos-nix": "logos-nix_278",
+        "logos-nix": "logos-nix_274",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55828,7 +55535,7 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-        "logos-nix": "logos-nix_279",
+        "logos-nix": "logos-nix_275",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55859,7 +55566,7 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-        "logos-nix": "logos-nix_282",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55972,7 +55679,7 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-        "logos-nix": "logos-nix_321",
+        "logos-nix": "logos-nix_317",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56006,7 +55713,7 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-        "logos-nix": "logos-nix_326",
+        "logos-nix": "logos-nix_322",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56040,7 +55747,7 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-        "logos-nix": "logos-nix_327",
+        "logos-nix": "logos-nix_323",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56075,7 +55782,7 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-        "logos-nix": "logos-nix_330",
+        "logos-nix": "logos-nix_326",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56110,7 +55817,7 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-        "logos-nix": "logos-nix_339",
+        "logos-nix": "logos-nix_335",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56141,7 +55848,7 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-        "logos-nix": "logos-nix_340",
+        "logos-nix": "logos-nix_336",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56200,7 +55907,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-        "logos-nix": "logos-nix_354",
+        "logos-nix": "logos-nix_350",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56230,7 +55937,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-        "logos-nix": "logos-nix_359",
+        "logos-nix": "logos-nix_355",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56260,7 +55967,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-        "logos-nix": "logos-nix_360",
+        "logos-nix": "logos-nix_356",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56291,7 +55998,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-        "logos-nix": "logos-nix_363",
+        "logos-nix": "logos-nix_359",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56322,7 +56029,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-        "logos-nix": "logos-nix_368",
+        "logos-nix": "logos-nix_364",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56349,7 +56056,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-        "logos-nix": "logos-nix_369",
+        "logos-nix": "logos-nix_365",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56377,7 +56084,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-        "logos-nix": "logos-nix_387",
+        "logos-nix": "logos-nix_383",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56403,7 +56110,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-        "logos-nix": "logos-nix_392",
+        "logos-nix": "logos-nix_388",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56429,7 +56136,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-        "logos-nix": "logos-nix_393",
+        "logos-nix": "logos-nix_389",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56456,7 +56163,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-        "logos-nix": "logos-nix_396",
+        "logos-nix": "logos-nix_392",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56508,7 +56215,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-        "logos-nix": "logos-nix_400",
+        "logos-nix": "logos-nix_396",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -56532,7 +56239,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-        "logos-nix": "logos-nix_401",
+        "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -56557,7 +56264,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
+        "logos-nix": "logos-nix_401",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -56580,7 +56287,7 @@
     },
     "nix-bundle-dir_63": {
       "inputs": {
-        "logos-nix": "logos-nix_406",
+        "logos-nix": "logos-nix_402",
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-dir",
@@ -56670,7 +56377,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-        "logos-nix": "logos-nix_445",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56700,7 +56407,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-        "logos-nix": "logos-nix_450",
+        "logos-nix": "logos-nix_446",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56730,7 +56437,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-        "logos-nix": "logos-nix_451",
+        "logos-nix": "logos-nix_447",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56761,7 +56468,7 @@
     },
     "nix-bundle-dir_69": {
       "inputs": {
-        "logos-nix": "logos-nix_454",
+        "logos-nix": "logos-nix_450",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56905,7 +56612,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-        "logos-nix": "logos-nix_493",
+        "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56939,7 +56646,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-        "logos-nix": "logos-nix_498",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56973,7 +56680,7 @@
     },
     "nix-bundle-dir_74": {
       "inputs": {
-        "logos-nix": "logos-nix_499",
+        "logos-nix": "logos-nix_495",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57008,7 +56715,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-        "logos-nix": "logos-nix_502",
+        "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57043,7 +56750,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-        "logos-nix": "logos-nix_511",
+        "logos-nix": "logos-nix_507",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57074,7 +56781,7 @@
     },
     "nix-bundle-dir_77": {
       "inputs": {
-        "logos-nix": "logos-nix_512",
+        "logos-nix": "logos-nix_508",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57106,7 +56813,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-        "logos-nix": "logos-nix_526",
+        "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57136,7 +56843,7 @@
     },
     "nix-bundle-dir_79": {
       "inputs": {
-        "logos-nix": "logos-nix_531",
+        "logos-nix": "logos-nix_527",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57166,7 +56873,7 @@
     },
     "nix-bundle-dir_8": {
       "inputs": {
-        "logos-nix": "logos-nix_55",
+        "logos-nix": "logos-nix_51",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -57193,7 +56900,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-        "logos-nix": "logos-nix_532",
+        "logos-nix": "logos-nix_528",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57224,7 +56931,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_535",
+        "logos-nix": "logos-nix_531",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57255,7 +56962,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_540",
+        "logos-nix": "logos-nix_536",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57282,7 +56989,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_541",
+        "logos-nix": "logos-nix_537",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57310,7 +57017,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-        "logos-nix": "logos-nix_559",
+        "logos-nix": "logos-nix_555",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57336,7 +57043,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-        "logos-nix": "logos-nix_564",
+        "logos-nix": "logos-nix_560",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57362,7 +57069,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-        "logos-nix": "logos-nix_565",
+        "logos-nix": "logos-nix_561",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57389,7 +57096,7 @@
     },
     "nix-bundle-dir_87": {
       "inputs": {
-        "logos-nix": "logos-nix_568",
+        "logos-nix": "logos-nix_564",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57416,7 +57123,7 @@
     },
     "nix-bundle-dir_88": {
       "inputs": {
-        "logos-nix": "logos-nix_572",
+        "logos-nix": "logos-nix_568",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -57440,7 +57147,7 @@
     },
     "nix-bundle-dir_89": {
       "inputs": {
-        "logos-nix": "logos-nix_573",
+        "logos-nix": "logos-nix_569",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -57465,7 +57172,7 @@
     },
     "nix-bundle-dir_9": {
       "inputs": {
-        "logos-nix": "logos-nix_60",
+        "logos-nix": "logos-nix_56",
         "nixpkgs": [
           "logos-liblogos",
           "logos-capability-module",
@@ -57558,7 +57265,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-        "logos-nix": "logos-nix_611",
+        "logos-nix": "logos-nix_607",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57588,7 +57295,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-        "logos-nix": "logos-nix_616",
+        "logos-nix": "logos-nix_612",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57618,7 +57325,7 @@
     },
     "nix-bundle-dir_94": {
       "inputs": {
-        "logos-nix": "logos-nix_617",
+        "logos-nix": "logos-nix_613",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57649,7 +57356,7 @@
     },
     "nix-bundle-dir_95": {
       "inputs": {
-        "logos-nix": "logos-nix_620",
+        "logos-nix": "logos-nix_616",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57762,7 +57469,7 @@
     },
     "nix-bundle-dir_98": {
       "inputs": {
-        "logos-nix": "logos-nix_659",
+        "logos-nix": "logos-nix_655",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57796,7 +57503,7 @@
     },
     "nix-bundle-dir_99": {
       "inputs": {
-        "logos-nix": "logos-nix_664",
+        "logos-nix": "logos-nix_660",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57857,7 +57564,7 @@
     },
     "nix-bundle-lgx_10": {
       "inputs": {
-        "logos-nix": "logos-nix_197",
+        "logos-nix": "logos-nix_193",
         "logos-package": "logos-package_18",
         "nix-bundle-dir": "nix-bundle-dir_29",
         "nixpkgs": [
@@ -57889,7 +57596,7 @@
     },
     "nix-bundle-lgx_11": {
       "inputs": {
-        "logos-nix": "logos-nix_221",
+        "logos-nix": "logos-nix_217",
         "logos-package": "logos-package_20",
         "nix-bundle-dir": "nix-bundle-dir_32",
         "nixpkgs": [
@@ -57916,7 +57623,7 @@
     },
     "nix-bundle-lgx_12": {
       "inputs": {
-        "logos-nix": "logos-nix_230",
+        "logos-nix": "logos-nix_226",
         "logos-package": "logos-package_22",
         "nix-bundle-dir": "nix-bundle-dir_35",
         "nixpkgs": [
@@ -57944,7 +57651,7 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-        "logos-nix": "logos-nix_271",
+        "logos-nix": "logos-nix_267",
         "logos-package": "logos-package_24",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -57975,7 +57682,7 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-        "logos-nix": "logos-nix_280",
+        "logos-nix": "logos-nix_276",
         "logos-package": "logos-package_26",
         "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
@@ -58007,7 +57714,7 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-        "logos-nix": "logos-nix_319",
+        "logos-nix": "logos-nix_315",
         "logos-package": "logos-package_27",
         "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
@@ -58042,7 +57749,7 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-        "logos-nix": "logos-nix_328",
+        "logos-nix": "logos-nix_324",
         "logos-package": "logos-package_29",
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
@@ -58078,7 +57785,7 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-        "logos-nix": "logos-nix_352",
+        "logos-nix": "logos-nix_348",
         "logos-package": "logos-package_31",
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
@@ -58109,7 +57816,7 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-        "logos-nix": "logos-nix_361",
+        "logos-nix": "logos-nix_357",
         "logos-package": "logos-package_33",
         "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
@@ -58141,7 +57848,7 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-        "logos-nix": "logos-nix_385",
+        "logos-nix": "logos-nix_381",
         "logos-package": "logos-package_35",
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
@@ -58196,7 +57903,7 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-        "logos-nix": "logos-nix_394",
+        "logos-nix": "logos-nix_390",
         "logos-package": "logos-package_37",
         "nix-bundle-dir": "nix-bundle-dir_59",
         "nixpkgs": [
@@ -58224,7 +57931,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-        "logos-nix": "logos-nix_443",
+        "logos-nix": "logos-nix_439",
         "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_66",
         "nixpkgs": [
@@ -58255,7 +57962,7 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-        "logos-nix": "logos-nix_452",
+        "logos-nix": "logos-nix_448",
         "logos-package": "logos-package_42",
         "nix-bundle-dir": "nix-bundle-dir_69",
         "nixpkgs": [
@@ -58287,7 +57994,7 @@
     },
     "nix-bundle-lgx_23": {
       "inputs": {
-        "logos-nix": "logos-nix_491",
+        "logos-nix": "logos-nix_487",
         "logos-package": "logos-package_43",
         "nix-bundle-dir": "nix-bundle-dir_72",
         "nixpkgs": [
@@ -58322,7 +58029,7 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-        "logos-nix": "logos-nix_500",
+        "logos-nix": "logos-nix_496",
         "logos-package": "logos-package_45",
         "nix-bundle-dir": "nix-bundle-dir_75",
         "nixpkgs": [
@@ -58358,7 +58065,7 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-        "logos-nix": "logos-nix_524",
+        "logos-nix": "logos-nix_520",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_78",
         "nixpkgs": [
@@ -58389,7 +58096,7 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-        "logos-nix": "logos-nix_533",
+        "logos-nix": "logos-nix_529",
         "logos-package": "logos-package_49",
         "nix-bundle-dir": "nix-bundle-dir_81",
         "nixpkgs": [
@@ -58421,7 +58128,7 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-        "logos-nix": "logos-nix_557",
+        "logos-nix": "logos-nix_553",
         "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_84",
         "nixpkgs": [
@@ -58448,7 +58155,7 @@
     },
     "nix-bundle-lgx_28": {
       "inputs": {
-        "logos-nix": "logos-nix_566",
+        "logos-nix": "logos-nix_562",
         "logos-package": "logos-package_53",
         "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
@@ -58476,7 +58183,7 @@
     },
     "nix-bundle-lgx_29": {
       "inputs": {
-        "logos-nix": "logos-nix_609",
+        "logos-nix": "logos-nix_605",
         "logos-package": "logos-package_55",
         "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
@@ -58507,7 +58214,7 @@
     },
     "nix-bundle-lgx_3": {
       "inputs": {
-        "logos-nix": "logos-nix_53",
+        "logos-nix": "logos-nix_49",
         "logos-package": "logos-package_4",
         "nix-bundle-dir": "nix-bundle-dir_8",
         "nixpkgs": [
@@ -58535,7 +58242,7 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-        "logos-nix": "logos-nix_618",
+        "logos-nix": "logos-nix_614",
         "logos-package": "logos-package_57",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nixpkgs": [
@@ -58567,7 +58274,7 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-        "logos-nix": "logos-nix_657",
+        "logos-nix": "logos-nix_653",
         "logos-package": "logos-package_58",
         "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
@@ -58602,7 +58309,7 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-        "logos-nix": "logos-nix_666",
+        "logos-nix": "logos-nix_662",
         "logos-package": "logos-package_60",
         "nix-bundle-dir": "nix-bundle-dir_101",
         "nixpkgs": [
@@ -58638,7 +58345,7 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-        "logos-nix": "logos-nix_690",
+        "logos-nix": "logos-nix_686",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
@@ -58669,7 +58376,7 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-        "logos-nix": "logos-nix_699",
+        "logos-nix": "logos-nix_695",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
@@ -58701,7 +58408,7 @@
     },
     "nix-bundle-lgx_35": {
       "inputs": {
-        "logos-nix": "logos-nix_723",
+        "logos-nix": "logos-nix_719",
         "logos-package": "logos-package_66",
         "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
@@ -58728,7 +58435,7 @@
     },
     "nix-bundle-lgx_36": {
       "inputs": {
-        "logos-nix": "logos-nix_732",
+        "logos-nix": "logos-nix_728",
         "logos-package": "logos-package_68",
         "nix-bundle-dir": "nix-bundle-dir_113",
         "nixpkgs": [
@@ -58756,7 +58463,7 @@
     },
     "nix-bundle-lgx_37": {
       "inputs": {
-        "logos-nix": "logos-nix_751",
+        "logos-nix": "logos-nix_747",
         "logos-package": "logos-package_71",
         "nix-bundle-dir": "nix-bundle-dir_118",
         "nixpkgs": [
@@ -58782,7 +58489,7 @@
     },
     "nix-bundle-lgx_4": {
       "inputs": {
-        "logos-nix": "logos-nix_62",
+        "logos-nix": "logos-nix_58",
         "logos-package": "logos-package_6",
         "nix-bundle-dir": "nix-bundle-dir_11",
         "nixpkgs": [
@@ -58811,7 +58518,7 @@
     },
     "nix-bundle-lgx_5": {
       "inputs": {
-        "logos-nix": "logos-nix_100",
+        "logos-nix": "logos-nix_96",
         "logos-package": "logos-package_8",
         "nix-bundle-dir": "nix-bundle-dir_14",
         "nixpkgs": [
@@ -58843,7 +58550,7 @@
     },
     "nix-bundle-lgx_6": {
       "inputs": {
-        "logos-nix": "logos-nix_109",
+        "logos-nix": "logos-nix_105",
         "logos-package": "logos-package_10",
         "nix-bundle-dir": "nix-bundle-dir_17",
         "nixpkgs": [
@@ -58876,7 +58583,7 @@
     },
     "nix-bundle-lgx_7": {
       "inputs": {
-        "logos-nix": "logos-nix_133",
+        "logos-nix": "logos-nix_129",
         "logos-package": "logos-package_12",
         "nix-bundle-dir": "nix-bundle-dir_20",
         "nixpkgs": [
@@ -58904,7 +58611,7 @@
     },
     "nix-bundle-lgx_8": {
       "inputs": {
-        "logos-nix": "logos-nix_142",
+        "logos-nix": "logos-nix_138",
         "logos-package": "logos-package_14",
         "nix-bundle-dir": "nix-bundle-dir_23",
         "nixpkgs": [
@@ -58933,7 +58640,7 @@
     },
     "nix-bundle-lgx_9": {
       "inputs": {
-        "logos-nix": "logos-nix_188",
+        "logos-nix": "logos-nix_184",
         "logos-package": "logos-package_16",
         "nix-bundle-dir": "nix-bundle-dir_26",
         "nixpkgs": [
@@ -58991,7 +58698,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-        "logos-nix": "logos-nix_388",
+        "logos-nix": "logos-nix_384",
         "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": "nix-bundle-lgx_20",
         "nixpkgs": [
@@ -59018,7 +58725,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-        "logos-nix": "logos-nix_446",
+        "logos-nix": "logos-nix_442",
         "logos-package-manager": "logos-package-manager_16",
         "nix-bundle-lgx": "nix-bundle-lgx_22",
         "nixpkgs": [
@@ -59049,7 +58756,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-        "logos-nix": "logos-nix_494",
+        "logos-nix": "logos-nix_490",
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nixpkgs": [
@@ -59084,7 +58791,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-        "logos-nix": "logos-nix_527",
+        "logos-nix": "logos-nix_523",
         "logos-package-manager": "logos-package-manager_19",
         "nix-bundle-lgx": "nix-bundle-lgx_26",
         "nixpkgs": [
@@ -59115,7 +58822,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-        "logos-nix": "logos-nix_560",
+        "logos-nix": "logos-nix_556",
         "logos-package-manager": "logos-package-manager_21",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
@@ -59142,7 +58849,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-        "logos-nix": "logos-nix_612",
+        "logos-nix": "logos-nix_608",
         "logos-package-manager": "logos-package-manager_23",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -59173,7 +58880,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-        "logos-nix": "logos-nix_660",
+        "logos-nix": "logos-nix_656",
         "logos-package-manager": "logos-package-manager_24",
         "nix-bundle-lgx": "nix-bundle-lgx_32",
         "nixpkgs": [
@@ -59208,7 +58915,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-        "logos-nix": "logos-nix_693",
+        "logos-nix": "logos-nix_689",
         "logos-package-manager": "logos-package-manager_26",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
@@ -59239,7 +58946,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-        "logos-nix": "logos-nix_726",
+        "logos-nix": "logos-nix_722",
         "logos-package-manager": "logos-package-manager_28",
         "nix-bundle-lgx": "nix-bundle-lgx_36",
         "nixpkgs": [
@@ -59266,7 +58973,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-        "logos-nix": "logos-nix_745",
+        "logos-nix": "logos-nix_741",
         "logos-package-manager": "logos-package-manager_29",
         "nix-bundle-lgx": "nix-bundle-lgx_37",
         "nixpkgs": [
@@ -59291,7 +58998,7 @@
     },
     "nix-bundle-logos-module-install_2": {
       "inputs": {
-        "logos-nix": "logos-nix_56",
+        "logos-nix": "logos-nix_52",
         "logos-package-manager": "logos-package-manager_2",
         "nix-bundle-lgx": "nix-bundle-lgx_4",
         "nixpkgs": [
@@ -59319,7 +59026,7 @@
     },
     "nix-bundle-logos-module-install_3": {
       "inputs": {
-        "logos-nix": "logos-nix_103",
+        "logos-nix": "logos-nix_99",
         "logos-package-manager": "logos-package-manager_3",
         "nix-bundle-lgx": "nix-bundle-lgx_6",
         "nixpkgs": [
@@ -59351,7 +59058,7 @@
     },
     "nix-bundle-logos-module-install_4": {
       "inputs": {
-        "logos-nix": "logos-nix_136",
+        "logos-nix": "logos-nix_132",
         "logos-package-manager": "logos-package-manager_5",
         "nix-bundle-lgx": "nix-bundle-lgx_8",
         "nixpkgs": [
@@ -59379,7 +59086,7 @@
     },
     "nix-bundle-logos-module-install_5": {
       "inputs": {
-        "logos-nix": "logos-nix_191",
+        "logos-nix": "logos-nix_187",
         "logos-package-manager": "logos-package-manager_6",
         "nix-bundle-lgx": "nix-bundle-lgx_10",
         "nixpkgs": [
@@ -59410,7 +59117,7 @@
     },
     "nix-bundle-logos-module-install_6": {
       "inputs": {
-        "logos-nix": "logos-nix_224",
+        "logos-nix": "logos-nix_220",
         "logos-package-manager": "logos-package-manager_8",
         "nix-bundle-lgx": "nix-bundle-lgx_12",
         "nixpkgs": [
@@ -59437,7 +59144,7 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-        "logos-nix": "logos-nix_274",
+        "logos-nix": "logos-nix_270",
         "logos-package-manager": "logos-package-manager_9",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
@@ -59468,7 +59175,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-        "logos-nix": "logos-nix_322",
+        "logos-nix": "logos-nix_318",
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
@@ -59503,7 +59210,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-        "logos-nix": "logos-nix_355",
+        "logos-nix": "logos-nix_351",
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -60080,7 +59787,7 @@
     },
     "nix-bundle-macos-app_20": {
       "inputs": {
-        "logos-nix": "logos-nix_754",
+        "logos-nix": "logos-nix_750",
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -70696,71 +70403,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-windows_679": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
     "nixpkgs-windows_68": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_680": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_681": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_682": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -82888,70 +82531,6 @@
         "type": "github"
       }
     },
-    "nixpkgs_751": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_752": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_753": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_754": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_76": {
       "locked": {
         "lastModified": 1759036355,
@@ -83370,7 +82949,7 @@
     },
     "process-stats": {
       "inputs": {
-        "logos-nix": "logos-nix_125",
+        "logos-nix": "logos-nix_121",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -83398,7 +82977,7 @@
     },
     "process-stats_2": {
       "inputs": {
-        "logos-nix": "logos-nix_146",
+        "logos-nix": "logos-nix_142",
         "nixpkgs": [
           "logos-liblogos",
           "process-stats",
@@ -83422,7 +83001,7 @@
     },
     "process-stats_3": {
       "inputs": {
-        "logos-nix": "logos-nix_213",
+        "logos-nix": "logos-nix_209",
         "nixpkgs": [
           "logos-modules-state-module",
           "logos-module-builder",
@@ -83449,7 +83028,7 @@
     },
     "process-stats_4": {
       "inputs": {
-        "logos-nix": "logos-nix_344",
+        "logos-nix": "logos-nix_340",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -83480,7 +83059,7 @@
     },
     "process-stats_5": {
       "inputs": {
-        "logos-nix": "logos-nix_375",
+        "logos-nix": "logos-nix_371",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -83507,7 +83086,7 @@
     },
     "process-stats_6": {
       "inputs": {
-        "logos-nix": "logos-nix_516",
+        "logos-nix": "logos-nix_512",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -83538,7 +83117,7 @@
     },
     "process-stats_7": {
       "inputs": {
-        "logos-nix": "logos-nix_547",
+        "logos-nix": "logos-nix_543",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -83565,7 +83144,7 @@
     },
     "process-stats_8": {
       "inputs": {
-        "logos-nix": "logos-nix_682",
+        "logos-nix": "logos-nix_678",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -83596,7 +83175,7 @@
     },
     "process-stats_9": {
       "inputs": {
-        "logos-nix": "logos-nix_713",
+        "logos-nix": "logos-nix_709",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -83627,19 +83206,19 @@
         "logos-cpp-sdk": "logos-cpp-sdk_3",
         "logos-design-system": "logos-design-system_2",
         "logos-liblogos": "logos-liblogos",
-        "logos-module": "logos-module_31",
+        "logos-module": "logos-module_30",
         "logos-module-loader-qt": "logos-module-loader-qt",
         "logos-modules-state-module": "logos-modules-state-module_2",
-        "logos-nix": "logos-nix_233",
+        "logos-nix": "logos-nix_229",
         "logos-package": "logos-package_23",
         "logos-package-downloader-module": "logos-package-downloader-module",
         "logos-package-manager": "logos-package-manager_15",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-        "logos-plugin-qt": "logos-plugin-qt_95",
-        "logos-protocol": "logos-protocol_124",
+        "logos-plugin-qt": "logos-plugin-qt_94",
+        "logos-protocol": "logos-protocol_123",
         "logos-qt-mcp": "logos-qt-mcp_9",
-        "logos-qt-sdk": "logos-qt-sdk_50",
+        "logos-qt-sdk": "logos-qt-sdk_49",
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-appimage": "nix-bundle-appimage_49",
         "nix-bundle-dir": "nix-bundle-dir_115",


### PR DESCRIPTION
Step 7 (final) of the logos-protocol propagation wave, alongside
logos-logoscore-cli#131.

|input|from|to|
|---|---|---|
|`logos-protocol`|`9ba2f5a7`|`fdc09ff`|
|`logos-cpp-sdk`|`41ca4491`|`fb88c7d5`|
|`logos-plugin-qt`|`1a0e399e`|`8af5b188`|
|`logos-qt-sdk`|`2dd4be54`|`dffe05e2`|
|`logos-liblogos`|`9ad79200`|`34a83419`|
|`logos-view-module-runtime`|`7eeae342`|`db31d118`|

A **plain relock** — this flake's five `logos-protocol` follows were already
complete, so nothing needed adding.

## Verification

`logos-abi-closure-check` on `.#default`: **PASS** — one `logos-protocol-lib`,
one `logos-qt-host`, *paired*. That protocol-lib is the byte-identical store path
(`xrfwjbfia4lkdwplg1fwgz0cs1fymmax-logos-protocol-lib-0.9.0`) every other repo in
this wave resolves.

**11 of 12 checks green**, and the two that matter most here are gates with
*working negative controls*:

|check|result|
|---|---|
|`link-gate`|`LINK GATE: PASS`|
|`link-gate-negative`|**PASS — the gate rejected a planted skew**|
|`symbol-gate`|`SYMBOL GATE: PASS`|
|`symbol-gate-negative`|**PASS — the gate rejected a planted duplicate**|
|`integration-test`|47 passed, 0 failed|
|`unit-tests`|22/22|
|`sandbox-test`|13/13|
|`qml-tests`|1/1|
|`shutdown-test`|4 passed, 1 skipped (no system tray in this environment)|
|`host-services-test`|1 passed — privileged operation succeeded, 0 refusals|
|`smoke-test`|passed|

A planted **skew** and a planted **duplicate** are precisely the two ways a
protocol move goes wrong in this repo, so those two controls — not the gates'
PASS lines — are what makes this verification worth anything.

## The one excluded check

`mock-tests` is not included. It fails on aarch64-darwin with:

```
mock/tests/run-standalone.sh: line 115: g++: command not found
```

and it fails **identically on master with this lock stashed** (verified, not
assumed). Pre-existing and platform-specific — macOS ships clang, and that
script wants `g++`. Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
