### PR TITLE
feat: tell same-named repositories apart in the UI

### DIFF
--- a/app/AppsModel.cpp
+++ b/app/AppsModel.cpp
@@ -82,10 +82,10 @@ QVariant AppsModel::data(const QModelIndex& index, int role) const
     case InstallStatusRole:    return static_cast<int>(r.installStatus);
     case InstallTypeRole:      return r.installType;
     case ActionRole: {
-        if (m_installRegistry) {
-            if (m_installRegistry->isInFlight(r.name))
+        if (InstallRegistry* reg = registryFor(r)) {
+            if (reg->isInFlight(r.name))
                 return QStringLiteral("installing");
-            if (m_installRegistry->stage(r.name) == InstallStage::Installed)
+            if (reg->stage(r.name) == InstallStage::Installed)
                 return QStringLiteral("installed");
         }
         return r.action;
@@ -93,26 +93,34 @@ QVariant AppsModel::data(const QModelIndex& index, int role) const
     case ToVersionRole:        return r.toVersion;
     case IsTopLevelRole:       return r.isTopLevel;
     case ResolverErrorRole:    return r.resolverError;
-    case InstallStageRole:
-        return m_installRegistry ? m_installRegistry->stage(r.name)
-                            : static_cast<int>(InstallStage::None);
-    case InstallErrorRole:
-        return m_installRegistry ? m_installRegistry->error(r.name) : QString();
-    case DownloadReceivedRole:
-        return QVariant::fromValue(
-            m_installRegistry ? m_installRegistry->downloadReceived(r.name) : quint64(0));
-    case DownloadTotalRole:
-        return QVariant::fromValue(
-            m_installRegistry ? m_installRegistry->downloadTotal(r.name) : quint64(0));
-    case PlanDownloadReceivedRole:
-        return QVariant::fromValue(
-            m_installRegistry ? m_installRegistry->planDownloadReceived(r.name) : quint64(0));
-    case PlanDownloadTotalRole:
-        return QVariant::fromValue(
-            m_installRegistry ? m_installRegistry->planDownloadTotal(r.name) : quint64(0));
-    case PlanInstallStageRole:
-        return m_installRegistry ? m_installRegistry->planStage(r.name)
-                                 : static_cast<int>(InstallStage::None);
+    case InstallStageRole: {
+        InstallRegistry* reg = registryFor(r);
+        return reg ? reg->stage(r.name) : static_cast<int>(InstallStage::None);
+    }
+    case InstallErrorRole: {
+        InstallRegistry* reg = registryFor(r);
+        return reg ? reg->error(r.name) : QString();
+    }
+    case DownloadReceivedRole: {
+        InstallRegistry* reg = registryFor(r);
+        return QVariant::fromValue(reg ? reg->downloadReceived(r.name) : quint64(0));
+    }
+    case DownloadTotalRole: {
+        InstallRegistry* reg = registryFor(r);
+        return QVariant::fromValue(reg ? reg->downloadTotal(r.name) : quint64(0));
+    }
+    case PlanDownloadReceivedRole: {
+        InstallRegistry* reg = registryFor(r);
+        return QVariant::fromValue(reg ? reg->planDownloadReceived(r.name) : quint64(0));
+    }
+    case PlanDownloadTotalRole: {
+        InstallRegistry* reg = registryFor(r);
+        return QVariant::fromValue(reg ? reg->planDownloadTotal(r.name) : quint64(0));
+    }
+    case PlanInstallStageRole: {
+        InstallRegistry* reg = registryFor(r);
+        return reg ? reg->planStage(r.name) : static_cast<int>(InstallStage::None);
+    }
     }
     return {};
 }
@@ -604,6 +612,21 @@ void AppsModel::setMissingDeps(const QString& name, const QStringList& missing)
 }
 
 // ── Wiring: live install state ────────────────────────────────────────────
+
+// The install registry is keyed by package NAME, but a name is not unique
+// across repositories — two repos can publish the same package, and this
+// model renders a row for each. Only the row whose repository the
+// operation targets may show its in-flight state; otherwise installing
+// from one repo animates the other repo's copy of the row too.
+//
+// Returns nullptr for a row the operation does not belong to, so callers
+// fall through to the same defaults they use when no registry is set.
+InstallRegistry* AppsModel::registryFor(const Row& r) const
+{
+    if (!m_installRegistry) return nullptr;
+    return m_installRegistry->belongsTo(r.name, r.repositoryUrl)
+               ? m_installRegistry : nullptr;
+}
 
 void AppsModel::setInstallRegistry(InstallRegistry* installRegistry)
 {

--- a/app/AppsModel.h
+++ b/app/AppsModel.h
@@ -123,6 +123,10 @@ private:
     void recomputeVersionDerivedFields(Row& r);
     void recomputeInstallStatus(Row& r);
 
+    // The registry, but only when its in-flight entry belongs to this
+    // row's repository. nullptr otherwise — see the .cpp for why.
+    InstallRegistry* registryFor(const Row& r) const;
+
     QList<Row>          m_rows;
     QHash<QString, int> m_indexByKey;     // (repo + "\n" + name) → row index
     QMultiHash<QString, int> m_indicesByName;

--- a/app/InstallRegistry.cpp
+++ b/app/InstallRegistry.cpp
@@ -121,15 +121,26 @@ int InstallRegistry::planStage(const QString& name) const
     return int(InstallStage::None);
 }
 
+bool InstallRegistry::belongsTo(const QString& name,
+                                const QString& repositoryUrl) const
+{
+    auto it = m_ops.constFind(name);
+    if (it == m_ops.constEnd()) return true;   // nothing in flight to gate
+    if (it->repositoryUrl.isEmpty()) return true;   // not attributable
+    return it->repositoryUrl == repositoryUrl;
+}
+
 void InstallRegistry::begin(const QString& name,
                        const QString& targetVersion,
                        const QString& targetHash,
-                       const QString& startedByTopLevel)
+                       const QString& startedByTopLevel,
+                       const QString& repositoryUrl)
 {
     if (name.isEmpty()) return;
     const bool added = !m_ops.contains(name);
     Entry& e = m_ops[name];
     e.name              = name;
+    e.repositoryUrl     = repositoryUrl;
     e.targetVersion     = targetVersion;
     e.targetHash        = targetHash;
     e.stage             = InstallStage::Downloading;
@@ -151,6 +162,7 @@ void InstallRegistry::beginPlan(const QString& topLevel,
             added = true;
             Entry& e = m_ops[p.name];
             e.name          = p.name;
+            e.repositoryUrl = p.repositoryUrl;
             e.targetVersion = p.version;
             e.targetHash    = p.rootHash;
             e.stage         = InstallStage::Queued;
@@ -261,14 +273,19 @@ void InstallRegistry::clearByTopLevel(const QString& topLevelName)
 void InstallRegistry::beginOrTrack(const QString& name,
                               const QString& targetVersion,
                               const QString& targetHash,
-                              const QString& startedByTopLevel)
+                              const QString& startedByTopLevel,
+                              const QString& repositoryUrl)
 {
     if (name.isEmpty()) return;
     if (!m_ops.contains(name)) {
-        begin(name, targetVersion, targetHash, startedByTopLevel);
+        begin(name, targetVersion, targetHash, startedByTopLevel, repositoryUrl);
         return;
     }
     Entry& e = m_ops[name];
+    // Fill in attribution a beginPlan seed may not have had; never
+    // overwrite one that is already set, or a later dep would re-point an
+    // entry that belongs to the repo the user actually clicked.
+    if (e.repositoryUrl.isEmpty())     e.repositoryUrl = repositoryUrl;
     if (!targetVersion.isEmpty()) e.targetVersion = targetVersion;
     if (!targetHash.isEmpty())    e.targetHash    = targetHash;
     // Track the additional owner: an entry seeded by beginPlan, or shared

--- a/app/InstallRegistry.h
+++ b/app/InstallRegistry.h
@@ -66,12 +66,16 @@ public:
                const QString& targetHash,
                const QString& startedByTopLevel,
                const QString& repositoryUrl = {});
+    // Aggregate-initialised positionally by callers and tests
+    // ({name, version, rootHash, size}), so ADD NEW FIELDS AT THE END —
+    // inserting one in the middle silently re-binds every existing
+    // initialiser.
     struct PlannedPackage {
         QString name;
-        QString repositoryUrl;   // the repo this entry resolved from
         QString version;
         QString rootHash;
         quint64 size = 0;
+        QString repositoryUrl;   // the repo this entry resolved from
     };
 
     void beginPlan(const QString& topLevel, const QList<PlannedPackage>& plan);

--- a/app/InstallRegistry.h
+++ b/app/InstallRegistry.h
@@ -8,7 +8,16 @@
 #include <QString>
 #include <QStringList>
 
-// Registry of in-flight install operations. One entry per package name
+// Registry of in-flight install operations. One entry per package name.
+//
+// A name is not unique across repositories — two repos can publish the
+// same package — so each entry also records WHICH repo the operation
+// targets. Views must gate on `belongsTo` before rendering an entry's
+// state, or an install started from one repo lights up every repo's copy
+// of that row. An entry with no recorded repository (a local .lgx, or a
+// caller that can't attribute it) matches every row, which is the old
+// behaviour and the safe default: better to show progress on one row too
+// many than on none at all.
 class InstallRegistry : public QObject {
     Q_OBJECT
     Q_PROPERTY(QStringList activeNames READ activeNames NOTIFY activeNamesChanged)
@@ -16,6 +25,7 @@ class InstallRegistry : public QObject {
 public:
     struct Entry {
         QString             name;
+        QString             repositoryUrl;   // empty = not attributable
         QString             targetVersion;
         QString             targetHash;
         InstallStage::Value stage = InstallStage::None;
@@ -30,6 +40,10 @@ public:
     explicit InstallRegistry(QObject* parent = nullptr);
 
     Q_INVOKABLE bool has(const QString& name) const { return m_ops.contains(name); }
+    // Whether the row identified by (name, repositoryUrl) is the one this
+    // operation belongs to. True when there is no entry, when the entry
+    // records no repository, or when the two match.
+    bool belongsTo(const QString& name, const QString& repositoryUrl) const;
     Q_INVOKABLE int  stage(const QString& name) const;
     Q_INVOKABLE bool isInFlight(const QString& name) const;
     QString          error(const QString& name) const;
@@ -45,13 +59,16 @@ public:
     void beginOrTrack(const QString& name,
                       const QString& targetVersion,
                       const QString& targetHash,
-                      const QString& startedByTopLevel);
+                      const QString& startedByTopLevel,
+                      const QString& repositoryUrl = {});
     void begin(const QString& name,
                const QString& targetVersion,
                const QString& targetHash,
-               const QString& startedByTopLevel);
+               const QString& startedByTopLevel,
+               const QString& repositoryUrl = {});
     struct PlannedPackage {
         QString name;
+        QString repositoryUrl;   // the repo this entry resolved from
         QString version;
         QString rootHash;
         quint64 size = 0;

--- a/app/PackageCoordinator.cpp
+++ b/app/PackageCoordinator.cpp
@@ -1101,11 +1101,17 @@ void PackageCoordinator::populateAppsModel(
 // should show for it
 static QVariantList withDisplayLabels(const QVariantList& repos)
 {
+    // Comparison keys only — the rendered label keeps the repo's own
+    // spelling. Trimmed and case-folded so neither a stray space nor a
+    // different capitalisation of the same GitHub account (which GitHub
+    // treats as one account) can slip past the collision check and leave
+    // two repos rendering the same bare name.
     auto nameOf = [](const QVariantMap& r) {
-        return r.value("displayName").toString().toLower();
+        return r.value("displayName").toString().trimmed().toLower();
     };
     auto pairOf = [&](const QVariantMap& r) {
-        return nameOf(r) + QChar(0x01) + r.value("sourceOwner").toString();
+        return nameOf(r) + QChar(0x01)
+             + r.value("sourceOwner").toString().trimmed().toLower();
     };
 
     // Counts first: a label depends on how many OTHER repos contest the name.
@@ -1120,8 +1126,10 @@ static QVariantList withDisplayLabels(const QVariantList& repos)
     out.reserve(repos.size());
     for (const QVariant& v : repos) {
         QVariantMap r = v.toMap();
-        QString label = r.value("displayName").toString();
-        if (label.isEmpty()) label = r.value("name").toString();
+        // Trimmed to match the collision keys above; a trailing space is
+        // invisible on screen but would otherwise dodge the check.
+        QString label = r.value("displayName").toString().trimmed();
+        if (label.isEmpty()) label = r.value("name").toString().trimmed();
 
         const QString owner = r.value("sourceOwner").toString();
         const QString repo  = r.value("sourceRepo").toString();
@@ -1780,10 +1788,10 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
             if (rowName.isEmpty() || !m.value("error").toString().isEmpty())
                 continue;
             plan.append({rowName,
-                         m.value("repositoryUrl").toString(),
                          m.value("version").toString(),
                          m.value("rootHash").toString(),
-                         m.value("size").toULongLong()});
+                         m.value("size").toULongLong(),
+                         m.value("repositoryUrl").toString()});
         }
         if (!plan.isEmpty()) {
             m_installRegistry->beginPlan(name, plan);

--- a/app/PackageCoordinator.cpp
+++ b/app/PackageCoordinator.cpp
@@ -7,9 +7,11 @@
 #include "LogosBasecampPaths.h"
 #include "utils/DependencyBlocker.h"
 
+#include <QCoreApplication>
 #include <QDebug>
 #include <QDir>
 #include <QFile>
+#include <QHash>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -1095,6 +1097,55 @@ void PackageCoordinator::populateAppsModel(
 
 // ── Package repository management ──────────────────────────────────────────
 
+// Stamp each repository with `displayLabel`, the one string every view
+// should show for it
+static QVariantList withDisplayLabels(const QVariantList& repos)
+{
+    auto nameOf = [](const QVariantMap& r) {
+        return r.value("displayName").toString().toLower();
+    };
+    auto pairOf = [&](const QVariantMap& r) {
+        return nameOf(r) + QChar(0x01) + r.value("sourceOwner").toString();
+    };
+
+    // Counts first: a label depends on how many OTHER repos contest the name.
+    QHash<QString, int> byName, byNameAndOwner;
+    for (const QVariant& v : repos) {
+        const QVariantMap r = v.toMap();
+        byName[nameOf(r)]++;
+        byNameAndOwner[pairOf(r)]++;
+    }
+
+    QVariantList out;
+    out.reserve(repos.size());
+    for (const QVariant& v : repos) {
+        QVariantMap r = v.toMap();
+        QString label = r.value("displayName").toString();
+        if (label.isEmpty()) label = r.value("name").toString();
+
+        const QString owner = r.value("sourceOwner").toString();
+        const QString repo  = r.value("sourceRepo").toString();
+        const QString host  = r.value("sourceHost").toString();
+        QString shortSource = owner.isEmpty() ? host : owner;
+        QString longSource  = (owner.isEmpty() || repo.isEmpty())
+                                  ? shortSource
+                                  : owner + QLatin1Char('/') + repo;
+        if (shortSource.isEmpty()) shortSource = r.value("url").toString();
+        if (longSource.isEmpty())  longSource  = shortSource;
+
+        if (label.isEmpty()) {
+            label = longSource;                    // nothing to qualify
+        } else if (byName.value(nameOf(r)) > 1 && !shortSource.isEmpty()) {
+            label = QCoreApplication::translate("PackageCoordinator", "%1 (%2)")
+                        .arg(label, byNameAndOwner.value(pairOf(r)) > 1
+                                        ? longSource : shortSource);
+        }
+        r.insert(QStringLiteral("displayLabel"), label);
+        out.append(r);
+    }
+    return out;
+}
+
 void PackageCoordinator::refreshRepositories()
 {
     LogosAPIClient* dlClient = m_logosAPI
@@ -1111,7 +1162,7 @@ void PackageCoordinator::refreshRepositories()
         "package_downloader", "listRepositories", QVariantList{},
         [self](QVariant result) {
             if (!self) return;
-            self->m_repositories = result.toList();
+            self->m_repositories = withDisplayLabels(result.toList());
             const int remaining = --self->m_repositoriesLoadingCount;
             emit self->repositoriesChanged();
             if (remaining == 0) emit self->repositoriesLoadingChanged();
@@ -1729,6 +1780,7 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
             if (rowName.isEmpty() || !m.value("error").toString().isEmpty())
                 continue;
             plan.append({rowName,
+                         m.value("repositoryUrl").toString(),
                          m.value("version").toString(),
                          m.value("rootHash").toString(),
                          m.value("size").toULongLong()});
@@ -1737,7 +1789,7 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
             m_installRegistry->beginPlan(name, plan);
         } else {
             m_installRegistry->begin(name, /*targetVersion=*/{}, /*targetHash=*/{},
-                                     /*startedByTopLevel=*/name);
+                                     /*startedByTopLevel=*/name, repositoryUrl);
         }
     }
 
@@ -1777,8 +1829,9 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
                     || installedHash.isEmpty()
                     || resolvedHash == installedHash;
                 if (versionMatches && hashMatches) {
-                    self->m_installRegistry->beginOrTrack(rowName, resolvedVersion,
-                                                    resolvedHash, name);
+                    self->m_installRegistry->beginOrTrack(
+                        rowName, resolvedVersion, resolvedHash, name,
+                        m.value("repositoryUrl").toString());
                     self->m_installRegistry->setStage(rowName, InstallStage::Installed);
                     continue;
                 }
@@ -1805,7 +1858,8 @@ void PackageCoordinator::confirmCatalogInstall(const QString& name,
                 self->m_installRegistry->beginOrTrack(rowName,
                     m.value("version").toString(),
                     m.value("rootHash").toString(),
-                    name);
+                    name,
+                    m.value("repositoryUrl").toString());
                 self->m_installRegistry->setStage(rowName, InstallStage::Queued);
             }
 
@@ -1938,7 +1992,8 @@ void PackageCoordinator::installResultsSequential(const QVariantList& results,
              << "topLevel=" << topLevelName;
     if (!rowName.isEmpty()) {
         m_installRegistry->beginOrTrack(rowName, dl.value("version").toString(),
-                                   dl.value("rootHash").toString(), topLevelName);
+                                   dl.value("rootHash").toString(), topLevelName,
+                                   dl.value("repositoryUrl").toString());
         m_installRegistry->setStage(rowName, InstallStage::Installing);
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -85,11 +85,7 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_243",
-=======
         "logos-nix": "logos-nix_239",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -117,11 +113,7 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_295",
-=======
         "logos-nix": "logos-nix_286",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -153,11 +145,7 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_415",
-=======
         "logos-nix": "logos-nix_395",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -185,11 +173,7 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_33",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_467",
-=======
         "logos-nix": "logos-nix_447",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -221,11 +205,7 @@
     "default-container_8": {
       "inputs": {
         "logos-container": "logos-container_38",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_581",
-=======
         "logos-nix": "logos-nix_555",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -253,11 +233,7 @@
     "default-container_9": {
       "inputs": {
         "logos-container": "logos-container_43",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_633",
-=======
         "logos-nix": "logos-nix_602",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -434,14 +410,6 @@
     "default-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_19",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_21",
-        "logos-module": "logos-module_53",
-        "logos-module-loader": "logos-module-loader_8",
-        "logos-nix": "logos-nix_248",
-        "logos-protocol": "logos-protocol_39",
-        "logos-qt-sdk": "logos-qt-sdk_17",
-=======
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -466,7 +434,6 @@
           "logos-liblogos",
           "logos-qt-sdk"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -505,15 +472,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_66",
-        "logos-module-loader": "logos-module-loader_10",
-        "logos-nix": "logos-nix_299",
-=======
         "logos-module": "logos-module_64",
         "logos-module-loader": "logos-module-loader_10",
         "logos-nix": "logos-nix_290",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -567,21 +528,12 @@
     "default-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_29",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_35",
-        "logos-module": "logos-module_87",
-        "logos-module-loader": "logos-module-loader_12",
-        "logos-nix": "logos-nix_420",
-        "logos-protocol": "logos-protocol_68",
-        "logos-qt-sdk": "logos-qt-sdk_28",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-module": "logos-module_82",
         "logos-module-loader": "logos-module-loader_12",
         "logos-nix": "logos-nix_400",
         "logos-protocol": "logos-protocol_61",
         "logos-qt-sdk": "logos-qt-sdk_27",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -620,15 +572,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_100",
-        "logos-module-loader": "logos-module-loader_14",
-        "logos-nix": "logos-nix_471",
-=======
         "logos-module": "logos-module_95",
         "logos-module-loader": "logos-module-loader_14",
         "logos-nix": "logos-nix_451",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -682,14 +628,6 @@
     "default-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_39",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_49",
-        "logos-module": "logos-module_120",
-        "logos-module-loader": "logos-module-loader_16",
-        "logos-nix": "logos-nix_586",
-        "logos-protocol": "logos-protocol_97",
-        "logos-qt-sdk": "logos-qt-sdk_39",
-=======
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -714,7 +652,6 @@
           "logos-liblogos",
           "logos-qt-sdk"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -753,15 +690,9 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_133",
-        "logos-module-loader": "logos-module-loader_18",
-        "logos-nix": "logos-nix_637",
-=======
         "logos-module": "logos-module_127",
         "logos-module-loader": "logos-module-loader_18",
         "logos-nix": "logos-nix_606",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -1310,11 +1241,7 @@
     },
     "logos-container_19": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_244",
-=======
         "logos-nix": "logos-nix_240",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1404,11 +1331,7 @@
     },
     "logos-container_21": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_279",
-=======
         "logos-nix": "logos-nix_271",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1513,11 +1436,7 @@
     },
     "logos-container_24": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_296",
-=======
         "logos-nix": "logos-nix_287",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1594,11 +1513,7 @@
     },
     "logos-container_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_327",
-=======
         "logos-nix": "logos-nix_318",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1707,11 +1622,7 @@
     },
     "logos-container_29": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_416",
-=======
         "logos-nix": "logos-nix_396",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1807,11 +1718,7 @@
     },
     "logos-container_31": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_451",
-=======
         "logos-nix": "logos-nix_431",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1916,11 +1823,7 @@
     },
     "logos-container_34": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_468",
-=======
         "logos-nix": "logos-nix_448",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1997,11 +1900,7 @@
     },
     "logos-container_36": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_499",
-=======
         "logos-nix": "logos-nix_479",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -2110,11 +2009,7 @@
     },
     "logos-container_39": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_582",
-=======
         "logos-nix": "logos-nix_556",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2203,11 +2098,7 @@
     },
     "logos-container_41": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_617",
-=======
         "logos-nix": "logos-nix_587",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2312,11 +2203,7 @@
     },
     "logos-container_44": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_634",
-=======
         "logos-nix": "logos-nix_603",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2393,11 +2280,7 @@
     },
     "logos-container_46": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_665",
-=======
         "logos-nix": "logos-nix_634",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2750,19 +2633,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-=======
         "lastModified": 1789102469,
         "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -2981,14 +2856,6 @@
     "logos-cpp-sdk_19": {
       "inputs": {
         "logos-lidl": "logos-lidl_68",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_231",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-=======
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2999,7 +2866,6 @@
           "logos-module-builder",
           "logos-protocol"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3009,19 +2875,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-=======
         "lastModified": 1789102469,
         "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -3066,10 +2924,6 @@
     "logos-cpp-sdk_20": {
       "inputs": {
         "logos-lidl": "logos-lidl_73",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_242",
-        "logos-protocol": "logos-protocol_38",
-=======
         "logos-nix": "logos-nix_238",
         "logos-protocol": [
           "logos-package-downloader-module",
@@ -3077,7 +2931,6 @@
           "logos-standalone-app",
           "logos-protocol"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3104,22 +2957,14 @@
     "logos-cpp-sdk_21": {
       "inputs": {
         "logos-lidl": "logos-lidl_74",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_245",
-=======
         "logos-nix": "logos-nix_244",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3127,12 +2972,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3154,26 +2995,16 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_76",
-        "logos-nix": "logos-nix_252",
-        "logos-protocol": [
-=======
         "logos-lidl": "logos-lidl_81",
         "logos-nix": [
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-protocol"
-=======
           "logos-view-module-runtime",
           "logos-nix"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         ],
         "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
@@ -3183,10 +3014,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3209,24 +3037,12 @@
     "logos-cpp-sdk_23": {
       "inputs": {
         "logos-lidl": "logos-lidl_83",
-<<<<<<< HEAD
-        "logos-nix": [
-=======
         "logos-nix": "logos-nix_274",
         "logos-protocol": [
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_43",
-=======
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
@@ -3262,7 +3078,6 @@
         "logos-lidl": "logos-lidl_88",
         "logos-nix": "logos-nix_285",
         "logos-protocol": "logos-protocol_45",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3271,58 +3086,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_24": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_85",
-        "logos-nix": "logos-nix_280",
-=======
-        "logos-lidl": "logos-lidl_89",
-        "logos-nix": "logos-nix_291",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3344,14 +3107,18 @@
     },
     "logos-cpp-sdk_25": {
       "inputs": {
-        "logos-lidl": "logos-lidl_86",
-        "logos-nix": "logos-nix_283",
+        "logos-lidl": "logos-lidl_89",
+        "logos-nix": "logos-nix_291",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
@@ -3362,17 +3129,21 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3383,90 +3154,7 @@
     },
     "logos-cpp-sdk_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_91",
-        "logos-nix": "logos-nix_294",
-        "logos-protocol": "logos-protocol_47",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_27": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_92",
-        "logos-nix": "logos-nix_300",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_28": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_99",
-=======
         "logos-lidl": "logos-lidl_96",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3481,11 +3169,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_50",
-=======
         "logos-protocol": "logos-protocol_48",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3517,17 +3201,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-cpp-sdk_29": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_101",
-        "logos-nix": "logos-nix_328",
-=======
     "logos-cpp-sdk_27": {
       "inputs": {
         "logos-lidl": "logos-lidl_98",
         "logos-nix": "logos-nix_319",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3567,8 +3244,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-cpp-sdk_28": {
       "inputs": {
         "logos-lidl": "logos-lidl_104",
@@ -3661,7 +3336,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-cpp-sdk_3": {
       "inputs": {
         "logos-lidl": "logos-lidl_10",
@@ -3691,18 +3365,6 @@
     },
     "logos-cpp-sdk_30": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_107",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-=======
         "logos-lidl": "logos-lidl_110",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -3715,19 +3377,10 @@
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         ],
-        "logos-protocol": "logos-protocol_55",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
@@ -3750,32 +3403,6 @@
     },
     "logos-cpp-sdk_31": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-=======
         "logos-lidl": "logos-lidl_112",
         "logos-nix": [
           "logos-package-manager-module",
@@ -3814,58 +3441,10 @@
         "logos-lidl": "logos-lidl_117",
         "logos-nix": "logos-nix_394",
         "logos-protocol": "logos-protocol_60",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_32": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_114",
-        "logos-nix": [
-          "logos-package-downloader-module",
-=======
-        "logos-lidl": "logos-lidl_118",
-        "logos-nix": "logos-nix_397",
-        "logos-protocol": [
-          "logos-package-manager-module",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_63",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3887,13 +3466,45 @@
     },
     "logos-cpp-sdk_33": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_116",
-        "logos-nix": "logos-nix_403",
-=======
+        "logos-lidl": "logos-lidl_118",
+        "logos-nix": "logos-nix_397",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_34": {
+      "inputs": {
         "logos-lidl": "logos-lidl_120",
         "logos-nix": "logos-nix_404",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3929,13 +3540,8 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_34": {
+    "logos-cpp-sdk_35": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_121",
-        "logos-nix": "logos-nix_414",
-        "logos-protocol": "logos-protocol_67",
-=======
         "logos-lidl": "logos-lidl_127",
         "logos-nix": [
           "logos-package-manager-module",
@@ -3948,7 +3554,6 @@
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_65",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3976,62 +3581,15 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_35": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_122",
-        "logos-nix": "logos-nix_417",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_36": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_124",
-        "logos-nix": "logos-nix_424",
-=======
         "logos-lidl": "logos-lidl_129",
         "logos-nix": "logos-nix_432",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -4039,11 +3597,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4065,26 +3618,13 @@
     },
     "logos-cpp-sdk_37": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_131",
-        "logos-nix": [
-=======
         "logos-lidl": "logos-lidl_130",
         "logos-nix": "logos-nix_435",
         "logos-protocol": [
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_72",
-=======
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
@@ -4120,7 +3660,6 @@
         "logos-lidl": "logos-lidl_135",
         "logos-nix": "logos-nix_446",
         "logos-protocol": "logos-protocol_69",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4148,13 +3687,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_38": {
+    "logos-cpp-sdk_39": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_133",
-=======
         "logos-lidl": "logos-lidl_136",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": "logos-nix_452",
         "logos-protocol": [
           "logos-package-manager-module",
@@ -4199,45 +3734,6 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_39": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_134",
-        "logos-nix": "logos-nix_455",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_4": {
       "inputs": {
         "logos-lidl": "logos-lidl_11",
@@ -4273,11 +3769,6 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_139",
-        "logos-nix": "logos-nix_466",
-        "logos-protocol": "logos-protocol_76",
-=======
         "logos-lidl": "logos-lidl_143",
         "logos-nix": [
           "logos-package-manager-module",
@@ -4294,7 +3785,6 @@
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_72",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4369,60 +3859,9 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_41": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_140",
-        "logos-nix": "logos-nix_472",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_42": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_147",
-=======
         "logos-lidl": "logos-lidl_151",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4430,21 +3869,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_79",
-=======
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_77",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4452,13 +3880,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
@@ -4481,93 +3902,6 @@
     },
     "logos-cpp-sdk_43": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_149",
-        "logos-nix": "logos-nix_500",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_44": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_155",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_84",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_45": {
-      "inputs": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4617,26 +3951,16 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-cpp-sdk_46": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_162",
-=======
     "logos-cpp-sdk_44": {
       "inputs": {
         "logos-lidl": "logos-lidl_158",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_92",
-=======
         "logos-protocol": "logos-protocol_85",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4660,12 +3984,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-cpp-sdk_47": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_164",
-        "logos-nix": "logos-nix_570",
-=======
     "logos-cpp-sdk_45": {
       "inputs": {
         "logos-lidl": "logos-lidl_160",
@@ -4674,7 +3992,6 @@
           "logos-module-builder",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4815,13 +4132,8 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_48": {
+    "logos-cpp-sdk_49": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_169",
-        "logos-nix": "logos-nix_580",
-        "logos-protocol": "logos-protocol_96",
-=======
         "logos-lidl": "logos-lidl_175",
         "logos-nix": "logos-nix_590",
         "logos-protocol": [
@@ -4833,7 +4145,6 @@
           "logos-module-builder",
           "logos-protocol"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4841,43 +4152,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_49": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_170",
-        "logos-nix": "logos-nix_583",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4934,36 +4208,17 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_172",
-        "logos-nix": "logos-nix_590",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-=======
         "logos-lidl": "logos-lidl_180",
         "logos-nix": "logos-nix_601",
         "logos-protocol": "logos-protocol_96",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-=======
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4985,9 +4240,6 @@
     },
     "logos-cpp-sdk_51": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_179",
-=======
         "logos-lidl": "logos-lidl_181",
         "logos-nix": "logos-nix_607",
         "logos-protocol": [
@@ -5036,7 +4288,6 @@
     "logos-cpp-sdk_52": {
       "inputs": {
         "logos-lidl": "logos-lidl_188",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5051,11 +4302,7 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_101",
-=======
         "logos-protocol": "logos-protocol_99",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5068,54 +4315,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_52": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_181",
-        "logos-nix": "logos-nix_618",
-=======
-        "logos-lidl": "logos-lidl_190",
-        "logos-nix": "logos-nix_635",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -5137,8 +4336,8 @@
     },
     "logos-cpp-sdk_53": {
       "inputs": {
-        "logos-lidl": "logos-lidl_182",
-        "logos-nix": "logos-nix_621",
+        "logos-lidl": "logos-lidl_190",
+        "logos-nix": "logos-nix_635",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5146,6 +4345,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -5155,17 +4356,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -5176,11 +4379,6 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_187",
-        "logos-nix": "logos-nix_632",
-        "logos-protocol": "logos-protocol_105",
-=======
         "logos-lidl": "logos-lidl_196",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -5193,7 +4391,6 @@
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_104",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5201,30 +4398,18 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-=======
         "lastModified": 1786467089,
         "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -5235,189 +4420,6 @@
     },
     "logos-cpp-sdk_55": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_188",
-        "logos-nix": "logos-nix_638",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_56": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_195",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_108",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_57": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_197",
-        "logos-nix": "logos-nix_666",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_58": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_203",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_113",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_59": {
-      "inputs": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5467,10 +4469,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-cpp-sdk_6": {
-      "inputs": {
-=======
     "logos-cpp-sdk_56": {
       "inputs": {
         "logos-lidl": "logos-lidl_202",
@@ -5511,7 +4509,6 @@
     },
     "logos-cpp-sdk_6": {
       "inputs": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_20",
         "logos-nix": "logos-nix_64",
         "logos-protocol": [
@@ -5543,46 +4540,8 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-cpp-sdk_60": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_210",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_121",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
     "logos-cpp-sdk_7": {
       "inputs": {
-=======
-    "logos-cpp-sdk_7": {
-      "inputs": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_25",
         "logos-nix": "logos-nix_75",
         "logos-protocol": "logos-protocol_13",
@@ -5611,12 +4570,6 @@
       }
     },
     "logos-cpp-sdk_8": {
-<<<<<<< HEAD
-      "inputs": {
-        "logos-lidl": "logos-lidl_26",
-        "logos-nix": "logos-nix_81",
-        "logos-protocol": [
-=======
       "inputs": {
         "logos-lidl": "logos-lidl_26",
         "logos-nix": "logos-nix_81",
@@ -5649,50 +4602,6 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_9": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_33",
-        "logos-nix": [
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_16",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -5774,11 +4683,7 @@
     },
     "logos-design-system_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_284",
-=======
         "logos-nix": "logos-nix_275",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
@@ -5810,11 +4715,7 @@
     },
     "logos-design-system_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_301",
-=======
         "logos-nix": "logos-nix_292",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nix-bundle-macos-app": "nix-bundle-macos-app_11",
@@ -5850,11 +4751,7 @@
     },
     "logos-design-system_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_404",
-=======
         "logos-nix": "logos-nix_387",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_28",
         "nix-bundle-dir": "nix-bundle-dir_63",
         "nix-bundle-macos-app": "nix-bundle-macos-app_12",
@@ -5882,11 +4779,7 @@
     },
     "logos-design-system_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_425",
-=======
         "logos-nix": "logos-nix_405",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_29",
         "nix-bundle-dir": "nix-bundle-dir_64",
         "nix-bundle-macos-app": "nix-bundle-macos-app_13",
@@ -5918,11 +4811,7 @@
     },
     "logos-design-system_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_456",
-=======
         "logos-nix": "logos-nix_436",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_31",
         "nix-bundle-dir": "nix-bundle-dir_69",
         "nix-bundle-macos-app": "nix-bundle-macos-app_14",
@@ -5954,11 +4843,7 @@
     },
     "logos-design-system_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_473",
-=======
         "logos-nix": "logos-nix_453",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_32",
         "nix-bundle-dir": "nix-bundle-dir_70",
         "nix-bundle-macos-app": "nix-bundle-macos-app_15",
@@ -5994,11 +4879,7 @@
     },
     "logos-design-system_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_571",
-=======
         "logos-nix": "logos-nix_547",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_39",
         "nix-bundle-dir": "nix-bundle-dir_88",
         "nix-bundle-macos-app": "nix-bundle-macos-app_16",
@@ -6026,11 +4907,7 @@
     },
     "logos-design-system_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_591",
-=======
         "logos-nix": "logos-nix_561",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_40",
         "nix-bundle-dir": "nix-bundle-dir_89",
         "nix-bundle-macos-app": "nix-bundle-macos-app_17",
@@ -6062,11 +4939,7 @@
     },
     "logos-design-system_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_622",
-=======
         "logos-nix": "logos-nix_591",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_42",
         "nix-bundle-dir": "nix-bundle-dir_94",
         "nix-bundle-macos-app": "nix-bundle-macos-app_18",
@@ -6098,11 +4971,7 @@
     },
     "logos-design-system_19": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_639",
-=======
         "logos-nix": "logos-nix_608",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_43",
         "nix-bundle-dir": "nix-bundle-dir_95",
         "nix-bundle-macos-app": "nix-bundle-macos-app_19",
@@ -6315,11 +5184,7 @@
     },
     "logos-design-system_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_232",
-=======
         "logos-nix": "logos-nix_231",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
@@ -6347,11 +5212,7 @@
     },
     "logos-design-system_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_253",
-=======
         "logos-nix": "logos-nix_245",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
@@ -6510,17 +5371,6 @@
         "default-module-loader": "default-module-loader_4",
         "logos-capability-module": "logos-capability-module_5",
         "logos-container": "logos-container_21",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_24",
-        "logos-module": "logos-module_61",
-        "logos-module-loader": "logos-module-loader_9",
-        "logos-modules-state-module": "logos-modules-state-module_3",
-        "logos-nix": "logos-nix_360",
-        "logos-package-manager": "logos-package-manager_13",
-        "logos-plugin-qt": "logos-plugin-qt_46",
-        "logos-protocol": "logos-protocol_58",
-        "logos-qt-sdk": "logos-qt-sdk_25",
-=======
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -6545,7 +5395,6 @@
           "logos-protocol"
         ],
         "logos-qt-sdk": "logos-qt-sdk_24",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -6576,16 +5425,6 @@
         "default-module-loader": "default-module-loader_5",
         "logos-capability-module": "logos-capability-module_6",
         "logos-container": "logos-container_26",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_29",
-        "logos-module": "logos-module_73",
-        "logos-module-loader": "logos-module-loader_11",
-        "logos-nix": "logos-nix_331",
-        "logos-package-manager": "logos-package-manager_11",
-        "logos-plugin-qt": "logos-plugin-qt_42",
-        "logos-protocol": "logos-protocol_52",
-        "logos-qt-sdk": "logos-qt-sdk_23",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-module": "logos-module_71",
         "logos-module-loader": "logos-module-loader_11",
@@ -6594,7 +5433,6 @@
         "logos-plugin-qt": "logos-plugin-qt_40",
         "logos-protocol": "logos-protocol_50",
         "logos-qt-sdk": "logos-qt-sdk_22",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -6629,17 +5467,6 @@
         "default-module-loader": "default-module-loader_6",
         "logos-capability-module": "logos-capability-module_7",
         "logos-container": "logos-container_31",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_38",
-        "logos-module": "logos-module_95",
-        "logos-module-loader": "logos-module-loader_13",
-        "logos-modules-state-module": "logos-modules-state-module_4",
-        "logos-nix": "logos-nix_532",
-        "logos-package-manager": "logos-package-manager_20",
-        "logos-plugin-qt": "logos-plugin-qt_68",
-        "logos-protocol": "logos-protocol_87",
-        "logos-qt-sdk": "logos-qt-sdk_36",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-module": "logos-module_90",
         "logos-module-loader": "logos-module-loader_13",
@@ -6649,7 +5476,6 @@
         "logos-plugin-qt": "logos-plugin-qt_63",
         "logos-protocol": "logos-protocol_80",
         "logos-qt-sdk": "logos-qt-sdk_35",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -6680,16 +5506,6 @@
         "default-module-loader": "default-module-loader_7",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_36",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_43",
-        "logos-module": "logos-module_107",
-        "logos-module-loader": "logos-module-loader_15",
-        "logos-nix": "logos-nix_503",
-        "logos-package-manager": "logos-package-manager_18",
-        "logos-plugin-qt": "logos-plugin-qt_64",
-        "logos-protocol": "logos-protocol_81",
-        "logos-qt-sdk": "logos-qt-sdk_34",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-module": "logos-module_102",
         "logos-module-loader": "logos-module-loader_15",
@@ -6698,7 +5514,6 @@
         "logos-plugin-qt": "logos-plugin-qt_59",
         "logos-protocol": "logos-protocol_74",
         "logos-qt-sdk": "logos-qt-sdk_33",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -6733,17 +5548,6 @@
         "default-module-loader": "default-module-loader_8",
         "logos-capability-module": "logos-capability-module_9",
         "logos-container": "logos-container_41",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_52",
-        "logos-module": "logos-module_128",
-        "logos-module-loader": "logos-module-loader_17",
-        "logos-modules-state-module": "logos-modules-state-module_5",
-        "logos-nix": "logos-nix_698",
-        "logos-package-manager": "logos-package-manager_27",
-        "logos-plugin-qt": "logos-plugin-qt_89",
-        "logos-protocol": "logos-protocol_116",
-        "logos-qt-sdk": "logos-qt-sdk_47",
-=======
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -6768,7 +5572,6 @@
           "logos-protocol"
         ],
         "logos-qt-sdk": "logos-qt-sdk_45",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -6799,16 +5602,6 @@
         "default-module-loader": "default-module-loader_9",
         "logos-capability-module": "logos-capability-module_10",
         "logos-container": "logos-container_46",
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_57",
-        "logos-module": "logos-module_140",
-        "logos-module-loader": "logos-module-loader_19",
-        "logos-nix": "logos-nix_669",
-        "logos-package-manager": "logos-package-manager_25",
-        "logos-plugin-qt": "logos-plugin-qt_85",
-        "logos-protocol": "logos-protocol_110",
-        "logos-qt-sdk": "logos-qt-sdk_45",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-module": "logos-module_134",
         "logos-module-loader": "logos-module-loader_19",
@@ -6817,7 +5610,6 @@
         "logos-plugin-qt": "logos-plugin-qt_79",
         "logos-protocol": "logos-protocol_101",
         "logos-qt-sdk": "logos-qt-sdk_43",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -6915,14 +5707,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6934,14 +5719,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6971,12 +5749,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6987,12 +5760,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7021,12 +5789,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7037,12 +5800,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7072,12 +5830,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -7088,12 +5841,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7123,13 +5871,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7139,13 +5882,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7174,11 +5912,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7189,11 +5923,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7221,12 +5951,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -7235,12 +5959,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7267,30 +5985,14 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7315,30 +6017,14 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7364,38 +6050,26 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7417,8 +6091,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7452,7 +6124,6 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7460,11 +6131,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -7473,65 +6144,19 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-lidl_110": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-lidl_111": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7557,34 +6182,24 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -7598,34 +6213,24 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -7639,23 +6244,13 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7680,42 +6275,24 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-=======
         "lastModified": 1788811494,
         "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -7729,40 +6306,24 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-=======
         "lastModified": 1788811494,
         "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -7776,23 +6337,15 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-standalone-app",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-standalone-app",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7817,27 +6370,19 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7862,24 +6407,18 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -7938,29 +6477,21 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7986,28 +6517,20 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8034,14 +6557,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-cpp-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8049,14 +6567,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-cpp-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8083,12 +6596,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -8097,12 +6606,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8132,11 +6637,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8146,11 +6647,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8179,12 +6676,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8194,12 +6687,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8228,12 +6717,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8243,12 +6728,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8277,12 +6758,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8292,12 +6769,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8326,12 +6799,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8341,12 +6810,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8373,14 +6838,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8388,25 +6846,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8457,12 +6908,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8472,23 +6918,18 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8506,12 +6947,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8521,12 +6957,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8555,10 +6986,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8638,7 +7065,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8649,86 +7075,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_133": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_134": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8757,7 +7103,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8767,18 +7114,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8796,15 +7144,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8814,15 +7158,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8851,15 +7191,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8869,15 +7205,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8906,15 +7238,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8924,15 +7252,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8962,14 +7286,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8980,14 +7300,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9053,11 +7369,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9071,30 +7383,18 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-=======
         "lastModified": 1785470541,
         "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -9116,12 +7416,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9135,12 +7431,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9173,12 +7465,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9192,12 +7480,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9230,12 +7514,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9249,12 +7529,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9287,12 +7563,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9306,23 +7578,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9342,14 +7610,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9361,14 +7622,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9399,14 +7653,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9418,14 +7665,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9456,14 +7696,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9475,14 +7708,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9512,13 +7738,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9530,13 +7749,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9566,14 +7778,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9583,14 +7789,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9652,14 +7852,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9669,14 +7863,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9705,14 +7893,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9722,14 +7904,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9758,11 +7934,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9773,11 +7945,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9805,12 +7973,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9819,12 +7981,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9852,12 +8008,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -9866,12 +8016,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9898,30 +8042,14 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9946,30 +8074,14 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -9995,38 +8107,26 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10040,38 +8140,26 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -10085,22 +8173,14 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10161,42 +8241,24 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-=======
         "lastModified": 1788811494,
         "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -10210,34 +8272,24 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10251,118 +8303,13 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
-          "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_163": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_164": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_165": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-core",
-=======
-          "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10482,29 +8429,21 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10529,29 +8468,21 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10576,29 +8507,21 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10624,28 +8547,20 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10707,14 +8622,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-cpp-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10722,14 +8632,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-cpp-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10756,15 +8661,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-qt-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10772,15 +8672,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-qt-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10809,12 +8704,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10824,12 +8715,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10858,12 +8745,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10873,12 +8756,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10907,10 +8786,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -10921,10 +8797,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10954,11 +8827,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -10968,11 +8837,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11001,11 +8866,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11015,11 +8876,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11048,10 +8905,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -11131,7 +8984,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11153,88 +9005,6 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_178": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_179": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11287,10 +9057,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-cpp-sdk",
           "logos-nix"
@@ -11384,7 +9150,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11410,92 +9175,6 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_181": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_182": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -11513,7 +9192,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11523,18 +9206,22 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -11552,15 +9239,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11570,15 +9253,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11607,15 +9286,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11625,15 +9300,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11662,16 +9333,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11681,16 +9348,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11720,15 +9383,11 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11739,15 +9398,11 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11780,10 +9435,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -11798,10 +9450,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -11835,12 +9484,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11854,12 +9499,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11925,13 +9566,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11943,13 +9578,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-=======
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -11980,13 +9609,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -11998,13 +9621,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12035,11 +9652,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-=======
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -12124,7 +9736,6 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12136,96 +9747,6 @@
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_193": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_194": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12254,12 +9775,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12269,12 +9786,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12303,17 +9816,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12323,17 +9827,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12362,14 +9857,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12379,14 +9868,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12413,15 +9896,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12429,15 +9904,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12463,32 +9930,14 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12577,30 +10026,14 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12626,33 +10059,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12677,33 +10092,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12728,33 +10125,15 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12777,30 +10156,10 @@
     "logos-lidl_204": {
       "inputs": {
         "logos-nix": [
-<<<<<<< HEAD
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
-<<<<<<< HEAD
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -12824,304 +10183,6 @@
     "logos-lidl_205": {
       "inputs": {
         "logos-nix": [
-<<<<<<< HEAD
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_206": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_207": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_208": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_209": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_21": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_210": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_211": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_212": {
-      "inputs": {
-        "logos-nix": [
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_213": {
-      "inputs": {
-        "logos-nix": [
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -13152,19 +10213,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
@@ -13198,7 +10253,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -14049,8 +11103,6 @@
       "inputs": {
         "logos-nix": [
           "logos-module-loader-qt",
-<<<<<<< HEAD
-=======
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -14097,69 +11149,6 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_45": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_44": {
-      "inputs": {
-        "logos-nix": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -15067,19 +12056,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-=======
         "lastModified": 1788811494,
         "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -15285,12 +12266,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -15299,12 +12276,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -15332,14 +12305,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-qt-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15347,14 +12315,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-qt-sdk",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15383,11 +12346,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15397,11 +12356,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15430,11 +12385,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15444,11 +12395,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15477,11 +12424,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15491,11 +12434,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-rust-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15524,12 +12463,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15539,12 +12474,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15606,12 +12537,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15621,12 +12548,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-test-framework",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15655,13 +12578,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15671,13 +12589,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-plugin-qt",
-=======
           "logos-view-module-runtime",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -15706,13 +12619,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15722,24 +12630,19 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-test-framework",
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -15757,10 +12660,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -15771,10 +12670,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -15804,10 +12699,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-=======
           "logos-plugin-core",
           "logos-nix"
         ],
@@ -15887,7 +12778,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -15898,84 +12788,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_85": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_86": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16004,7 +12816,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16014,7 +12826,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16043,12 +12855,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16058,12 +12866,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16092,15 +12896,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16110,15 +12910,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16180,15 +12976,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16198,15 +12990,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-rust-sdk",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-core",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16236,14 +13024,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16254,14 +13038,10 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16294,11 +13074,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16312,11 +13088,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16349,150 +13121,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_94": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_95": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_96": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-rust-sdk",
           "logos-nix"
         ],
@@ -16527,11 +13155,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-lidl_97": {
-=======
     "logos-lidl_94": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -16580,11 +13204,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-lidl_98": {
-=======
     "logos-lidl_95": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -16633,8 +13253,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-lidl_96": {
       "inputs": {
         "logos-nix": [
@@ -16776,7 +13394,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-lidl_99": {
       "inputs": {
         "logos-nix": [
@@ -16788,14 +13405,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -16807,14 +13417,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -16902,16 +13505,6 @@
     },
     "logos-module-builder_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_27",
-        "logos-design-system": "logos-design-system_11",
-        "logos-module": "logos-module_67",
-        "logos-nix": "logos-nix_303",
-        "logos-plugin-core": "logos-plugin-core_10",
-        "logos-plugin-qt": "logos-plugin-qt_38",
-        "logos-protocol": "logos-protocol_48",
-        "logos-qt-sdk": "logos-qt-sdk_21",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_25",
         "logos-design-system": "logos-design-system_11",
         "logos-module": "logos-module_65",
@@ -16920,7 +13513,6 @@
         "logos-plugin-qt": "logos-plugin-qt_36",
         "logos-protocol": "logos-protocol_46",
         "logos-qt-sdk": "logos-qt-sdk_20",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -16970,16 +13562,6 @@
     },
     "logos-module-builder_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_33",
-        "logos-design-system": "logos-design-system_12",
-        "logos-module": "logos-module_83",
-        "logos-nix": "logos-nix_406",
-        "logos-plugin-core": "logos-plugin-core_11",
-        "logos-plugin-qt": "logos-plugin-qt_51",
-        "logos-protocol": "logos-protocol_65",
-        "logos-qt-sdk": "logos-qt-sdk_27",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_31",
         "logos-design-system": "logos-design-system_12",
         "logos-module": "logos-module_79",
@@ -16988,7 +13570,6 @@
         "logos-plugin-qt": "logos-plugin-qt_47",
         "logos-protocol": "logos-protocol_58",
         "logos-qt-sdk": "logos-qt-sdk_26",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
         "logos-test-framework": "logos-test-framework_14",
@@ -17020,16 +13601,6 @@
     },
     "logos-module-builder_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_36",
-        "logos-design-system": "logos-design-system_13",
-        "logos-module": "logos-module_89",
-        "logos-nix": "logos-nix_427",
-        "logos-plugin-core": "logos-plugin-core_12",
-        "logos-plugin-qt": "logos-plugin-qt_54",
-        "logos-protocol": "logos-protocol_69",
-        "logos-qt-sdk": "logos-qt-sdk_29",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_34",
         "logos-design-system": "logos-design-system_13",
         "logos-module": "logos-module_84",
@@ -17038,7 +13609,6 @@
         "logos-plugin-qt": "logos-plugin-qt_49",
         "logos-protocol": "logos-protocol_62",
         "logos-qt-sdk": "logos-qt-sdk_28",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -17080,16 +13650,6 @@
     },
     "logos-module-builder_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_39",
-        "logos-design-system": "logos-design-system_14",
-        "logos-module": "logos-module_96",
-        "logos-nix": "logos-nix_458",
-        "logos-plugin-core": "logos-plugin-core_13",
-        "logos-plugin-qt": "logos-plugin-qt_58",
-        "logos-protocol": "logos-protocol_74",
-        "logos-qt-sdk": "logos-qt-sdk_31",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-design-system": "logos-design-system_14",
         "logos-module": "logos-module_91",
@@ -17098,7 +13658,6 @@
         "logos-plugin-qt": "logos-plugin-qt_53",
         "logos-protocol": "logos-protocol_67",
         "logos-qt-sdk": "logos-qt-sdk_30",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_13",
         "logos-standalone-app": "logos-standalone-app_6",
         "logos-test-framework": "logos-test-framework_13",
@@ -17134,16 +13693,6 @@
     },
     "logos-module-builder_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_41",
-        "logos-design-system": "logos-design-system_15",
-        "logos-module": "logos-module_101",
-        "logos-nix": "logos-nix_475",
-        "logos-plugin-core": "logos-plugin-core_14",
-        "logos-plugin-qt": "logos-plugin-qt_60",
-        "logos-protocol": "logos-protocol_77",
-        "logos-qt-sdk": "logos-qt-sdk_32",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-design-system": "logos-design-system_15",
         "logos-module": "logos-module_96",
@@ -17152,7 +13701,6 @@
         "logos-plugin-qt": "logos-plugin-qt_55",
         "logos-protocol": "logos-protocol_70",
         "logos-qt-sdk": "logos-qt-sdk_31",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_14",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -17202,16 +13750,6 @@
     },
     "logos-module-builder_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_47",
-        "logos-design-system": "logos-design-system_16",
-        "logos-module": "logos-module_117",
-        "logos-nix": "logos-nix_573",
-        "logos-plugin-core": "logos-plugin-core_15",
-        "logos-plugin-qt": "logos-plugin-qt_73",
-        "logos-protocol": "logos-protocol_94",
-        "logos-qt-sdk": "logos-qt-sdk_38",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_45",
         "logos-design-system": "logos-design-system_16",
         "logos-module": "logos-module_112",
@@ -17220,7 +13758,6 @@
         "logos-plugin-qt": "logos-plugin-qt_68",
         "logos-protocol": "logos-protocol_87",
         "logos-qt-sdk": "logos-qt-sdk_37",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_15",
         "logos-standalone-app": "logos-standalone-app_7",
         "logos-test-framework": "logos-test-framework_18",
@@ -17252,16 +13789,6 @@
     },
     "logos-module-builder_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_50",
-        "logos-design-system": "logos-design-system_17",
-        "logos-module": "logos-module_122",
-        "logos-nix": "logos-nix_593",
-        "logos-plugin-core": "logos-plugin-core_16",
-        "logos-plugin-qt": "logos-plugin-qt_75",
-        "logos-protocol": "logos-protocol_98",
-        "logos-qt-sdk": "logos-qt-sdk_40",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_47",
         "logos-design-system": "logos-design-system_17",
         "logos-module": "logos-module_116",
@@ -17270,7 +13797,6 @@
         "logos-plugin-qt": "logos-plugin-qt_69",
         "logos-protocol": "logos-protocol_89",
         "logos-qt-sdk": "logos-qt-sdk_38",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_16",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -17312,16 +13838,6 @@
     },
     "logos-module-builder_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_53",
-        "logos-design-system": "logos-design-system_18",
-        "logos-module": "logos-module_129",
-        "logos-nix": "logos-nix_624",
-        "logos-plugin-core": "logos-plugin-core_17",
-        "logos-plugin-qt": "logos-plugin-qt_79",
-        "logos-protocol": "logos-protocol_103",
-        "logos-qt-sdk": "logos-qt-sdk_42",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-design-system": "logos-design-system_18",
         "logos-module": "logos-module_123",
@@ -17330,7 +13846,6 @@
         "logos-plugin-qt": "logos-plugin-qt_73",
         "logos-protocol": "logos-protocol_94",
         "logos-qt-sdk": "logos-qt-sdk_40",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_17",
         "logos-standalone-app": "logos-standalone-app_8",
         "logos-test-framework": "logos-test-framework_17",
@@ -17366,16 +13881,6 @@
     },
     "logos-module-builder_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_55",
-        "logos-design-system": "logos-design-system_19",
-        "logos-module": "logos-module_134",
-        "logos-nix": "logos-nix_641",
-        "logos-plugin-core": "logos-plugin-core_18",
-        "logos-plugin-qt": "logos-plugin-qt_81",
-        "logos-protocol": "logos-protocol_106",
-        "logos-qt-sdk": "logos-qt-sdk_43",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-design-system": "logos-design-system_19",
         "logos-module": "logos-module_128",
@@ -17384,7 +13889,6 @@
         "logos-plugin-qt": "logos-plugin-qt_75",
         "logos-protocol": "logos-protocol_97",
         "logos-qt-sdk": "logos-qt-sdk_41",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_18",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -17659,11 +14163,7 @@
         "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-design-system": "logos-design-system_8",
         "logos-module": "logos-module_49",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_234",
-=======
         "logos-nix": "logos-nix_233",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_29",
         "logos-protocol": "logos-protocol_36",
@@ -17699,16 +14199,6 @@
     },
     "logos-module-builder_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_22",
-        "logos-design-system": "logos-design-system_9",
-        "logos-module": "logos-module_55",
-        "logos-nix": "logos-nix_255",
-        "logos-plugin-core": "logos-plugin-core_8",
-        "logos-plugin-qt": "logos-plugin-qt_32",
-        "logos-protocol": "logos-protocol_40",
-        "logos-qt-sdk": "logos-qt-sdk_18",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_21",
         "logos-design-system": "logos-design-system_9",
         "logos-module": "logos-module_53",
@@ -17717,7 +14207,6 @@
         "logos-plugin-qt": "logos-plugin-qt_30",
         "logos-protocol": "logos-protocol_38",
         "logos-qt-sdk": "logos-qt-sdk_17",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -17759,16 +14248,6 @@
     },
     "logos-module-builder_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_25",
-        "logos-design-system": "logos-design-system_10",
-        "logos-module": "logos-module_62",
-        "logos-nix": "logos-nix_286",
-        "logos-plugin-core": "logos-plugin-core_9",
-        "logos-plugin-qt": "logos-plugin-qt_36",
-        "logos-protocol": "logos-protocol_45",
-        "logos-qt-sdk": "logos-qt-sdk_20",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-design-system": "logos-design-system_10",
         "logos-module": "logos-module_60",
@@ -17777,7 +14256,6 @@
         "logos-plugin-qt": "logos-plugin-qt_34",
         "logos-protocol": "logos-protocol_43",
         "logos-qt-sdk": "logos-qt-sdk_19",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_9",
         "logos-standalone-app": "logos-standalone-app_4",
         "logos-test-framework": "logos-test-framework_9",
@@ -17869,11 +14347,7 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_298",
-=======
         "logos-nix": "logos-nix_289",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -17906,11 +14380,7 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_330",
-=======
         "logos-nix": "logos-nix_321",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -17942,11 +14412,7 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_419",
-=======
         "logos-nix": "logos-nix_399",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -17975,11 +14441,7 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_454",
-=======
         "logos-nix": "logos-nix_434",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18007,11 +14469,7 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_470",
-=======
         "logos-nix": "logos-nix_450",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18044,11 +14502,7 @@
     "logos-module-loader_15": {
       "inputs": {
         "logos-container": "logos-container_37",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_502",
-=======
         "logos-nix": "logos-nix_482",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18080,11 +14534,7 @@
     "logos-module-loader_16": {
       "inputs": {
         "logos-container": "logos-container_40",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_585",
-=======
         "logos-nix": "logos-nix_558",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -18113,11 +14563,7 @@
     "logos-module-loader_17": {
       "inputs": {
         "logos-container": "logos-container_42",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_620",
-=======
         "logos-nix": "logos-nix_589",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -18145,11 +14591,7 @@
     "logos-module-loader_18": {
       "inputs": {
         "logos-container": "logos-container_45",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_636",
-=======
         "logos-nix": "logos-nix_605",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -18182,11 +14624,7 @@
     "logos-module-loader_19": {
       "inputs": {
         "logos-container": "logos-container_47",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_668",
-=======
         "logos-nix": "logos-nix_637",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -18384,11 +14822,7 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_247",
-=======
         "logos-nix": "logos-nix_242",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18417,11 +14851,7 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_282",
-=======
         "logos-nix": "logos-nix_273",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18484,8 +14914,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -18521,7 +14949,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -18547,48 +14974,9 @@
         "type": "github"
       }
     },
-    "logos-module_101": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_474",
-=======
-        "logos-nix": "logos-nix_481",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_102": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_476",
-=======
-        "logos-nix": "logos-nix_489",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_481",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18598,7 +14986,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18620,7 +15007,7 @@
     },
     "logos-module_103": {
       "inputs": {
-        "logos-nix": "logos-nix_478",
+        "logos-nix": "logos-nix_489",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18630,8 +15017,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18663,13 +15048,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18692,11 +15070,7 @@
     },
     "logos-module_105": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_484",
-=======
         "logos-nix": "logos-nix_497",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18704,13 +15078,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
@@ -18734,11 +15101,7 @@
     },
     "logos-module_106": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_486",
-=======
         "logos-nix": "logos-nix_499",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -18746,13 +15109,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
@@ -18776,24 +15132,13 @@
     },
     "logos-module_107": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_501",
-=======
         "logos-nix": "logos-nix_518",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18815,24 +15160,13 @@
     },
     "logos-module_108": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_509",
-=======
         "logos-nix": "logos-nix_522",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-qt-sdk",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18855,22 +15189,11 @@
     },
     "logos-module_109": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_514",
-=======
         "logos-nix": "logos-nix_525",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -18921,9 +15244,6 @@
     },
     "logos-module_110": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_517",
-=======
         "logos-nix": "logos-nix_530",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -18952,41 +15272,8 @@
     "logos-module_111": {
       "inputs": {
         "logos-nix": "logos-nix_532",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_111": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_519",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -19011,148 +15298,7 @@
     },
     "logos-module_112": {
       "inputs": {
-        "logos-nix": "logos-nix_538",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_113": {
-      "inputs": {
-        "logos-nix": "logos-nix_542",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_114": {
-      "inputs": {
-        "logos-nix": "logos-nix_545",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_115": {
-      "inputs": {
-        "logos-nix": "logos-nix_550",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_116": {
-      "inputs": {
-        "logos-nix": "logos-nix_552",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_117": {
-      "inputs": {
-        "logos-nix": "logos-nix_572",
-=======
         "logos-nix": "logos-nix_548",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -19175,15 +15321,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_118": {
-      "inputs": {
-        "logos-nix": "logos-nix_574",
-=======
     "logos-module_113": {
       "inputs": {
         "logos-nix": "logos-nix_550",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -19207,14 +15347,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_119": {
-      "inputs": {
-        "logos-nix": "logos-nix_576",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-=======
     "logos-module_114": {
       "inputs": {
         "logos-nix": "logos-nix_552",
@@ -19397,7 +15529,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19418,39 +15549,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_12": {
-      "inputs": {
-        "logos-nix": "logos-nix_48",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_120": {
-      "inputs": {
-        "logos-nix": "logos-nix_584",
-=======
     "logos-module_120": {
       "inputs": {
         "logos-nix": "logos-nix_572",
@@ -19485,7 +15583,6 @@
     "logos-module_121": {
       "inputs": {
         "logos-nix": "logos-nix_574",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -19514,14 +15611,10 @@
         "type": "github"
       }
     },
-    "logos-module_121": {
+    "logos-module_122": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_589",
-=======
         "logos-nix": "logos-nix_588",
         "logos-package": "logos-package_57",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -19546,7 +15639,7 @@
         "type": "github"
       }
     },
-    "logos-module_122": {
+    "logos-module_123": {
       "inputs": {
         "logos-nix": "logos-nix_592",
         "nixpkgs": [
@@ -19575,7 +15668,7 @@
         "type": "github"
       }
     },
-    "logos-module_123": {
+    "logos-module_124": {
       "inputs": {
         "logos-nix": "logos-nix_594",
         "nixpkgs": [
@@ -19605,36 +15698,6 @@
         "type": "github"
       }
     },
-    "logos-module_124": {
-      "inputs": {
-        "logos-nix": "logos-nix_596",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_125": {
       "inputs": {
         "logos-nix": "logos-nix_596",
@@ -19645,7 +15708,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -19668,9 +15730,6 @@
     },
     "logos-module_126": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_602",
-=======
         "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -19703,7 +15762,6 @@
     "logos-module_127": {
       "inputs": {
         "logos-nix": "logos-nix_604",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -19929,212 +15987,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_127": {
-      "inputs": {
-        "logos-nix": "logos-nix_604",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_128": {
-      "inputs": {
-        "logos-nix": "logos-nix_619",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_129": {
-      "inputs": {
-        "logos-nix": "logos-nix_623",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_13": {
-      "inputs": {
-        "logos-nix": "logos-nix_62",
-        "logos-package": "logos-package_7",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788740724,
-        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_130": {
-      "inputs": {
-        "logos-nix": "logos-nix_625",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_131": {
-      "inputs": {
-        "logos-nix": "logos-nix_627",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_132": {
-      "inputs": {
-        "logos-nix": "logos-nix_631",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-module_133": {
       "inputs": {
         "logos-nix": "logos-nix_621",
@@ -20145,8 +15997,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -20182,41 +16032,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_134": {
-      "inputs": {
-        "logos-nix": "logos-nix_640",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -20238,11 +16055,7 @@
     },
     "logos-module_135": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_642",
-=======
-        "logos-nix": "logos-nix_649",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_644",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -20251,6 +16064,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20273,7 +16087,7 @@
     },
     "logos-module_136": {
       "inputs": {
-        "logos-nix": "logos-nix_644",
+        "logos-nix": "logos-nix_649",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -20282,9 +16096,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20315,15 +16126,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20346,11 +16149,7 @@
     },
     "logos-module_138": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_650",
-=======
         "logos-nix": "logos-nix_654",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -20358,15 +16157,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20389,26 +16180,11 @@
     },
     "logos-module_139": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_652",
-=======
         "logos-nix": "logos-nix_676",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-<<<<<<< HEAD
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20457,25 +16233,12 @@
     },
     "logos-module_140": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_667",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
         "logos-nix": "logos-nix_681",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -20497,115 +16260,10 @@
     },
     "logos-module_141": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_675",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_142": {
-      "inputs": {
-        "logos-nix": "logos-nix_680",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_143": {
-      "inputs": {
         "logos-nix": "logos-nix_683",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_144": {
-      "inputs": {
-        "logos-nix": "logos-nix_685",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
-        "logos-nix": "logos-nix_683",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
@@ -20627,132 +16285,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_145": {
-      "inputs": {
-        "logos-nix": "logos-nix_704",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_146": {
-=======
     "logos-module_142": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_694",
         "nixpkgs": [
-<<<<<<< HEAD
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_147": {
-      "inputs": {
-        "logos-nix": "logos-nix_711",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_148": {
-      "inputs": {
-        "logos-nix": "logos-nix_716",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_149": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_718",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -20775,41 +16311,12 @@
     },
     "logos-module_15": {
       "inputs": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": "logos-nix_68",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
-<<<<<<< HEAD
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_150": {
-      "inputs": {
-        "logos-nix": "logos-nix_732",
-        "nixpkgs": [
-          "logos-plugin-qt",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -21847,11 +17354,7 @@
     },
     "logos-module_49": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_233",
-=======
         "logos-nix": "logos-nix_232",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -21903,11 +17406,7 @@
     },
     "logos-module_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_235",
-=======
         "logos-nix": "logos-nix_234",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -21933,11 +17432,7 @@
     },
     "logos-module_51": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_237",
-=======
         "logos-nix": "logos-nix_236",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -21967,14 +17462,9 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -21997,67 +17487,6 @@
     "logos-module_53": {
       "inputs": {
         "logos-nix": "logos-nix_246",
-<<<<<<< HEAD
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_54": {
-      "inputs": {
-        "logos-nix": "logos-nix_251",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_55": {
-      "inputs": {
-        "logos-nix": "logos-nix_254",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22084,15 +17513,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_56": {
-      "inputs": {
-        "logos-nix": "logos-nix_256",
-=======
     "logos-module_54": {
       "inputs": {
         "logos-nix": "logos-nix_248",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22120,41 +17543,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_57": {
-      "inputs": {
-        "logos-nix": "logos-nix_258",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_58": {
-=======
     "logos-module_55": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_250",
         "nixpkgs": [
@@ -22164,7 +17553,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -22187,9 +17575,6 @@
     },
     "logos-module_56": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_264",
-=======
         "logos-nix": "logos-nix_254",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -22222,7 +17607,6 @@
     "logos-module_57": {
       "inputs": {
         "logos-nix": "logos-nix_256",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22251,40 +17635,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_6": {
-      "inputs": {
-        "logos-nix": "logos-nix_31",
-        "nixpkgs": [
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_60": {
-      "inputs": {
-        "logos-nix": "logos-nix_266",
-=======
     "logos-module_58": {
       "inputs": {
         "logos-nix": "logos-nix_258",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22313,38 +17666,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_61": {
-      "inputs": {
-        "logos-nix": "logos-nix_281",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_62": {
-=======
     "logos-module_59": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_272",
         "logos-package": "logos-package_27",
@@ -22353,8 +17675,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -22490,11 +17810,7 @@
     },
     "logos-module_63": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_287",
-=======
         "logos-nix": "logos-nix_284",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22502,12 +17818,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-core",
-=======
           "logos-qt-sdk",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -22529,11 +17841,7 @@
     },
     "logos-module_64": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_289",
-=======
         "logos-nix": "logos-nix_288",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22541,13 +17849,9 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-plugin-qt",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -22577,72 +17881,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_66": {
-      "inputs": {
-        "logos-nix": "logos-nix_297",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_302",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -22666,15 +17904,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_68": {
-      "inputs": {
-        "logos-nix": "logos-nix_304",
-=======
     "logos-module_66": {
       "inputs": {
         "logos-nix": "logos-nix_295",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22706,10 +17938,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_69": {
+    "logos-module_67": {
       "inputs": {
-        "logos-nix": "logos-nix_306",
+        "logos-nix": "logos-nix_297",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22741,40 +17972,9 @@
         "type": "github"
       }
     },
-    "logos-module_7": {
+    "logos-module_68": {
       "inputs": {
-        "logos-nix": "logos-nix_36",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_70": {
-      "inputs": {
-        "logos-nix": "logos-nix_310",
-=======
-    "logos-module_67": {
-      "inputs": {
-        "logos-nix": "logos-nix_297",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_301",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22807,13 +18007,9 @@
         "type": "github"
       }
     },
-    "logos-module_68": {
+    "logos-module_69": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_312",
-=======
-        "logos-nix": "logos-nix_301",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_303",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22846,13 +18042,35 @@
         "type": "github"
       }
     },
-    "logos-module_69": {
+    "logos-module_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_314",
-=======
-        "logos-nix": "logos-nix_303",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_36",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_70": {
+      "inputs": {
+        "logos-nix": "logos-nix_305",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22885,74 +18103,9 @@
         "type": "github"
       }
     },
-    "logos-module_7": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_329",
-=======
-        "logos-nix": "logos-nix_36",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_70": {
-      "inputs": {
-        "logos-nix": "logos-nix_305",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
     "logos-module_71": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_337",
-=======
         "logos-nix": "logos-nix_320",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22962,7 +18115,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -22984,11 +18136,7 @@
     },
     "logos-module_72": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_342",
-=======
         "logos-nix": "logos-nix_328",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -22997,6 +18145,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -23019,9 +18168,6 @@
     },
     "logos-module_73": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_345",
-=======
         "logos-nix": "logos-nix_333",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -23143,42 +18289,10 @@
     "logos-module_77": {
       "inputs": {
         "logos-nix": "logos-nix_365",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_77": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_347",
-=======
-        "logos-nix": "logos-nix_367",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -23201,146 +18315,7 @@
     },
     "logos-module_78": {
       "inputs": {
-        "logos-nix": "logos-nix_366",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_79": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_370",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_8": {
-      "inputs": {
-        "logos-nix": "logos-nix_38",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_80": {
-      "inputs": {
-        "logos-nix": "logos-nix_373",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_81": {
-      "inputs": {
-        "logos-nix": "logos-nix_378",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_82": {
-      "inputs": {
-        "logos-nix": "logos-nix_380",
+        "logos-nix": "logos-nix_367",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -23365,12 +18340,9 @@
         "type": "github"
       }
     },
-    "logos-module_83": {
+    "logos-module_79": {
       "inputs": {
-        "logos-nix": "logos-nix_405",
-=======
         "logos-nix": "logos-nix_388",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -23393,11 +18365,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_84": {
-      "inputs": {
-        "logos-nix": "logos-nix_407",
-=======
     "logos-module_8": {
       "inputs": {
         "logos-nix": "logos-nix_38",
@@ -23428,7 +18395,6 @@
     "logos-module_80": {
       "inputs": {
         "logos-nix": "logos-nix_390",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -23452,43 +18418,12 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_85": {
-      "inputs": {
-        "logos-nix": "logos-nix_409",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_86": {
-=======
     "logos-module_81": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_392",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -23511,19 +18446,13 @@
     },
     "logos-module_82": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_418",
-=======
         "logos-nix": "logos-nix_398",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
-<<<<<<< HEAD
-=======
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -23674,7 +18603,6 @@
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -23696,188 +18624,7 @@
     },
     "logos-module_88": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_423",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_89": {
-      "inputs": {
-        "logos-nix": "logos-nix_426",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_9": {
-      "inputs": {
-        "logos-nix": "logos-nix_40",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_90": {
-      "inputs": {
-        "logos-nix": "logos-nix_428",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_91": {
-      "inputs": {
-        "logos-nix": "logos-nix_430",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_92": {
-      "inputs": {
-        "logos-nix": "logos-nix_434",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_93": {
-      "inputs": {
-        "logos-nix": "logos-nix_436",
-=======
         "logos-nix": "logos-nix_416",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -23906,15 +18653,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_94": {
-      "inputs": {
-        "logos-nix": "logos-nix_438",
-=======
     "logos-module_89": {
       "inputs": {
         "logos-nix": "logos-nix_418",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -23943,38 +18684,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-module_95": {
-      "inputs": {
-        "logos-nix": "logos-nix_453",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_96": {
-=======
     "logos-module_9": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_40",
         "nixpkgs": [
@@ -24009,8 +18719,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -24032,11 +18740,7 @@
     },
     "logos-module_91": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_459",
-=======
         "logos-nix": "logos-nix_437",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -24044,7 +18748,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -24066,11 +18769,7 @@
     },
     "logos-module_92": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_461",
-=======
         "logos-nix": "logos-nix_439",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -24078,7 +18777,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -24108,7 +18807,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -27144,19 +21842,11 @@
         "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1788961777,
-        "narHash": "sha256-p3bCNBLWks0Z7OoJaBhkTPpXtfgX59rtUefcbC59gM8=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "5378de595fa5d200d3e2f950b9a3a4c193170528",
-=======
         "lastModified": 1789054121,
         "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -27247,19 +21937,11 @@
         "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
         "lastModified": 1789054121,
         "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -27274,11 +21956,11 @@
         "nixpkgs-windows": "nixpkgs-windows_216"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27559,11 +22241,11 @@
         "nixpkgs-windows": "nixpkgs-windows_230"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -27711,11 +22393,11 @@
         "nixpkgs-windows": "nixpkgs-windows_237"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28032,11 +22714,11 @@
         "nixpkgs-windows": "nixpkgs-windows_250"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28051,11 +22733,11 @@
         "nixpkgs-windows": "nixpkgs-windows_251"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -28085,49 +22767,8 @@
     },
     "logos-nix_273": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_273"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_274": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_274"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_275": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_275",
-        "nixpkgs-windows": "nixpkgs-windows_255"
-=======
         "nixpkgs": "nixpkgs_273",
         "nixpkgs-windows": "nixpkgs-windows_253"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28143,8 +22784,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_274": {
       "inputs": {
         "nixpkgs": "nixpkgs_274",
@@ -28183,7 +22822,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_276": {
       "inputs": {
         "nixpkgs": "nixpkgs_276",
@@ -28665,11 +23303,11 @@
         "nixpkgs-windows": "nixpkgs-windows_279"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29153,19 +23791,15 @@
     },
     "logos-nix_321": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_321"
-=======
         "nixpkgs": "nixpkgs_321",
         "nixpkgs-windows": "nixpkgs-windows_299"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29176,19 +23810,15 @@
     },
     "logos-nix_322": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_322"
-=======
         "nixpkgs": "nixpkgs_322",
         "nixpkgs-windows": "nixpkgs-windows_300"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29237,15 +23867,14 @@
     },
     "logos-nix_325": {
       "inputs": {
-        "nixpkgs": "nixpkgs_325",
-        "nixpkgs-windows": "nixpkgs-windows_303"
+        "nixpkgs": "nixpkgs_325"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29256,15 +23885,14 @@
     },
     "logos-nix_326": {
       "inputs": {
-        "nixpkgs": "nixpkgs_326",
-        "nixpkgs-windows": "nixpkgs-windows_304"
+        "nixpkgs": "nixpkgs_326"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29445,19 +24073,15 @@
     },
     "logos-nix_335": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_335"
-=======
         "nixpkgs": "nixpkgs_335",
         "nixpkgs-windows": "nixpkgs-windows_310"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29469,11 +24093,7 @@
     "logos-nix_336": {
       "inputs": {
         "nixpkgs": "nixpkgs_336",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_312"
-=======
         "nixpkgs-windows": "nixpkgs-windows_311"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29492,11 +24112,7 @@
     "logos-nix_337": {
       "inputs": {
         "nixpkgs": "nixpkgs_337",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_313"
-=======
         "nixpkgs-windows": "nixpkgs-windows_312"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29515,11 +24131,7 @@
     "logos-nix_338": {
       "inputs": {
         "nixpkgs": "nixpkgs_338",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_314"
-=======
         "nixpkgs-windows": "nixpkgs-windows_313"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29538,11 +24150,7 @@
     "logos-nix_339": {
       "inputs": {
         "nixpkgs": "nixpkgs_339",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_315"
-=======
         "nixpkgs-windows": "nixpkgs-windows_314"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29602,11 +24210,11 @@
         "nixpkgs-windows": "nixpkgs-windows_316"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29636,19 +24244,15 @@
     },
     "logos-nix_343": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_343"
-=======
         "nixpkgs": "nixpkgs_343",
         "nixpkgs-windows": "nixpkgs-windows_318"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -29678,57 +24282,14 @@
     },
     "logos-nix_345": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_345",
-        "nixpkgs-windows": "nixpkgs-windows_320"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_346": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_346",
-        "nixpkgs-windows": "nixpkgs-windows_321"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_347": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_347",
-        "nixpkgs-windows": "nixpkgs-windows_322"
-=======
         "nixpkgs": "nixpkgs_345"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29912,19 +24473,11 @@
         "nixpkgs": "nixpkgs_354"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -29954,11 +24507,7 @@
     "logos-nix_356": {
       "inputs": {
         "nixpkgs": "nixpkgs_356",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_329"
-=======
         "nixpkgs-windows": "nixpkgs-windows_327"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29977,9 +24526,6 @@
     "logos-nix_357": {
       "inputs": {
         "nixpkgs": "nixpkgs_357",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_330"
-=======
         "nixpkgs-windows": "nixpkgs-windows_328"
       },
       "locked": {
@@ -30000,7 +24546,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_358",
         "nixpkgs-windows": "nixpkgs-windows_329"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30016,38 +24561,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_358": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_358",
-        "nixpkgs-windows": "nixpkgs-windows_331"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_359": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_359",
-        "nixpkgs-windows": "nixpkgs-windows_332"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
     "logos-nix_359": {
       "inputs": {
         "nixpkgs": "nixpkgs_359",
@@ -30059,7 +24572,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -30093,11 +24605,11 @@
         "nixpkgs-windows": "nixpkgs-windows_331"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30112,11 +24624,11 @@
         "nixpkgs-windows": "nixpkgs-windows_332"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30149,27 +24661,6 @@
         "nixpkgs": "nixpkgs_363"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_364": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_364"
-      },
-      "locked": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -30183,17 +24674,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_365": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_365",
-        "nixpkgs-windows": "nixpkgs-windows_336"
-=======
     "logos-nix_364": {
       "inputs": {
         "nixpkgs": "nixpkgs_364",
         "nixpkgs-windows": "nixpkgs-windows_334"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30209,12 +24693,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_366": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_366",
-        "nixpkgs-windows": "nixpkgs-windows_337"
-=======
     "logos-nix_365": {
       "inputs": {
         "nixpkgs": "nixpkgs_365",
@@ -30238,7 +24716,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_366",
         "nixpkgs-windows": "nixpkgs-windows_336"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30257,11 +24734,7 @@
     "logos-nix_367": {
       "inputs": {
         "nixpkgs": "nixpkgs_367",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_338"
-=======
         "nixpkgs-windows": "nixpkgs-windows_337"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30280,11 +24753,7 @@
     "logos-nix_368": {
       "inputs": {
         "nixpkgs": "nixpkgs_368",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_339"
-=======
         "nixpkgs-windows": "nixpkgs-windows_338"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30452,9 +24921,6 @@
     },
     "logos-nix_376": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_376"
-=======
         "nixpkgs": "nixpkgs_376",
         "nixpkgs-windows": "nixpkgs-windows_344"
       },
@@ -30476,14 +24942,13 @@
       "inputs": {
         "nixpkgs": "nixpkgs_377",
         "nixpkgs-windows": "nixpkgs-windows_345"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30492,36 +24957,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_377": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_377",
-        "nixpkgs-windows": "nixpkgs-windows_347"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_378": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_378",
-        "nixpkgs-windows": "nixpkgs-windows_348"
-=======
     "logos-nix_378": {
       "inputs": {
         "nixpkgs": "nixpkgs_378",
         "nixpkgs-windows": "nixpkgs-windows_346"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30539,12 +24978,7 @@
     },
     "logos-nix_379": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_379",
-        "nixpkgs-windows": "nixpkgs-windows_349"
-=======
         "nixpkgs": "nixpkgs_379"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1774455309,
@@ -30581,15 +25015,14 @@
     },
     "logos-nix_380": {
       "inputs": {
-        "nixpkgs": "nixpkgs_380",
-        "nixpkgs-windows": "nixpkgs-windows_350"
+        "nixpkgs": "nixpkgs_380"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -30660,19 +25093,11 @@
         "nixpkgs": "nixpkgs_384"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-=======
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -30686,19 +25111,11 @@
         "nixpkgs": "nixpkgs_385"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-=======
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -30728,19 +25145,15 @@
     },
     "logos-nix_387": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_387"
-=======
         "nixpkgs": "nixpkgs_387",
         "nixpkgs-windows": "nixpkgs-windows_351"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30751,16 +25164,6 @@
     },
     "logos-nix_388": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_388"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "nixpkgs": "nixpkgs_388",
         "nixpkgs-windows": "nixpkgs-windows_352"
       },
@@ -30770,7 +25173,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -30782,16 +25184,6 @@
     "logos-nix_389": {
       "inputs": {
         "nixpkgs": "nixpkgs_389",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_357"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
         "nixpkgs-windows": "nixpkgs-windows_353"
       },
       "locked": {
@@ -30800,7 +25192,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -30831,11 +25222,7 @@
     "logos-nix_390": {
       "inputs": {
         "nixpkgs": "nixpkgs_390",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_358"
-=======
         "nixpkgs-windows": "nixpkgs-windows_354"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30854,56 +25241,14 @@
     "logos-nix_391": {
       "inputs": {
         "nixpkgs": "nixpkgs_391",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_359"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_392": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_392",
-        "nixpkgs-windows": "nixpkgs-windows_360"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_393": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_393",
-        "nixpkgs-windows": "nixpkgs-windows_361"
-=======
         "nixpkgs-windows": "nixpkgs-windows_355"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -30971,49 +25316,8 @@
     },
     "logos-nix_395": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_395"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_396": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_396"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_397": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_397",
-        "nixpkgs-windows": "nixpkgs-windows_363"
-=======
         "nixpkgs": "nixpkgs_395",
         "nixpkgs-windows": "nixpkgs-windows_359"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31029,16 +25333,8 @@
         "type": "github"
       }
     },
-    "logos-nix_398": {
+    "logos-nix_396": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_398",
-        "nixpkgs-windows": "nixpkgs-windows_364"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-=======
         "nixpkgs": "nixpkgs_396",
         "nixpkgs-windows": "nixpkgs-windows_360"
       },
@@ -31064,7 +25360,6 @@
       "locked": {
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
@@ -31076,15 +25371,10 @@
         "type": "github"
       }
     },
-    "logos-nix_399": {
+    "logos-nix_398": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_399",
-        "nixpkgs-windows": "nixpkgs-windows_365"
-=======
         "nixpkgs": "nixpkgs_398",
         "nixpkgs-windows": "nixpkgs-windows_362"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31100,8 +25390,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_399": {
       "inputs": {
         "nixpkgs": "nixpkgs_399",
@@ -31121,7 +25409,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_4": {
       "inputs": {
         "nixpkgs": "nixpkgs_4",
@@ -31166,31 +25453,8 @@
         "nixpkgs-windows": "nixpkgs-windows_364"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_401": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_401"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-=======
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
@@ -31202,15 +25466,10 @@
         "type": "github"
       }
     },
-    "logos-nix_402": {
+    "logos-nix_401": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_402",
-        "nixpkgs-windows": "nixpkgs-windows_366"
-=======
         "nixpkgs": "nixpkgs_401",
         "nixpkgs-windows": "nixpkgs-windows_365"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31226,8 +25485,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_402": {
       "inputs": {
         "nixpkgs": "nixpkgs_402",
@@ -31247,7 +25504,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_403": {
       "inputs": {
         "nixpkgs": "nixpkgs_403",
@@ -31311,11 +25567,11 @@
         "nixpkgs-windows": "nixpkgs-windows_370"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31615,11 +25871,11 @@
         "nixpkgs-windows": "nixpkgs-windows_384"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -31672,35 +25928,11 @@
         "nixpkgs-windows": "nixpkgs-windows_387"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_424": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_424",
-        "nixpkgs-windows": "nixpkgs-windows_388"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-=======
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31770,11 +26002,11 @@
         "nixpkgs-windows": "nixpkgs-windows_389"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32093,11 +26325,11 @@
         "nixpkgs-windows": "nixpkgs-windows_404"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32112,11 +26344,11 @@
         "nixpkgs-windows": "nixpkgs-windows_405"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32146,49 +26378,8 @@
     },
     "logos-nix_445": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_445"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_446": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_446"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_447": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_447",
-        "nixpkgs-windows": "nixpkgs-windows_409"
-=======
         "nixpkgs": "nixpkgs_445",
         "nixpkgs-windows": "nixpkgs-windows_407"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32204,8 +26395,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_446": {
       "inputs": {
         "nixpkgs": "nixpkgs_446",
@@ -32244,7 +26433,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_448": {
       "inputs": {
         "nixpkgs": "nixpkgs_448",
@@ -32745,11 +26933,11 @@
         "nixpkgs-windows": "nixpkgs-windows_433"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -32832,47 +27020,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_474": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_474",
-        "nixpkgs-windows": "nixpkgs-windows_436"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_475": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_475",
-        "nixpkgs-windows": "nixpkgs-windows_437"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_476": {
       "inputs": {
         "nixpkgs": "nixpkgs_476",
@@ -33234,16 +27381,6 @@
     },
     "logos-nix_493": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_493"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "nixpkgs": "nixpkgs_493",
         "nixpkgs-windows": "nixpkgs-windows_451"
       },
@@ -33253,7 +27390,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -33264,19 +27400,15 @@
     },
     "logos-nix_494": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_494"
-=======
         "nixpkgs": "nixpkgs_494",
         "nixpkgs-windows": "nixpkgs-windows_452"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -33287,12 +27419,7 @@
     },
     "logos-nix_495": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_495",
-        "nixpkgs-windows": "nixpkgs-windows_455"
-=======
         "nixpkgs": "nixpkgs_495"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -33311,11 +27438,7 @@
     "logos-nix_496": {
       "inputs": {
         "nixpkgs": "nixpkgs_496",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_456"
-=======
         "nixpkgs-windows": "nixpkgs-windows_453"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33334,11 +27457,7 @@
     "logos-nix_497": {
       "inputs": {
         "nixpkgs": "nixpkgs_497",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_457"
-=======
         "nixpkgs-windows": "nixpkgs-windows_454"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33357,11 +27476,7 @@
     "logos-nix_498": {
       "inputs": {
         "nixpkgs": "nixpkgs_498",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_458"
-=======
         "nixpkgs-windows": "nixpkgs-windows_455"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33587,11 +27702,7 @@
     "logos-nix_508": {
       "inputs": {
         "nixpkgs": "nixpkgs_508",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_466"
-=======
         "nixpkgs-windows": "nixpkgs-windows_463"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33610,11 +27721,7 @@
     "logos-nix_509": {
       "inputs": {
         "nixpkgs": "nixpkgs_509",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_467"
-=======
         "nixpkgs-windows": "nixpkgs-windows_464"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33652,11 +27759,7 @@
     "logos-nix_510": {
       "inputs": {
         "nixpkgs": "nixpkgs_510",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_468"
-=======
         "nixpkgs-windows": "nixpkgs-windows_465"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33675,11 +27778,7 @@
     "logos-nix_511": {
       "inputs": {
         "nixpkgs": "nixpkgs_511",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_469"
-=======
         "nixpkgs-windows": "nixpkgs-windows_466"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33757,19 +27856,11 @@
         "nixpkgs": "nixpkgs_515"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -33780,12 +27871,7 @@
     },
     "logos-nix_516": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_516",
-        "nixpkgs-windows": "nixpkgs-windows_473"
-=======
         "nixpkgs": "nixpkgs_516"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -33804,11 +27890,7 @@
     "logos-nix_517": {
       "inputs": {
         "nixpkgs": "nixpkgs_517",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_474"
-=======
         "nixpkgs-windows": "nixpkgs-windows_470"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33827,11 +27909,7 @@
     "logos-nix_518": {
       "inputs": {
         "nixpkgs": "nixpkgs_518",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_475"
-=======
         "nixpkgs-windows": "nixpkgs-windows_471"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33850,8 +27928,7 @@
     "logos-nix_519": {
       "inputs": {
         "nixpkgs": "nixpkgs_519",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_476"
+        "nixpkgs-windows": "nixpkgs-windows_472"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -33859,28 +27936,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_52": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_52",
-        "nixpkgs-windows": "nixpkgs-windows_50"
-=======
-        "nixpkgs-windows": "nixpkgs-windows_472"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -34024,19 +28079,15 @@
     },
     "logos-nix_526": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_526"
-=======
         "nixpkgs": "nixpkgs_526",
         "nixpkgs-windows": "nixpkgs-windows_479"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34047,19 +28098,15 @@
     },
     "logos-nix_527": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_527"
-=======
         "nixpkgs": "nixpkgs_527",
         "nixpkgs-windows": "nixpkgs-windows_480"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34070,12 +28117,7 @@
     },
     "logos-nix_528": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_528",
-        "nixpkgs-windows": "nixpkgs-windows_483"
-=======
         "nixpkgs": "nixpkgs_528"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -34094,11 +28136,7 @@
     "logos-nix_529": {
       "inputs": {
         "nixpkgs": "nixpkgs_529",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_484"
-=======
         "nixpkgs-windows": "nixpkgs-windows_481"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34136,11 +28174,7 @@
     "logos-nix_530": {
       "inputs": {
         "nixpkgs": "nixpkgs_530",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_485"
-=======
         "nixpkgs-windows": "nixpkgs-windows_482"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34159,11 +28193,7 @@
     "logos-nix_531": {
       "inputs": {
         "nixpkgs": "nixpkgs_531",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_486"
-=======
         "nixpkgs-windows": "nixpkgs-windows_483"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34185,11 +28215,11 @@
         "nixpkgs-windows": "nixpkgs-windows_484"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34204,11 +28234,11 @@
         "nixpkgs-windows": "nixpkgs-windows_485"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34238,49 +28268,8 @@
     },
     "logos-nix_535": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_535"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_536": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_536"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_537": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_537",
-        "nixpkgs-windows": "nixpkgs-windows_490"
-=======
         "nixpkgs": "nixpkgs_535",
         "nixpkgs-windows": "nixpkgs-windows_487"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34296,12 +28285,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_538": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_538",
-        "nixpkgs-windows": "nixpkgs-windows_491"
-=======
     "logos-nix_536": {
       "inputs": {
         "nixpkgs": "nixpkgs_536",
@@ -34344,7 +28327,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_538",
         "nixpkgs-windows": "nixpkgs-windows_490"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34362,15 +28344,14 @@
     },
     "logos-nix_539": {
       "inputs": {
-        "nixpkgs": "nixpkgs_539",
-        "nixpkgs-windows": "nixpkgs-windows_492"
+        "nixpkgs": "nixpkgs_539"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -34400,15 +28381,14 @@
     },
     "logos-nix_540": {
       "inputs": {
-        "nixpkgs": "nixpkgs_540",
-        "nixpkgs-windows": "nixpkgs-windows_493"
+        "nixpkgs": "nixpkgs_540"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -34479,19 +28459,11 @@
         "nixpkgs": "nixpkgs_544"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-=======
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -34558,16 +28530,6 @@
     },
     "logos-nix_548": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_548"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "nixpkgs": "nixpkgs_548",
         "nixpkgs-windows": "nixpkgs-windows_496"
       },
@@ -34577,7 +28539,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -34589,11 +28550,7 @@
     "logos-nix_549": {
       "inputs": {
         "nixpkgs": "nixpkgs_549",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_501"
-=======
         "nixpkgs-windows": "nixpkgs-windows_497"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1789054121,
@@ -34630,11 +28587,7 @@
     "logos-nix_550": {
       "inputs": {
         "nixpkgs": "nixpkgs_550",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_502"
-=======
         "nixpkgs-windows": "nixpkgs-windows_498"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34653,11 +28606,7 @@
     "logos-nix_551": {
       "inputs": {
         "nixpkgs": "nixpkgs_551",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_503"
-=======
         "nixpkgs-windows": "nixpkgs-windows_499"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34676,30 +28625,7 @@
     "logos-nix_552": {
       "inputs": {
         "nixpkgs": "nixpkgs_552",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_504"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_553": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_553",
-        "nixpkgs-windows": "nixpkgs-windows_505"
-=======
         "nixpkgs-windows": "nixpkgs-windows_500"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34778,11 +28704,11 @@
         "nixpkgs-windows": "nixpkgs-windows_504"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34797,11 +28723,11 @@
         "nixpkgs-windows": "nixpkgs-windows_505"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -34831,16 +28757,6 @@
     },
     "logos-nix_559": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_559"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-=======
         "nixpkgs": "nixpkgs_559",
         "nixpkgs-windows": "nixpkgs-windows_507"
       },
@@ -34850,7 +28766,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -34879,31 +28794,8 @@
     },
     "logos-nix_560": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_560"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_561": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_561",
-        "nixpkgs-windows": "nixpkgs-windows_511"
-=======
         "nixpkgs": "nixpkgs_560",
         "nixpkgs-windows": "nixpkgs-windows_508"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34919,12 +28811,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_562": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_562",
-        "nixpkgs-windows": "nixpkgs-windows_512"
-=======
     "logos-nix_561": {
       "inputs": {
         "nixpkgs": "nixpkgs_561",
@@ -34948,7 +28834,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_562",
         "nixpkgs-windows": "nixpkgs-windows_510"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -34967,16 +28852,6 @@
     "logos-nix_563": {
       "inputs": {
         "nixpkgs": "nixpkgs_563",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_513"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
         "nixpkgs-windows": "nixpkgs-windows_511"
       },
       "locked": {
@@ -34985,7 +28860,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -34997,11 +28871,7 @@
     "logos-nix_564": {
       "inputs": {
         "nixpkgs": "nixpkgs_564",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_514"
-=======
         "nixpkgs-windows": "nixpkgs-windows_512"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -35023,11 +28893,11 @@
         "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -35057,15 +28927,15 @@
     },
     "logos-nix_567": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_567"
+        "nixpkgs": "nixpkgs_567",
+        "nixpkgs-windows": "nixpkgs-windows_515"
       },
       "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -35076,54 +28946,8 @@
     },
     "logos-nix_568": {
       "inputs": {
-        "nixpkgs": "nixpkgs_568"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_569": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_569",
-        "nixpkgs-windows": "nixpkgs-windows_517"
-=======
-        "nixpkgs": "nixpkgs_567",
-        "nixpkgs-windows": "nixpkgs-windows_515"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_57": {
-      "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_57",
-        "nixpkgs-windows": "nixpkgs-windows_53"
-=======
         "nixpkgs": "nixpkgs_568",
         "nixpkgs-windows": "nixpkgs-windows_516"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -35139,8 +28963,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_569": {
       "inputs": {
         "nixpkgs": "nixpkgs_569",
@@ -35179,7 +29001,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_570": {
       "inputs": {
         "nixpkgs": "nixpkgs_570",
@@ -35243,11 +29064,11 @@
         "nixpkgs-windows": "nixpkgs-windows_521"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -35507,11 +29328,11 @@
         "nixpkgs-windows": "nixpkgs-windows_532"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -35659,11 +29480,11 @@
         "nixpkgs-windows": "nixpkgs-windows_539"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -35982,11 +29803,11 @@
         "nixpkgs-windows": "nixpkgs-windows_554"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -36001,11 +29822,11 @@
         "nixpkgs-windows": "nixpkgs-windows_555"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -36054,49 +29875,8 @@
     },
     "logos-nix_611": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_611"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_612": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_612"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_613": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_613",
-        "nixpkgs-windows": "nixpkgs-windows_559"
-=======
         "nixpkgs": "nixpkgs_611",
         "nixpkgs-windows": "nixpkgs-windows_557"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -36112,8 +29892,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-nix_612": {
       "inputs": {
         "nixpkgs": "nixpkgs_612",
@@ -36152,7 +29930,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_614": {
       "inputs": {
         "nixpkgs": "nixpkgs_614",
@@ -36632,11 +30409,11 @@
         "nixpkgs-windows": "nixpkgs-windows_581"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -36726,19 +30503,11 @@
         "nixpkgs": "nixpkgs_641"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -37089,19 +30858,15 @@
     },
     "logos-nix_659": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_659"
-=======
         "nixpkgs": "nixpkgs_659",
         "nixpkgs-windows": "nixpkgs-windows_600"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37131,19 +30896,15 @@
     },
     "logos-nix_660": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_660"
-=======
         "nixpkgs": "nixpkgs_660",
         "nixpkgs-windows": "nixpkgs-windows_601"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37154,12 +30915,7 @@
     },
     "logos-nix_661": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_661",
-        "nixpkgs-windows": "nixpkgs-windows_605"
-=======
         "nixpkgs": "nixpkgs_661"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -37177,10 +30933,6 @@
     },
     "logos-nix_662": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_662",
-        "nixpkgs-windows": "nixpkgs-windows_606"
-=======
         "nixpkgs": "nixpkgs_662"
       },
       "locked": {
@@ -37201,7 +30953,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_663",
         "nixpkgs-windows": "nixpkgs-windows_602"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37217,36 +30968,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_663": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_663",
-        "nixpkgs-windows": "nixpkgs-windows_607"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_664": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_664",
-        "nixpkgs-windows": "nixpkgs-windows_608"
-=======
     "logos-nix_664": {
       "inputs": {
         "nixpkgs": "nixpkgs_664",
         "nixpkgs-windows": "nixpkgs-windows_603"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37414,19 +31139,15 @@
     },
     "logos-nix_672": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_672"
-=======
         "nixpkgs": "nixpkgs_672",
         "nixpkgs-windows": "nixpkgs-windows_609"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37437,16 +31158,6 @@
     },
     "logos-nix_673": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_673"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-=======
         "nixpkgs": "nixpkgs_673",
         "nixpkgs-windows": "nixpkgs-windows_610"
       },
@@ -37456,7 +31167,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -37468,11 +31178,7 @@
     "logos-nix_674": {
       "inputs": {
         "nixpkgs": "nixpkgs_674",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_616"
-=======
         "nixpkgs-windows": "nixpkgs-windows_611"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37491,9 +31197,6 @@
     "logos-nix_675": {
       "inputs": {
         "nixpkgs": "nixpkgs_675",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_617"
-=======
         "nixpkgs-windows": "nixpkgs-windows_612"
       },
       "locked": {
@@ -37514,7 +31217,6 @@
       "inputs": {
         "nixpkgs": "nixpkgs_676",
         "nixpkgs-windows": "nixpkgs-windows_613"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37530,36 +31232,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_676": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_676",
-        "nixpkgs-windows": "nixpkgs-windows_618"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_677": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_677",
-        "nixpkgs-windows": "nixpkgs-windows_619"
-=======
     "logos-nix_677": {
       "inputs": {
         "nixpkgs": "nixpkgs_677",
         "nixpkgs-windows": "nixpkgs-windows_614"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37599,19 +31275,11 @@
         "nixpkgs": "nixpkgs_679"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-=======
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -37660,19 +31328,15 @@
     },
     "logos-nix_681": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_681"
-=======
         "nixpkgs": "nixpkgs_681",
         "nixpkgs-windows": "nixpkgs-windows_617"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37684,11 +31348,7 @@
     "logos-nix_682": {
       "inputs": {
         "nixpkgs": "nixpkgs_682",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_623"
-=======
         "nixpkgs-windows": "nixpkgs-windows_618"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37707,11 +31367,7 @@
     "logos-nix_683": {
       "inputs": {
         "nixpkgs": "nixpkgs_683",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_624"
-=======
         "nixpkgs-windows": "nixpkgs-windows_619"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37730,11 +31386,7 @@
     "logos-nix_684": {
       "inputs": {
         "nixpkgs": "nixpkgs_684",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_625"
-=======
         "nixpkgs-windows": "nixpkgs-windows_620"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37753,11 +31405,7 @@
     "logos-nix_685": {
       "inputs": {
         "nixpkgs": "nixpkgs_685",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_626"
-=======
         "nixpkgs-windows": "nixpkgs-windows_621"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37906,19 +31554,15 @@
     },
     "logos-nix_692": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_692"
-=======
         "nixpkgs": "nixpkgs_692",
         "nixpkgs-windows": "nixpkgs-windows_626"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37929,19 +31573,15 @@
     },
     "logos-nix_693": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_693"
-=======
         "nixpkgs": "nixpkgs_693",
         "nixpkgs-windows": "nixpkgs-windows_627"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -37953,11 +31593,7 @@
     "logos-nix_694": {
       "inputs": {
         "nixpkgs": "nixpkgs_694",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_633"
-=======
         "nixpkgs-windows": "nixpkgs-windows_628"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37976,11 +31612,7 @@
     "logos-nix_695": {
       "inputs": {
         "nixpkgs": "nixpkgs_695",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_634"
-=======
         "nixpkgs-windows": "nixpkgs-windows_629"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -37999,11 +31631,7 @@
     "logos-nix_696": {
       "inputs": {
         "nixpkgs": "nixpkgs_696",
-<<<<<<< HEAD
-        "nixpkgs-windows": "nixpkgs-windows_635"
-=======
         "nixpkgs-windows": "nixpkgs-windows_630"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -38021,15 +31649,14 @@
     },
     "logos-nix_697": {
       "inputs": {
-        "nixpkgs": "nixpkgs_697",
-        "nixpkgs-windows": "nixpkgs-windows_636"
+        "nixpkgs": "nixpkgs_697"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -38044,19 +31671,11 @@
         "nixpkgs-windows": "nixpkgs-windows_631"
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-=======
         "lastModified": 1788889549,
         "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -38071,11 +31690,11 @@
         "nixpkgs-windows": "nixpkgs-windows_632"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -38124,27 +31743,7 @@
     },
     "logos-nix_700": {
       "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_700",
-        "nixpkgs-windows": "nixpkgs-windows_639"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_701": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_701"
+        "nixpkgs": "nixpkgs_700"
       },
       "locked": {
         "lastModified": 1774455309,
@@ -38160,9 +31759,9 @@
         "type": "github"
       }
     },
-    "logos-nix_702": {
+    "logos-nix_701": {
       "inputs": {
-        "nixpkgs": "nixpkgs_702"
+        "nixpkgs": "nixpkgs_701"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -38170,89 +31769,6 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_703": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_703",
-        "nixpkgs-windows": "nixpkgs-windows_640"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_704": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_704",
-        "nixpkgs-windows": "nixpkgs-windows_641"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_705": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_705",
-        "nixpkgs-windows": "nixpkgs-windows_642"
-=======
-        "nixpkgs": "nixpkgs_700"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_701": {
-      "inputs": {
-<<<<<<< HEAD
-        "nixpkgs": "nixpkgs_706",
-        "nixpkgs-windows": "nixpkgs-windows_643"
-=======
-        "nixpkgs": "nixpkgs_701"
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -38436,11 +31952,11 @@
         "nixpkgs-windows": "nixpkgs-windows_639"
       },
       "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
       "original": {
@@ -38477,143 +31993,7 @@
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-<<<<<<< HEAD
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_713": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_713",
-        "nixpkgs-windows": "nixpkgs-windows_650"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_714": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_714"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_715": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_715",
-        "nixpkgs-windows": "nixpkgs-windows_651"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_716": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_716",
-        "nixpkgs-windows": "nixpkgs-windows_652"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_717": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_717",
-        "nixpkgs-windows": "nixpkgs-windows_653"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_718": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_718",
-        "nixpkgs-windows": "nixpkgs-windows_654"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_719": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_719",
-        "nixpkgs-windows": "nixpkgs-windows_655"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-=======
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -38641,197 +32021,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_720": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_720",
-        "nixpkgs-windows": "nixpkgs-windows_656"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_721": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_721",
-        "nixpkgs-windows": "nixpkgs-windows_657"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_722": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_722",
-        "nixpkgs-windows": "nixpkgs-windows_658"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_723": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_723",
-        "nixpkgs-windows": "nixpkgs-windows_659"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_724": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_724",
-        "nixpkgs-windows": "nixpkgs-windows_660"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_725": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_725"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_726": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_726"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_727": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_727",
-        "nixpkgs-windows": "nixpkgs-windows_661"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_728": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_728",
-        "nixpkgs-windows": "nixpkgs-windows_662"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_729": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_729",
-        "nixpkgs-windows": "nixpkgs-windows_663"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_73": {
       "inputs": {
         "nixpkgs": "nixpkgs_73",
@@ -38851,196 +32040,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_730": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_730",
-        "nixpkgs-windows": "nixpkgs-windows_664"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_731": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_731",
-        "nixpkgs-windows": "nixpkgs-windows_665"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_732": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_732",
-        "nixpkgs-windows": "nixpkgs-windows_666"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_733": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_733",
-        "nixpkgs-windows": "nixpkgs-windows_667"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_734": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_734",
-        "nixpkgs-windows": "nixpkgs-windows_668"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_735": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_735"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_736": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_736",
-        "nixpkgs-windows": "nixpkgs-windows_669"
-      },
-      "locked": {
-        "lastModified": 1788889549,
-        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_737": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_737",
-        "nixpkgs-windows": "nixpkgs-windows_670"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_738": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_738"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_739": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_739"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_74": {
       "inputs": {
         "nixpkgs": "nixpkgs_74",
@@ -39060,197 +32059,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_740": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_740",
-        "nixpkgs-windows": "nixpkgs-windows_671"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_741": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_741",
-        "nixpkgs-windows": "nixpkgs-windows_672"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_742": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_742",
-        "nixpkgs-windows": "nixpkgs-windows_673"
-      },
-      "locked": {
-        "lastModified": 1786729772,
-        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_743": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_743",
-        "nixpkgs-windows": "nixpkgs-windows_674"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_744": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_744"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_745": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_745"
-      },
-      "locked": {
-        "lastModified": 1773955630,
-        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_746": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_746",
-        "nixpkgs-windows": "nixpkgs-windows_675"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_747": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_747",
-        "nixpkgs-windows": "nixpkgs-windows_676"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_748": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_748",
-        "nixpkgs-windows": "nixpkgs-windows_677"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_749": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_749",
-        "nixpkgs-windows": "nixpkgs-windows_678"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_75": {
       "inputs": {
         "nixpkgs": "nixpkgs_75",
@@ -39270,27 +32078,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-nix_750": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_750"
-      },
-      "locked": {
-        "lastModified": 1774455309,
-        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_76": {
       "inputs": {
         "nixpkgs": "nixpkgs_76",
@@ -39813,11 +32600,7 @@
     },
     "logos-package-downloader": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_393",
-=======
         "logos-nix": "logos-nix_377",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
         "nix-bundle-dir": "nix-bundle-dir_60",
@@ -39921,11 +32704,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789128665,
-        "narHash": "sha256-kAm8/aVITHEuT53jJGm46WPBpDHZRrym/HwucL2eXWg=",
+        "lastModified": 1789131452,
+        "narHash": "sha256-cwdEslbGGAiZCDdbkFE50gD4WQP3sBZ14KxHHMoTkgI=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "45935fbf3b568b2e492298730f6151f3044129d9",
+        "rev": "427d2e0d9d3120f74d87623a8c243f8c0faa2a39",
         "type": "github"
       },
       "original": {
@@ -39936,13 +32719,8 @@
     },
     "logos-package-manager_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_319",
-        "logos-package": "logos-package_28",
-=======
         "logos-nix": "logos-nix_310",
         "logos-package": "logos-package_29",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
@@ -39978,13 +32756,8 @@
     },
     "logos-package-manager_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_332",
-        "logos-package": "logos-package_30",
-=======
         "logos-nix": "logos-nix_323",
         "logos-package": "logos-package_31",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
@@ -40017,13 +32790,8 @@
     },
     "logos-package-manager_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_352",
-        "logos-package": "logos-package_32",
-=======
         "logos-nix": "logos-nix_343",
         "logos-package": "logos-package_33",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
@@ -40055,13 +32823,8 @@
     },
     "logos-package-manager_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_361",
-        "logos-package": "logos-package_34",
-=======
         "logos-nix": "logos-nix_352",
         "logos-package": "logos-package_35",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
@@ -40090,13 +32853,8 @@
     },
     "logos-package-manager_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_385",
-        "logos-package": "logos-package_36",
-=======
         "logos-nix": "logos-nix_372",
         "logos-package": "logos-package_37",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
@@ -40124,11 +32882,7 @@
     },
     "logos-package-manager_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_398",
-=======
         "logos-nix": "logos-nix_382",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_39",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
         "nix-bundle-dir": "nix-bundle-dir_62",
@@ -40154,11 +32908,7 @@
     },
     "logos-package-manager_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_443",
-=======
         "logos-nix": "logos-nix_423",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
         "nix-bundle-dir": "nix-bundle-dir_67",
@@ -40191,11 +32941,7 @@
     },
     "logos-package-manager_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_491",
-=======
         "logos-nix": "logos-nix_471",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_44",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
         "nix-bundle-dir": "nix-bundle-dir_73",
@@ -40232,11 +32978,7 @@
     },
     "logos-package-manager_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_504",
-=======
         "logos-nix": "logos-nix_484",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
         "nix-bundle-dir": "nix-bundle-dir_76",
@@ -40270,11 +33012,7 @@
     },
     "logos-package-manager_19": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_524",
-=======
         "logos-nix": "logos-nix_504",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
         "nix-bundle-dir": "nix-bundle-dir_79",
@@ -40337,11 +33075,7 @@
     },
     "logos-package-manager_20": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_533",
-=======
         "logos-nix": "logos-nix_513",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
         "nix-bundle-dir": "nix-bundle-dir_82",
@@ -40371,11 +33105,7 @@
     },
     "logos-package-manager_21": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_557",
-=======
         "logos-nix": "logos-nix_537",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_52",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
         "nix-bundle-dir": "nix-bundle-dir_85",
@@ -40404,13 +33134,8 @@
     },
     "logos-package-manager_22": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_565",
-        "logos-package": "logos-package_54",
-=======
         "logos-nix": "logos-nix_542",
         "logos-package": "logos-package_53",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_38",
         "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
@@ -40436,13 +33161,8 @@
     },
     "logos-package-manager_23": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_609",
-        "logos-package": "logos-package_56",
-=======
         "logos-nix": "logos-nix_579",
         "logos-package": "logos-package_55",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_41",
         "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
@@ -40474,11 +33194,7 @@
     },
     "logos-package-manager_24": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_657",
-=======
         "logos-nix": "logos-nix_626",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_59",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
         "nix-bundle-dir": "nix-bundle-dir_98",
@@ -40515,11 +33231,7 @@
     },
     "logos-package-manager_25": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_670",
-=======
         "logos-nix": "logos-nix_639",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_61",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
         "nix-bundle-dir": "nix-bundle-dir_101",
@@ -40553,11 +33265,7 @@
     },
     "logos-package-manager_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_690",
-=======
         "logos-nix": "logos-nix_659",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
         "nix-bundle-dir": "nix-bundle-dir_104",
@@ -40590,11 +33298,7 @@
     },
     "logos-package-manager_27": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_699",
-=======
         "logos-nix": "logos-nix_668",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_47",
         "nix-bundle-dir": "nix-bundle-dir_107",
@@ -40624,11 +33328,7 @@
     },
     "logos-package-manager_28": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_723",
-=======
         "logos-nix": "logos-nix_688",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_67",
         "nix-bundle-appimage": "nix-bundle-appimage_48",
         "nix-bundle-dir": "nix-bundle-dir_110",
@@ -40657,13 +33357,8 @@
     },
     "logos-package-manager_29": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_742",
-        "logos-package": "logos-package_70",
-=======
         "logos-nix": "logos-nix_704",
         "logos-package": "logos-package_69",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_50",
         "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
@@ -40876,11 +33571,7 @@
     },
     "logos-package-manager_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_271",
-=======
         "logos-nix": "logos-nix_263",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_25",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_40",
@@ -41334,11 +34025,7 @@
     },
     "logos-package_24": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_268",
-=======
         "logos-nix": "logos-nix_260",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41368,11 +34055,7 @@
     },
     "logos-package_25": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_272",
-=======
         "logos-nix": "logos-nix_264",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41403,11 +34086,7 @@
     },
     "logos-package_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_277",
-=======
         "logos-nix": "logos-nix_269",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41438,9 +34117,6 @@
     },
     "logos-package_27": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_316",
-=======
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41477,7 +34153,6 @@
     "logos-package_28": {
       "inputs": {
         "logos-nix": "logos-nix_307",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41509,50 +34184,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-package_28": {
-      "inputs": {
-        "logos-nix": "logos-nix_320",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786463662,
-        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_29": {
-      "inputs": {
-        "logos-nix": "logos-nix_325",
-=======
     "logos-package_29": {
       "inputs": {
         "logos-nix": "logos-nix_311",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41614,11 +34248,7 @@
     },
     "logos-package_30": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_333",
-=======
         "logos-nix": "logos-nix_316",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41653,11 +34283,7 @@
     },
     "logos-package_31": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_349",
-=======
         "logos-nix": "logos-nix_324",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41689,11 +34315,7 @@
     },
     "logos-package_32": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_353",
-=======
         "logos-nix": "logos-nix_340",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41723,9 +34345,6 @@
     },
     "logos-package_33": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_358",
-=======
         "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -41758,7 +34377,6 @@
     "logos-package_34": {
       "inputs": {
         "logos-nix": "logos-nix_349",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41789,11 +34407,7 @@
     },
     "logos-package_35": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_362",
-=======
         "logos-nix": "logos-nix_353",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41810,37 +34424,7 @@
         "narHash": "sha256-v0Nbhy4YXm1d/luboCbIL4yNIgcfkRXVTs1jXucLoVY=",
         "owner": "logos-co",
         "repo": "logos-package",
-<<<<<<< HEAD
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_382",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-=======
         "rev": "49151f003690333764d73f956d64e1245e2a0c38",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -41851,9 +34435,6 @@
     },
     "logos-package_36": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_386",
-=======
         "logos-nix": "logos-nix_369",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -41881,7 +34462,6 @@
     "logos-package_37": {
       "inputs": {
         "logos-nix": "logos-nix_373",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -41897,38 +34477,7 @@
         "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-<<<<<<< HEAD
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_37": {
-      "inputs": {
-        "logos-nix": "logos-nix_391",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-=======
         "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -41939,11 +34488,7 @@
     },
     "logos-package_38": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_394",
-=======
         "logos-nix": "logos-nix_378",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -41968,11 +34513,7 @@
     },
     "logos-package_39": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_399",
-=======
         "logos-nix": "logos-nix_383",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "logos-package",
@@ -42023,11 +34564,7 @@
     },
     "logos-package_40": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_440",
-=======
         "logos-nix": "logos-nix_420",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42057,11 +34594,7 @@
     },
     "logos-package_41": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_444",
-=======
         "logos-nix": "logos-nix_424",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42092,11 +34625,7 @@
     },
     "logos-package_42": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_449",
-=======
         "logos-nix": "logos-nix_429",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42127,11 +34656,7 @@
     },
     "logos-package_43": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_488",
-=======
         "logos-nix": "logos-nix_468",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42165,11 +34690,7 @@
     },
     "logos-package_44": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_492",
-=======
         "logos-nix": "logos-nix_472",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42204,11 +34725,7 @@
     },
     "logos-package_45": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_497",
-=======
         "logos-nix": "logos-nix_477",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42243,11 +34760,7 @@
     },
     "logos-package_46": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_505",
-=======
         "logos-nix": "logos-nix_485",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42279,11 +34792,7 @@
     },
     "logos-package_47": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_521",
-=======
         "logos-nix": "logos-nix_501",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42313,11 +34822,7 @@
     },
     "logos-package_48": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_525",
-=======
         "logos-nix": "logos-nix_505",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42348,11 +34853,7 @@
     },
     "logos-package_49": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_530",
-=======
         "logos-nix": "logos-nix_510",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42411,11 +34912,7 @@
     },
     "logos-package_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_534",
-=======
         "logos-nix": "logos-nix_514",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42443,11 +34940,7 @@
     },
     "logos-package_51": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_554",
-=======
         "logos-nix": "logos-nix_534",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42473,11 +34966,7 @@
     },
     "logos-package_52": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_558",
-=======
         "logos-nix": "logos-nix_538",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -42504,38 +34993,7 @@
     },
     "logos-package_53": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_563",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_54": {
-      "inputs": {
-        "logos-nix": "logos-nix_566",
-=======
         "logos-nix": "logos-nix_543",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -42560,11 +35018,7 @@
     },
     "logos-package_54": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_606",
-=======
         "logos-nix": "logos-nix_576",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42594,11 +35048,7 @@
     },
     "logos-package_55": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_610",
-=======
         "logos-nix": "logos-nix_580",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42629,11 +35079,7 @@
     },
     "logos-package_56": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_615",
-=======
         "logos-nix": "logos-nix_585",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42699,11 +35145,7 @@
     },
     "logos-package_58": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_654",
-=======
         "logos-nix": "logos-nix_623",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42737,11 +35179,7 @@
     },
     "logos-package_59": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_658",
-=======
         "logos-nix": "logos-nix_627",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42804,11 +35242,7 @@
     },
     "logos-package_60": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_663",
-=======
         "logos-nix": "logos-nix_632",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42843,11 +35277,7 @@
     },
     "logos-package_61": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_671",
-=======
         "logos-nix": "logos-nix_640",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42879,11 +35309,7 @@
     },
     "logos-package_62": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_687",
-=======
         "logos-nix": "logos-nix_656",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42913,11 +35339,7 @@
     },
     "logos-package_63": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_691",
-=======
         "logos-nix": "logos-nix_660",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42948,11 +35370,7 @@
     },
     "logos-package_64": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_696",
-=======
         "logos-nix": "logos-nix_665",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42983,11 +35401,7 @@
     },
     "logos-package_65": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_700",
-=======
         "logos-nix": "logos-nix_669",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43015,11 +35429,7 @@
     },
     "logos-package_66": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_720",
-=======
         "logos-nix": "logos-nix_685",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43045,11 +35455,7 @@
     },
     "logos-package_67": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_724",
-=======
         "logos-nix": "logos-nix_689",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43076,11 +35482,7 @@
     },
     "logos-package_68": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_729",
-=======
         "logos-nix": "logos-nix_693",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-package",
@@ -43104,11 +35506,7 @@
     },
     "logos-package_69": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_731",
-=======
         "logos-nix": "logos-nix_705",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -43162,36 +35560,7 @@
     },
     "logos-package_70": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_743",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "logos-package",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-package",
-        "type": "github"
-      }
-    },
-    "logos-package_71": {
-      "inputs": {
-        "logos-nix": "logos-nix_748",
-=======
         "logos-nix": "logos-nix_710",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -43311,15 +35680,9 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_93",
-        "logos-module": "logos-module_68",
-        "logos-nix": "logos-nix_305",
-=======
         "logos-lidl": "logos-lidl_90",
         "logos-module": "logos-module_66",
         "logos-nix": "logos-nix_296",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -43365,15 +35728,9 @@
     },
     "logos-plugin-core_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_117",
-        "logos-module": "logos-module_84",
-        "logos-nix": "logos-nix_408",
-=======
         "logos-lidl": "logos-lidl_113",
         "logos-module": "logos-module_80",
         "logos-nix": "logos-nix_391",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43403,15 +35760,9 @@
     },
     "logos-plugin-core_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_125",
-        "logos-module": "logos-module_90",
-        "logos-nix": "logos-nix_429",
-=======
         "logos-lidl": "logos-lidl_121",
         "logos-module": "logos-module_85",
         "logos-nix": "logos-nix_409",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43449,15 +35800,9 @@
     },
     "logos-plugin-core_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_135",
-        "logos-module": "logos-module_97",
-        "logos-nix": "logos-nix_460",
-=======
         "logos-lidl": "logos-lidl_131",
         "logos-module": "logos-module_92",
         "logos-nix": "logos-nix_440",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43495,15 +35840,9 @@
     },
     "logos-plugin-core_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_141",
-        "logos-module": "logos-module_102",
-        "logos-nix": "logos-nix_477",
-=======
         "logos-lidl": "logos-lidl_137",
         "logos-module": "logos-module_97",
         "logos-nix": "logos-nix_457",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -43549,15 +35888,9 @@
     },
     "logos-plugin-core_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_165",
-        "logos-module": "logos-module_118",
-        "logos-nix": "logos-nix_575",
-=======
         "logos-lidl": "logos-lidl_161",
         "logos-module": "logos-module_113",
         "logos-nix": "logos-nix_551",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43587,15 +35920,9 @@
     },
     "logos-plugin-core_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_173",
-        "logos-module": "logos-module_123",
-        "logos-nix": "logos-nix_595",
-=======
         "logos-lidl": "logos-lidl_167",
         "logos-module": "logos-module_117",
         "logos-nix": "logos-nix_565",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43633,15 +35960,9 @@
     },
     "logos-plugin-core_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_183",
-        "logos-module": "logos-module_130",
-        "logos-nix": "logos-nix_626",
-=======
         "logos-lidl": "logos-lidl_176",
         "logos-module": "logos-module_124",
         "logos-nix": "logos-nix_595",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43679,15 +36000,9 @@
     },
     "logos-plugin-core_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_189",
-        "logos-module": "logos-module_135",
-        "logos-nix": "logos-nix_643",
-=======
         "logos-lidl": "logos-lidl_182",
         "logos-module": "logos-module_129",
         "logos-nix": "logos-nix_612",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -43917,11 +36232,7 @@
       "inputs": {
         "logos-lidl": "logos-lidl_69",
         "logos-module": "logos-module_50",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_236",
-=======
         "logos-nix": "logos-nix_235",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -43951,15 +36262,9 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_77",
-        "logos-module": "logos-module_56",
-        "logos-nix": "logos-nix_257",
-=======
         "logos-lidl": "logos-lidl_75",
         "logos-module": "logos-module_54",
         "logos-nix": "logos-nix_249",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -43997,15 +36302,9 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_87",
-        "logos-module": "logos-module_63",
-        "logos-nix": "logos-nix_288",
-=======
         "logos-lidl": "logos-lidl_84",
         "logos-module": "logos-module_61",
         "logos-nix": "logos-nix_279",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44518,38 +36817,6 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_19": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_47",
-        "logos-module": "logos-module_35",
-        "logos-nix": "logos-nix_159",
-        "logos-protocol": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
     "logos-plugin-qt_2": {
       "inputs": {
         "logos-lidl": "logos-lidl_6",
@@ -44984,15 +37251,11 @@
       "inputs": {
         "logos-lidl": "logos-lidl_70",
         "logos-module": "logos-module_51",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_238",
-=======
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45007,19 +37270,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-=======
         "lastModified": 1789101842,
         "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "8af5b188225a22043c4380395d668e133fb1c873",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -45067,8 +37322,6 @@
     },
     "logos-plugin-qt_30": {
       "inputs": {
-<<<<<<< HEAD
-=======
         "logos-lidl": "logos-lidl_76",
         "logos-module": "logos-module_55",
         "logos-nix": "logos-nix_251",
@@ -45109,7 +37362,6 @@
     },
     "logos-plugin-qt_31": {
       "inputs": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45120,11 +37372,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_52",
-=======
         "logos-module": "logos-module_56",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45152,62 +37400,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_31": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_54",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -45230,113 +37422,8 @@
     },
     "logos-plugin-qt_32": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_78",
-        "logos-module": "logos-module_57",
-        "logos-nix": "logos-nix_259",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_33": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_58",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_34": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_81",
-        "logos-module": "logos-module_59",
-=======
         "logos-lidl": "logos-lidl_79",
         "logos-module": "logos-module_57",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45382,17 +37469,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_35": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_84",
-        "logos-module": "logos-module_60",
-=======
     "logos-plugin-qt_33": {
       "inputs": {
         "logos-lidl": "logos-lidl_82",
         "logos-module": "logos-module_58",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45438,19 +37518,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_36": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_88",
-        "logos-module": "logos-module_64",
-        "logos-nix": "logos-nix_290",
-=======
     "logos-plugin-qt_34": {
       "inputs": {
         "logos-lidl": "logos-lidl_85",
         "logos-module": "logos-module_62",
         "logos-nix": "logos-nix_281",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45486,11 +37558,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_37": {
-=======
     "logos-plugin-qt_35": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -45502,11 +37570,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_65",
-=======
         "logos-module": "logos-module_63",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45554,19 +37618,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_38": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_94",
-        "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_307",
-=======
     "logos-plugin-qt_36": {
       "inputs": {
         "logos-lidl": "logos-lidl_91",
         "logos-module": "logos-module_67",
         "logos-nix": "logos-nix_298",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -45610,24 +37666,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_39": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-=======
     "logos-plugin-qt_37": {
       "inputs": {
         "logos-lidl": [
@@ -45768,7 +37806,6 @@
     "logos-plugin-qt_39": {
       "inputs": {
         "logos-lidl": "logos-lidl_97",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_70",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45781,11 +37818,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -45799,11 +37832,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -45817,13 +37846,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-=======
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -45877,72 +37900,7 @@
     },
     "logos-plugin-qt_40": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_97",
-        "logos-module": "logos-module_71",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_41": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_100",
-=======
         "logos-lidl": "logos-lidl_99",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_72",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -45953,12 +37911,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -45970,12 +37922,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -45987,12 +37933,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -46070,120 +38010,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
-          "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
-          "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
-          "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_43": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_105",
-        "logos-module": "logos-module_75",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_44": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_105",
-        "logos-module": "logos-module_76",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
@@ -46222,10 +38048,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_45": {
+    "logos-plugin-qt_43": {
       "inputs": {
-        "logos-lidl": "logos-lidl_108",
-        "logos-module": "logos-module_77",
+        "logos-lidl": "logos-lidl_105",
+        "logos-module": "logos-module_75",
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46233,8 +38059,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -46273,63 +38097,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_46": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_109",
-        "logos-module": "logos-module_78",
-        "logos-nix": "logos-nix_367",
-        "logos-protocol": "logos-protocol_57",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_47": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_79",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-=======
     "logos-plugin-qt_44": {
       "inputs": {
         "logos-lidl": "logos-lidl_107",
         "logos-module": "logos-module_76",
         "logos-nix": "logos-nix_361",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46359,46 +38131,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_48": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_111",
-        "logos-module": "logos-module_80",
-        "logos-nix": "logos-nix_374",
-        "logos-protocol": "logos-protocol_60",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_49": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_112",
-        "logos-module": "logos-module_81",
-=======
     "logos-plugin-qt_45": {
       "inputs": {
         "logos-lidl": "logos-lidl_108",
         "logos-module": "logos-module_77",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46432,65 +38168,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_5": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_10",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_50": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_115",
-        "logos-module": "logos-module_82",
-=======
     "logos-plugin-qt_46": {
       "inputs": {
         "logos-lidl": "logos-lidl_111",
         "logos-module": "logos-module_78",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46616,19 +38297,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_51": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_118",
-        "logos-module": "logos-module_85",
-        "logos-nix": "logos-nix_410",
-=======
     "logos-plugin-qt_49": {
       "inputs": {
         "logos-lidl": "logos-lidl_122",
         "logos-module": "logos-module_86",
         "logos-nix": "logos-nix_411",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46664,11 +38337,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_52": {
-=======
     "logos-plugin-qt_5": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-liblogos",
@@ -46677,11 +38346,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_86",
-=======
         "logos-module": "logos-module_10",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-liblogos",
           "logos-capability-module",
@@ -46720,42 +38385,26 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_53": {
-=======
     "logos-plugin-qt_50": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_88",
-=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
         "logos-module": "logos-module_87",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -46764,12 +38413,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-protocol"
         ],
@@ -46778,12 +38423,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "default-module-loader",
-=======
           "logos-capability-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -46804,13 +38445,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_54": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_126",
-        "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_431",
-=======
     "logos-plugin-qt_51": {
       "inputs": {
         "logos-lidl": "logos-lidl_125",
@@ -47014,7 +38648,6 @@
         "logos-lidl": "logos-lidl_138",
         "logos-module": "logos-module_98",
         "logos-nix": "logos-nix_459",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47039,86 +38672,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_55": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_92",
-=======
-        "logos-module": "logos-module_99",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
@@ -47140,13 +38693,21 @@
     },
     "logos-plugin-qt_56": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_129",
-        "logos-module": "logos-module_93",
-=======
-        "logos-lidl": "logos-lidl_141",
-        "logos-module": "logos-module_100",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_99",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47158,7 +38719,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -47172,7 +38733,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -47186,7 +38747,9 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
           "nixpkgs"
         ]
       },
@@ -47206,13 +38769,8 @@
     },
     "logos-plugin-qt_57": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_132",
-        "logos-module": "logos-module_94",
-=======
-        "logos-lidl": "logos-lidl_144",
-        "logos-module": "logos-module_101",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-lidl": "logos-lidl_141",
+        "logos-module": "logos-module_100",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47224,7 +38782,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -47238,7 +38796,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -47252,17 +38810,16 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
         "type": "github"
       },
       "original": {
@@ -47273,57 +38830,8 @@
     },
     "logos-plugin-qt_58": {
       "inputs": {
-        "logos-lidl": "logos-lidl_136",
-        "logos-module": "logos-module_98",
-        "logos-nix": "logos-nix_462",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_59": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_99",
+        "logos-lidl": "logos-lidl_144",
+        "logos-module": "logos-module_101",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47331,7 +38839,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
@@ -47341,92 +38853,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_6": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_16",
-        "logos-module": "logos-module_11",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_60": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_142",
-        "logos-module": "logos-module_103",
-        "logos-nix": "logos-nix_479",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -47440,14 +38871,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-view-module-runtime",
           "nixpkgs"
         ]
       },
       "locked": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "lastModified": 1787165449,
         "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
@@ -47463,26 +38891,8 @@
     },
     "logos-plugin-qt_59": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_104",
-=======
         "logos-lidl": "logos-lidl_146",
         "logos-module": "logos-module_103",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47492,12 +38902,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -47509,12 +38913,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -47551,11 +38949,6 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-=======
           "logos-test-framework",
           "logos-nix"
         ],
@@ -47669,7 +39062,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -47689,285 +39081,8 @@
     },
     "logos-plugin-qt_62": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_145",
-        "logos-module": "logos-module_105",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_63": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_148",
-        "logos-module": "logos-module_106",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_64": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_150",
-        "logos-module": "logos-module_108",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_65": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_152",
-        "logos-module": "logos-module_109",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_66": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_153",
-        "logos-module": "logos-module_110",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_67": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_156",
-        "logos-module": "logos-module_111",
-=======
         "logos-lidl": "logos-lidl_152",
         "logos-module": "logos-module_106",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48013,21 +39128,12 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_68": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_157",
-        "logos-module": "logos-module_112",
-        "logos-nix": "logos-nix_539",
-        "logos-protocol": "logos-protocol_86",
-=======
     "logos-plugin-qt_63": {
       "inputs": {
         "logos-lidl": "logos-lidl_153",
         "logos-module": "logos-module_107",
         "logos-nix": "logos-nix_519",
         "logos-protocol": "logos-protocol_79",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -48052,72 +39158,12 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_69": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_113",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_7": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_19",
-        "logos-module": "logos-module_12",
-        "logos-nix": [
-=======
     "logos-plugin-qt_64": {
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-liblogos",
           "logos-qt-sdk",
           "logos-lidl"
@@ -48200,21 +39246,18 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-view-module-runtime",
-=======
           "logos-test-framework",
           "nixpkgs"
         ]
@@ -48429,7 +39472,6 @@
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -48447,21 +39489,12 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_70": {
+    "logos-plugin-qt_71": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_159",
-        "logos-module": "logos-module_114",
-        "logos-nix": "logos-nix_546",
-        "logos-protocol": "logos-protocol_89",
-        "nixpkgs": [
-          "logos-package-manager-module",
-=======
         "logos-lidl": "logos-lidl_171",
         "logos-module": "logos-module_120",
         "logos-nix": [
           "logos-package-manager-ui",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -48505,79 +39538,36 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_71": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_160",
-        "logos-module": "logos-module_115",
-=======
-        "logos-lidl": "logos-lidl_174",
-        "logos-module": "logos-module_121",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
     "logos-plugin-qt_72": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_163",
-        "logos-module": "logos-module_116",
+        "logos-lidl": "logos-lidl_174",
+        "logos-module": "logos-module_121",
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -48599,300 +39589,9 @@
     },
     "logos-plugin-qt_73": {
       "inputs": {
-        "logos-lidl": "logos-lidl_166",
-        "logos-module": "logos-module_119",
-        "logos-nix": "logos-nix_577",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1788230090,
-        "narHash": "sha256-SHO7g0AqKt2trDMRag0VZHTbIA2EYTZuW1tuKu/YQSc=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "5ef95a4172bf9d0f541f37e7573598f395fb49ef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_74": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_121",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_75": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_174",
-        "logos-module": "logos-module_124",
-        "logos-nix": "logos-nix_597",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_76": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_125",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_77": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_177",
-        "logos-module": "logos-module_126",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_78": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_180",
-        "logos-module": "logos-module_127",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_79": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_184",
-        "logos-module": "logos-module_131",
-        "logos-nix": "logos-nix_628",
-=======
         "logos-lidl": "logos-lidl_177",
         "logos-module": "logos-module_125",
         "logos-nix": "logos-nix_597",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48928,45 +39627,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_8": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_22",
-        "logos-module": "logos-module_16",
-        "logos-nix": "logos-nix_71",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787747885,
-        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_80": {
-=======
     "logos-plugin-qt_74": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -48978,11 +39639,7 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
-<<<<<<< HEAD
-        "logos-module": "logos-module_132",
-=======
         "logos-module": "logos-module_126",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49030,19 +39687,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_81": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_190",
-        "logos-module": "logos-module_136",
-        "logos-nix": "logos-nix_645",
-=======
     "logos-plugin-qt_75": {
       "inputs": {
         "logos-lidl": "logos-lidl_183",
         "logos-module": "logos-module_130",
         "logos-nix": "logos-nix_614",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49086,87 +39735,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_82": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_137",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_83": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_193",
-=======
     "logos-plugin-qt_76": {
       "inputs": {
         "logos-lidl": [
@@ -49552,7 +40120,6 @@
     "logos-plugin-qt_82": {
       "inputs": {
         "logos-lidl": "logos-lidl_197",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_138",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -49561,281 +40128,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_84": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_196",
-        "logos-module": "logos-module_139",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_85": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_198",
-        "logos-module": "logos-module_141",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_86": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_200",
-        "logos-module": "logos-module_142",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787275742,
-        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_87": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_201",
-        "logos-module": "logos-module_143",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_88": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_204",
-        "logos-module": "logos-module_144",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -49874,111 +40166,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_89": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_205",
-        "logos-module": "logos-module_145",
-        "logos-nix": "logos-nix_705",
-        "logos-protocol": "logos-protocol_115",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_9": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_17",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_90": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
-        "logos-module": "logos-module_146",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-=======
     "logos-plugin-qt_83": {
       "inputs": {
         "logos-lidl": "logos-lidl_199",
         "logos-module": "logos-module_139",
         "logos-nix": "logos-nix_677",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50008,46 +40200,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_91": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_207",
-        "logos-module": "logos-module_147",
-        "logos-nix": "logos-nix_712",
-        "logos-protocol": "logos-protocol_118",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_92": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_208",
-        "logos-module": "logos-module_148",
-=======
     "logos-plugin-qt_84": {
       "inputs": {
         "logos-lidl": "logos-lidl_200",
         "logos-module": "logos-module_140",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50081,17 +40237,10 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_93": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_211",
-        "logos-module": "logos-module_149",
-=======
     "logos-plugin-qt_85": {
       "inputs": {
         "logos-lidl": "logos-lidl_203",
         "logos-module": "logos-module_141",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50125,19 +40274,11 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-plugin-qt_94": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_212",
-        "logos-module": "logos-module_150",
-        "logos-nix": "logos-nix_733",
-=======
     "logos-plugin-qt_86": {
       "inputs": {
         "logos-lidl": "logos-lidl_204",
         "logos-module": "logos-module_142",
         "logos-nix": "logos-nix_695",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -50153,8 +40294,6 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "8af5b188225a22043c4380395d668e133fb1c873",
-<<<<<<< HEAD
-=======
         "type": "github"
       },
       "original": {
@@ -50203,7 +40342,6 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -50251,8 +40389,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-<<<<<<< HEAD
-=======
           "nixpkgs"
         ]
       },
@@ -50298,45 +40434,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_100": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -50356,395 +40453,7 @@
     },
     "logos-protocol_101": {
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_102": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_103": {
-      "inputs": {
-        "logos-nix": "logos-nix_629",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_104": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_105": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_106": {
-      "inputs": {
-        "logos-nix": "logos-nix_646",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_107": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_108": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_109": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_11": {
-      "inputs": {
-        "logos-nix": "logos-nix_72",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_110": {
-      "inputs": {
-        "logos-nix": "logos-nix_676",
-=======
         "logos-nix": "logos-nix_645",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50773,11 +40482,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_111": {
-=======
     "logos-protocol_102": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -50814,11 +40519,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_112": {
-=======
     "logos-protocol_103": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -50855,11 +40556,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_113": {
-=======
     "logos-protocol_104": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -50900,11 +40597,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_114": {
-=======
     "logos-protocol_105": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -50941,145 +40634,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_115": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_116": {
-      "inputs": {
-        "logos-nix": "logos-nix_706",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_117": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_118": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_119": {
-      "inputs": {
-        "logos-nix": "logos-nix_713",
-=======
     "logos-protocol_106": {
       "inputs": {
         "logos-nix": "logos-nix_678",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51090,19 +40647,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-=======
         "lastModified": 1789101259,
         "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -51111,44 +40660,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_12": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_120": {
-=======
     "logos-protocol_107": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -51177,11 +40689,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_121": {
-=======
     "logos-protocol_108": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -51210,11 +40718,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_122": {
-=======
     "logos-protocol_109": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_696",
         "nixpkgs": [
@@ -51263,11 +40767,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_123": {
-      "inputs": {
-        "logos-nix": "logos-nix_734",
-=======
     "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
@@ -51277,7 +40776,6 @@
           "logos-rust-sdk",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51289,19 +40787,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1789101259,
-        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
-=======
         "lastModified": 1787580993,
         "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -51320,8 +40810,6 @@
           "logos-cpp-sdk",
           "logos-nix"
         ],
-<<<<<<< HEAD
-=======
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51350,7 +40838,6 @@
     "logos-protocol_14": {
       "inputs": {
         "logos-nix": "logos-nix_89",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -51361,49 +40848,6 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_14": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_89",
-=======
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -52164,15 +41608,11 @@
     },
     "logos-protocol_36": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_239",
-=======
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52255,42 +41695,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_37": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_38": {
-=======
     "logos-protocol_39": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -52310,34 +41715,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_39": {
-      "inputs": {
-        "logos-nix": "logos-nix_249",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -52392,77 +41769,6 @@
     },
     "logos-protocol_40": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_260",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_41": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_42": {
-      "inputs": {
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52498,11 +41804,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_43": {
-=======
     "logos-protocol_41": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -52543,9 +41845,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_44": {
-=======
     "logos-protocol_42": {
       "inputs": {
         "logos-nix": [
@@ -52652,121 +41951,12 @@
       }
     },
     "logos-protocol_45": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_45": {
-      "inputs": {
-        "logos-nix": "logos-nix_291",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_46": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_47": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -52801,15 +41991,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_48": {
-      "inputs": {
-        "logos-nix": "logos-nix_308",
-=======
     "logos-protocol_46": {
       "inputs": {
         "logos-nix": "logos-nix_299",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52840,11 +42024,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_49": {
-=======
     "logos-protocol_47": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -52889,8 +42069,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-protocol_48": {
       "inputs": {
         "logos-nix": [
@@ -52985,7 +42163,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-protocol_5": {
       "inputs": {
         "logos-nix": [
@@ -53017,105 +42194,7 @@
     },
     "logos-protocol_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_51": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_52": {
-      "inputs": {
-        "logos-nix": "logos-nix_338",
-=======
         "logos-nix": "logos-nix_329",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -53144,11 +42223,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_53": {
-=======
     "logos-protocol_51": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53185,11 +42260,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_54": {
-=======
     "logos-protocol_52": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53226,11 +42297,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_55": {
-=======
     "logos-protocol_53": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53271,11 +42338,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_56": {
-=======
     "logos-protocol_54": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53312,171 +42375,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_57": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_58": {
-      "inputs": {
-        "logos-nix": "logos-nix_368",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_59": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_6": {
-      "inputs": {
-        "logos-nix": "logos-nix_42",
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_60": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_61": {
-      "inputs": {
-        "logos-nix": "logos-nix_375",
-=======
     "logos-protocol_55": {
       "inputs": {
         "logos-nix": "logos-nix_362",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -53487,19 +42388,11 @@
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-=======
         "lastModified": 1789101259,
         "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -53508,11 +42401,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_62": {
-=======
     "logos-protocol_56": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53541,11 +42430,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_63": {
-=======
     "logos-protocol_57": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -53867,11 +42752,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_64": {
-=======
     "logos-protocol_66": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -53908,36 +42789,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_65": {
-      "inputs": {
-        "logos-nix": "logos-nix_411",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_66": {
-=======
     "logos-protocol_67": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": "logos-nix_443",
         "nixpkgs": [
@@ -53966,44 +42818,8 @@
         "type": "github"
       }
     },
-    "logos-protocol_67": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
     "logos-protocol_68": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_421",
-=======
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -54054,7 +42870,6 @@
           "logos-cpp-sdk",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -54116,15 +42931,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_69": {
-      "inputs": {
-        "logos-nix": "logos-nix_432",
-=======
     "logos-protocol_70": {
       "inputs": {
         "logos-nix": "logos-nix_460",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -54138,84 +42947,6 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_7": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_70": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -54246,8 +42977,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
+          "logos-test-framework",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -54261,19 +42991,16 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -54296,276 +43023,6 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_73": {
-      "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_74": {
-      "inputs": {
-        "logos-nix": "logos-nix_463",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_75": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_76": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_77": {
-      "inputs": {
-        "logos-nix": "logos-nix_480",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_78": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_79": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -54601,38 +43058,7 @@
         "type": "github"
       }
     },
-    "logos-protocol_8": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_80": {
+    "logos-protocol_73": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -54677,12 +43103,9 @@
         "type": "github"
       }
     },
-    "logos-protocol_81": {
+    "logos-protocol_74": {
       "inputs": {
-        "logos-nix": "logos-nix_510",
-=======
         "logos-nix": "logos-nix_490",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -54711,11 +43134,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_82": {
-=======
     "logos-protocol_75": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -54752,11 +43171,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_83": {
-=======
     "logos-protocol_76": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -54793,11 +43208,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_84": {
-=======
     "logos-protocol_77": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -54838,9 +43249,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_85": {
-=======
     "logos-protocol_78": {
       "inputs": {
         "logos-nix": [
@@ -55128,304 +43536,10 @@
       }
     },
     "logos-protocol_86": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787344378,
-        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_86": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_87": {
-      "inputs": {
-        "logos-nix": "logos-nix_540",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_88": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_89": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_9": {
-      "inputs": {
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_90": {
-      "inputs": {
-        "logos-nix": "logos-nix_547",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_91": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787107309,
-        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_92": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_93": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -55450,11 +43564,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_94": {
-      "inputs": {
-        "logos-nix": "logos-nix_578",
-=======
     "logos-protocol_87": {
       "inputs": {
         "logos-nix": [
@@ -55462,7 +43571,6 @@
           "logos-module-builder",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55485,11 +43593,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_95": {
-=======
     "logos-protocol_88": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -55520,76 +43624,9 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_96": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_97": {
-      "inputs": {
-        "logos-nix": "logos-nix_587",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_98": {
-      "inputs": {
-        "logos-nix": "logos-nix_598",
-=======
     "logos-protocol_89": {
       "inputs": {
         "logos-nix": "logos-nix_568",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -55616,9 +43653,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-protocol_99": {
-=======
     "logos-protocol_9": {
       "inputs": {
         "logos-nix": [
@@ -55655,7 +43689,6 @@
       }
     },
     "logos-protocol_90": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -55694,8 +43727,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-=======
     "logos-protocol_91": {
       "inputs": {
         "logos-nix": [
@@ -56047,7 +44078,6 @@
         "type": "github"
       }
     },
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-qt-mcp": {
       "inputs": {
         "logos-nix": "logos-nix_124",
@@ -56103,11 +44133,7 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_343",
-=======
         "logos-nix": "logos-nix_334",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56137,11 +44163,7 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_376",
-=======
         "logos-nix": "logos-nix_363",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56167,11 +44189,7 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_515",
-=======
         "logos-nix": "logos-nix_495",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56201,11 +44219,7 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_548",
-=======
         "logos-nix": "logos-nix_528",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56231,11 +44245,7 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_681",
-=======
         "logos-nix": "logos-nix_650",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -56265,11 +44275,7 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_714",
-=======
         "logos-nix": "logos-nix_679",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -56295,11 +44301,7 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_735",
-=======
         "logos-nix": "logos-nix_697",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -56647,17 +44649,12 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_71",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_240",
-        "logos-plugin-qt": "logos-plugin-qt_30",
-=======
         "logos-nix": "logos-nix_237",
         "logos-plugin-qt": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-plugin-qt"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56734,7 +44731,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_17": {
+    "logos-qt-sdk_18": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -56746,11 +44743,6 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_75",
-        "logos-nix": "logos-nix_250",
-        "logos-plugin-qt": "logos-plugin-qt_31",
-=======
         "logos-lidl": "logos-lidl_80",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -56772,7 +44764,6 @@
           "logos-test-framework",
           "logos-plugin-qt"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56808,7 +44799,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_18": {
+    "logos-qt-sdk_19": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -56819,15 +44810,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_79",
-        "logos-nix": "logos-nix_261",
-        "logos-plugin-qt": "logos-plugin-qt_33",
-=======
         "logos-lidl": "logos-lidl_86",
         "logos-nix": "logos-nix_283",
         "logos-plugin-qt": "logos-plugin-qt_35",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56855,74 +44840,6 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_19": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_82",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -56986,208 +44903,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-<<<<<<< HEAD
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_89",
-        "logos-nix": "logos-nix_292",
-        "logos-plugin-qt": "logos-plugin-qt_37",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787538017,
-        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_21": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_95",
-        "logos-nix": "logos-nix_309",
-        "logos-plugin-qt": "logos-plugin-qt_39",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_22": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_98",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_23": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -57251,15 +44966,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_103",
-        "logos-nix": "logos-nix_339",
-=======
         "logos-lidl": "logos-lidl_95",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -57347,7 +45060,6 @@
         ],
         "logos-lidl": "logos-lidl_100",
         "logos-nix": "logos-nix_330",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57387,11 +45099,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_24": {
-=======
     "logos-qt-sdk_23": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -57403,11 +45111,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_106",
-=======
         "logos-lidl": "logos-lidl_103",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -57463,17 +45167,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_25": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_31",
-        "logos-lidl": "logos-lidl_110",
-        "logos-nix": "logos-nix_369",
-        "logos-plugin-qt": "logos-plugin-qt_47",
-        "logos-protocol": "logos-protocol_59",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-=======
     "logos-qt-sdk_24": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_29",
@@ -57586,7 +45279,6 @@
         ],
         "nixpkgs": [
           "logos-package-manager-module",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -57607,7 +45299,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_26": {
+    "logos-qt-sdk_27": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -57617,25 +45309,9 @@
           "default-module-loader",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_113",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-=======
         "logos-lidl": "logos-lidl_119",
         "logos-nix": "logos-nix_402",
         "logos-plugin-qt": "logos-plugin-qt_48",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57661,43 +45337,6 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_27": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_119",
-        "logos-nix": "logos-nix_412",
-        "logos-plugin-qt": "logos-plugin-qt_52",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
         "type": "github"
       },
       "original": {
@@ -57711,145 +45350,6 @@
         "logos-cpp-sdk": [
           "logos-package-manager-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_123",
-        "logos-nix": "logos-nix_422",
-        "logos-plugin-qt": "logos-plugin-qt_53",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_29": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_127",
-        "logos-nix": "logos-nix_433",
-        "logos-plugin-qt": "logos-plugin-qt_55",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_3": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_14",
-        "logos-nix": "logos-nix_43",
-        "logos-plugin-qt": "logos-plugin-qt_5",
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_30": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-=======
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -57901,17 +45401,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_130",
-=======
         "logos-lidl": "logos-lidl_126",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57967,9 +45462,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_31": {
-=======
     "logos-qt-sdk_3": {
       "inputs": {
         "logos-cpp-sdk": [
@@ -58011,7 +45503,6 @@
       }
     },
     "logos-qt-sdk_30": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -58022,15 +45513,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_137",
-        "logos-nix": "logos-nix_464",
-        "logos-plugin-qt": "logos-plugin-qt_59",
-=======
         "logos-lidl": "logos-lidl_133",
         "logos-nix": "logos-nix_444",
         "logos-plugin-qt": "logos-plugin-qt_54",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58066,11 +45551,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_32": {
-=======
     "logos-qt-sdk_31": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -58085,15 +45566,9 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_143",
-        "logos-nix": "logos-nix_481",
-        "logos-plugin-qt": "logos-plugin-qt_61",
-=======
         "logos-lidl": "logos-lidl_139",
         "logos-nix": "logos-nix_461",
         "logos-plugin-qt": "logos-plugin-qt_56",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58137,99 +45612,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_33": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_146",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_34": {
-=======
     "logos-qt-sdk_32": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -58240,12 +45623,11 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_151",
-        "logos-nix": "logos-nix_511",
-=======
         "logos-lidl": "logos-lidl_142",
         "logos-nix": [
           "logos-package-manager-module",
@@ -58333,7 +45715,6 @@
         ],
         "logos-lidl": "logos-lidl_147",
         "logos-nix": "logos-nix_491",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58373,11 +45754,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_35": {
-=======
     "logos-qt-sdk_34": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -58389,11 +45766,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_154",
-=======
         "logos-lidl": "logos-lidl_150",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58449,15 +45822,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_36": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_45",
-        "logos-lidl": "logos-lidl_158",
-        "logos-nix": "logos-nix_541",
-        "logos-plugin-qt": "logos-plugin-qt_69",
-        "logos-protocol": "logos-protocol_88",
-=======
     "logos-qt-sdk_35": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_43",
@@ -58556,7 +45920,6 @@
           "logos-module-builder",
           "logos-protocol"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58628,11 +45991,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_37": {
-=======
     "logos-qt-sdk_39": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -58644,11 +46003,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_161",
-=======
         "logos-lidl": "logos-lidl_172",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58704,32 +46059,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_38": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_167",
-        "logos-nix": "logos-nix_579",
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-=======
     "logos-qt-sdk_4": {
       "inputs": {
         "logos-cpp-sdk": [
@@ -58766,24 +46095,15 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
       "locked": {
-<<<<<<< HEAD
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
-=======
         "lastModified": 1787168233,
         "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -58792,11 +46112,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_39": {
-=======
     "logos-qt-sdk_40": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -58807,13 +46123,8 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_171",
-        "logos-nix": "logos-nix_588",
-=======
         "logos-lidl": "logos-lidl_178",
         "logos-nix": "logos-nix_599",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": "logos-plugin-qt_74",
         "logos-protocol": [
           "logos-package-manager-ui",
@@ -58850,60 +46161,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_4": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_17",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_40": {
+    "logos-qt-sdk_41": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -58918,13 +46176,8 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_175",
-        "logos-nix": "logos-nix_599",
-=======
         "logos-lidl": "logos-lidl_184",
         "logos-nix": "logos-nix_616",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": "logos-plugin-qt_76",
         "logos-protocol": [
           "logos-package-manager-ui",
@@ -58969,7 +46222,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_41": {
+    "logos-qt-sdk_42": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -58985,11 +46238,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_178",
-=======
         "logos-lidl": "logos-lidl_187",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -59053,56 +46302,6 @@
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_42": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-<<<<<<< HEAD
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_185",
-        "logos-nix": "logos-nix_630",
-        "logos-plugin-qt": "logos-plugin-qt_80",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787538017,
-        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -59122,166 +46321,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_191",
-        "logos-nix": "logos-nix_647",
-        "logos-plugin-qt": "logos-plugin-qt_82",
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_44": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_194",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_45": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_199",
-        "logos-nix": "logos-nix_677",
-=======
         "logos-lidl": "logos-lidl_192",
         "logos-nix": "logos-nix_646",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -59321,11 +46364,7 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_46": {
-=======
     "logos-qt-sdk_44": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -59337,11 +46376,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_202",
-=======
         "logos-lidl": "logos-lidl_195",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -59397,15 +46432,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_47": {
-      "inputs": {
-        "logos-cpp-sdk": "logos-cpp-sdk_59",
-        "logos-lidl": "logos-lidl_206",
-        "logos-nix": "logos-nix_707",
-        "logos-plugin-qt": "logos-plugin-qt_90",
-        "logos-protocol": "logos-protocol_117",
-=======
     "logos-qt-sdk_45": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_55",
@@ -59425,7 +46451,6 @@
           "logos-liblogos",
           "logos-protocol"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -59450,67 +46475,14 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "logos-qt-sdk_48": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-cpp-sdk"
-        ],
-        "logos-lidl": "logos-lidl_209",
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_49": {
-=======
     "logos-qt-sdk_46": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_213",
-        "logos-nix": "logos-nix_736",
-=======
         "logos-lidl": "logos-lidl_201",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -59558,7 +46530,6 @@
         ],
         "logos-lidl": "logos-lidl_205",
         "logos-nix": "logos-nix_698",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -59678,8 +46649,6 @@
       }
     },
     "logos-qt-sdk_7": {
-<<<<<<< HEAD
-=======
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -59753,7 +46722,6 @@
       }
     },
     "logos-qt-sdk_8": {
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -59763,79 +46731,6 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_32",
-        "logos-nix": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-nix"
-        ],
-        "logos-plugin-qt": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-plugin-qt"
-        ],
-        "logos-protocol": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-qt-sdk",
-        "type": "github"
-      }
-    },
-    "logos-qt-sdk_8": {
-      "inputs": {
-        "logos-cpp-sdk": [
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk"
-        ],
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_37",
         "logos-nix": "logos-nix_120",
         "logos-protocol": [
@@ -59967,11 +46862,7 @@
     },
     "logos-rust-sdk_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_96",
-=======
         "logos-lidl": "logos-lidl_93",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -60043,11 +46934,7 @@
     },
     "logos-rust-sdk_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_120",
-=======
         "logos-lidl": "logos-lidl_116",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60063,11 +46950,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_66",
-=======
         "logos-protocol": "logos-protocol_59",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60092,11 +46975,7 @@
     },
     "logos-rust-sdk_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_128",
-=======
         "logos-lidl": "logos-lidl_124",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60124,11 +47003,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_70",
-=======
         "logos-protocol": "logos-protocol_63",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60157,11 +47032,7 @@
     },
     "logos-rust-sdk_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_138",
-=======
         "logos-lidl": "logos-lidl_134",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60189,11 +47060,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_75",
-=======
         "logos-protocol": "logos-protocol_68",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60222,11 +47089,7 @@
     },
     "logos-rust-sdk_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_144",
-=======
         "logos-lidl": "logos-lidl_140",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -60298,11 +47161,7 @@
     },
     "logos-rust-sdk_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_168",
-=======
         "logos-lidl": "logos-lidl_164",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60318,11 +47177,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_95",
-=======
         "logos-protocol": "logos-protocol_88",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60347,11 +47202,7 @@
     },
     "logos-rust-sdk_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_176",
-=======
         "logos-lidl": "logos-lidl_170",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60379,11 +47230,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_99",
-=======
         "logos-protocol": "logos-protocol_90",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60412,11 +47259,7 @@
     },
     "logos-rust-sdk_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_186",
-=======
         "logos-lidl": "logos-lidl_179",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60444,11 +47287,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_104",
-=======
         "logos-protocol": "logos-protocol_95",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60477,11 +47316,7 @@
     },
     "logos-rust-sdk_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_192",
-=======
         "logos-lidl": "logos-lidl_185",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -60841,11 +47676,7 @@
     },
     "logos-rust-sdk_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_80",
-=======
         "logos-lidl": "logos-lidl_78",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -60873,11 +47704,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_41",
-=======
         "logos-protocol": "logos-protocol_39",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -60906,11 +47733,7 @@
     },
     "logos-rust-sdk_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-lidl": "logos-lidl_90",
-=======
         "logos-lidl": "logos-lidl_87",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -60938,11 +47761,7 @@
           "logos-module-builder",
           "logos-nix"
         ],
-<<<<<<< HEAD
-        "logos-protocol": "logos-protocol_46",
-=======
         "logos-protocol": "logos-protocol_44",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61061,15 +47880,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_372",
-        "logos-plugin-qt": "logos-plugin-qt_48",
-        "logos-protocol": "logos-protocol_61",
-=======
         "logos-nix": "logos-nix_359",
         "logos-plugin-qt": "logos-plugin-qt_44",
         "logos-protocol": "logos-protocol_55",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -61100,11 +47913,7 @@
     },
     "logos-standalone-app_4": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_26",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_24",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61115,15 +47924,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_341",
-        "logos-plugin-qt": "logos-plugin-qt_43",
-        "logos-protocol": "logos-protocol_53",
-=======
         "logos-nix": "logos-nix_332",
         "logos-plugin-qt": "logos-plugin-qt_41",
         "logos-protocol": "logos-protocol_51",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -61162,26 +47965,16 @@
     },
     "logos-standalone-app_5": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_34",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_32",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_6",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_544",
-        "logos-plugin-qt": "logos-plugin-qt_70",
-        "logos-protocol": "logos-protocol_90",
-=======
         "logos-nix": "logos-nix_524",
         "logos-plugin-qt": "logos-plugin-qt_65",
         "logos-protocol": "logos-protocol_83",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -61212,11 +48005,7 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_40",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_38",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61227,15 +48016,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_7",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_513",
-        "logos-plugin-qt": "logos-plugin-qt_65",
-        "logos-protocol": "logos-protocol_82",
-=======
         "logos-nix": "logos-nix_493",
         "logos-plugin-qt": "logos-plugin-qt_60",
         "logos-protocol": "logos-protocol_75",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -61274,26 +48057,16 @@
     },
     "logos-standalone-app_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_48",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_46",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_8",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_710",
-        "logos-plugin-qt": "logos-plugin-qt_91",
-        "logos-protocol": "logos-protocol_119",
-=======
         "logos-nix": "logos-nix_675",
         "logos-plugin-qt": "logos-plugin-qt_83",
         "logos-protocol": "logos-protocol_106",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -61324,11 +48097,7 @@
     },
     "logos-standalone-app_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_54",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_50",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61339,15 +48108,9 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_9",
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_679",
-        "logos-plugin-qt": "logos-plugin-qt_86",
-        "logos-protocol": "logos-protocol_111",
-=======
         "logos-nix": "logos-nix_648",
         "logos-plugin-qt": "logos-plugin-qt_80",
         "logos-protocol": "logos-protocol_102",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -61424,17 +48187,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_377",
-        "logos-plugin-qt": "logos-plugin-qt_49",
-        "logos-protocol": "logos-protocol_62",
-        "logos-qt-sdk": "logos-qt-sdk_26",
-=======
         "logos-nix": "logos-nix_364",
         "logos-plugin-qt": "logos-plugin-qt_45",
         "logos-protocol": "logos-protocol_56",
         "logos-qt-sdk": "logos-qt-sdk_25",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -61468,17 +48224,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_435",
-        "logos-plugin-qt": "logos-plugin-qt_56",
-        "logos-protocol": "logos-protocol_71",
-        "logos-qt-sdk": "logos-qt-sdk_30",
-=======
         "logos-nix": "logos-nix_415",
         "logos-plugin-qt": "logos-plugin-qt_51",
         "logos-protocol": "logos-protocol_64",
         "logos-qt-sdk": "logos-qt-sdk_29",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61520,17 +48269,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_483",
-        "logos-plugin-qt": "logos-plugin-qt_62",
-        "logos-protocol": "logos-protocol_78",
-        "logos-qt-sdk": "logos-qt-sdk_33",
-=======
         "logos-nix": "logos-nix_463",
         "logos-plugin-qt": "logos-plugin-qt_57",
         "logos-protocol": "logos-protocol_71",
         "logos-qt-sdk": "logos-qt-sdk_32",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61572,17 +48314,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_516",
-        "logos-plugin-qt": "logos-plugin-qt_66",
-        "logos-protocol": "logos-protocol_83",
-        "logos-qt-sdk": "logos-qt-sdk_35",
-=======
         "logos-nix": "logos-nix_496",
         "logos-plugin-qt": "logos-plugin-qt_61",
         "logos-protocol": "logos-protocol_76",
         "logos-qt-sdk": "logos-qt-sdk_34",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61616,17 +48351,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_549",
-        "logos-plugin-qt": "logos-plugin-qt_71",
-        "logos-protocol": "logos-protocol_91",
-        "logos-qt-sdk": "logos-qt-sdk_37",
-=======
         "logos-nix": "logos-nix_529",
         "logos-plugin-qt": "logos-plugin-qt_66",
         "logos-protocol": "logos-protocol_84",
         "logos-qt-sdk": "logos-qt-sdk_36",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -61660,17 +48388,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_601",
-        "logos-plugin-qt": "logos-plugin-qt_77",
-        "logos-protocol": "logos-protocol_100",
-        "logos-qt-sdk": "logos-qt-sdk_41",
-=======
         "logos-nix": "logos-nix_571",
         "logos-plugin-qt": "logos-plugin-qt_71",
         "logos-protocol": "logos-protocol_91",
         "logos-qt-sdk": "logos-qt-sdk_39",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61712,17 +48433,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_649",
-        "logos-plugin-qt": "logos-plugin-qt_83",
-        "logos-protocol": "logos-protocol_107",
-        "logos-qt-sdk": "logos-qt-sdk_44",
-=======
         "logos-nix": "logos-nix_618",
         "logos-plugin-qt": "logos-plugin-qt_77",
         "logos-protocol": "logos-protocol_98",
         "logos-qt-sdk": "logos-qt-sdk_42",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61764,17 +48478,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_682",
-        "logos-plugin-qt": "logos-plugin-qt_87",
-        "logos-protocol": "logos-protocol_112",
-        "logos-qt-sdk": "logos-qt-sdk_46",
-=======
         "logos-nix": "logos-nix_651",
         "logos-plugin-qt": "logos-plugin-qt_81",
         "logos-protocol": "logos-protocol_103",
         "logos-qt-sdk": "logos-qt-sdk_44",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -61808,17 +48515,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_715",
-        "logos-plugin-qt": "logos-plugin-qt_92",
-        "logos-protocol": "logos-protocol_120",
-        "logos-qt-sdk": "logos-qt-sdk_48",
-=======
         "logos-nix": "logos-nix_680",
         "logos-plugin-qt": "logos-plugin-qt_84",
         "logos-protocol": "logos-protocol_107",
         "logos-qt-sdk": "logos-qt-sdk_46",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -62039,17 +48739,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_263",
-        "logos-plugin-qt": "logos-plugin-qt_34",
-        "logos-protocol": "logos-protocol_42",
-        "logos-qt-sdk": "logos-qt-sdk_19",
-=======
         "logos-nix": "logos-nix_255",
         "logos-plugin-qt": "logos-plugin-qt_32",
         "logos-protocol": "logos-protocol_40",
         "logos-qt-sdk": "logos-qt-sdk_18",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62091,17 +48784,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_311",
-        "logos-plugin-qt": "logos-plugin-qt_40",
-        "logos-protocol": "logos-protocol_49",
-        "logos-qt-sdk": "logos-qt-sdk_22",
-=======
         "logos-nix": "logos-nix_302",
         "logos-plugin-qt": "logos-plugin-qt_38",
         "logos-protocol": "logos-protocol_47",
         "logos-qt-sdk": "logos-qt-sdk_21",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62143,17 +48829,10 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_344",
-        "logos-plugin-qt": "logos-plugin-qt_44",
-        "logos-protocol": "logos-protocol_54",
-        "logos-qt-sdk": "logos-qt-sdk_24",
-=======
         "logos-nix": "logos-nix_335",
         "logos-plugin-qt": "logos-plugin-qt_42",
         "logos-protocol": "logos-protocol_52",
         "logos-qt-sdk": "logos-qt-sdk_23",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62239,17 +48918,10 @@
     },
     "logos-view-module-runtime_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_32",
-        "logos-nix": "logos-nix_379",
-        "logos-plugin-qt": "logos-plugin-qt_50",
-        "logos-protocol": "logos-protocol_64",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-nix": "logos-nix_366",
         "logos-plugin-qt": "logos-plugin-qt_46",
         "logos-protocol": "logos-protocol_57",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62274,17 +48946,10 @@
     },
     "logos-view-module-runtime_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_37",
-        "logos-nix": "logos-nix_437",
-        "logos-plugin-qt": "logos-plugin-qt_57",
-        "logos-protocol": "logos-protocol_73",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-nix": "logos-nix_417",
         "logos-plugin-qt": "logos-plugin-qt_52",
         "logos-protocol": "logos-protocol_66",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62313,17 +48978,10 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_42",
-        "logos-nix": "logos-nix_485",
-        "logos-plugin-qt": "logos-plugin-qt_63",
-        "logos-protocol": "logos-protocol_80",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_40",
         "logos-nix": "logos-nix_465",
         "logos-plugin-qt": "logos-plugin-qt_58",
         "logos-protocol": "logos-protocol_73",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62356,17 +49014,10 @@
     },
     "logos-view-module-runtime_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_44",
-        "logos-nix": "logos-nix_518",
-        "logos-plugin-qt": "logos-plugin-qt_67",
-        "logos-protocol": "logos-protocol_85",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-nix": "logos-nix_498",
         "logos-plugin-qt": "logos-plugin-qt_62",
         "logos-protocol": "logos-protocol_78",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62395,17 +49046,10 @@
     },
     "logos-view-module-runtime_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_46",
-        "logos-nix": "logos-nix_551",
-        "logos-plugin-qt": "logos-plugin-qt_72",
-        "logos-protocol": "logos-protocol_93",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-nix": "logos-nix_531",
         "logos-plugin-qt": "logos-plugin-qt_67",
         "logos-protocol": "logos-protocol_86",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -62430,17 +49074,10 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_51",
-        "logos-nix": "logos-nix_603",
-        "logos-plugin-qt": "logos-plugin-qt_78",
-        "logos-protocol": "logos-protocol_102",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_48",
         "logos-nix": "logos-nix_573",
         "logos-plugin-qt": "logos-plugin-qt_72",
         "logos-protocol": "logos-protocol_93",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -62469,17 +49106,10 @@
     },
     "logos-view-module-runtime_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_56",
-        "logos-nix": "logos-nix_651",
-        "logos-plugin-qt": "logos-plugin-qt_84",
-        "logos-protocol": "logos-protocol_109",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_52",
         "logos-nix": "logos-nix_620",
         "logos-plugin-qt": "logos-plugin-qt_78",
         "logos-protocol": "logos-protocol_100",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -62512,17 +49142,10 @@
     },
     "logos-view-module-runtime_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_58",
-        "logos-nix": "logos-nix_684",
-        "logos-plugin-qt": "logos-plugin-qt_88",
-        "logos-protocol": "logos-protocol_114",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_54",
         "logos-nix": "logos-nix_653",
         "logos-plugin-qt": "logos-plugin-qt_82",
         "logos-protocol": "logos-protocol_105",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -62551,17 +49174,10 @@
     },
     "logos-view-module-runtime_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_60",
-        "logos-nix": "logos-nix_717",
-        "logos-plugin-qt": "logos-plugin-qt_93",
-        "logos-protocol": "logos-protocol_122",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_56",
         "logos-nix": "logos-nix_682",
         "logos-plugin-qt": "logos-plugin-qt_85",
         "logos-protocol": "logos-protocol_108",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -62589,11 +49205,7 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_737",
-=======
         "logos-nix": "logos-nix_699",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -62773,17 +49385,10 @@
     },
     "logos-view-module-runtime_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_23",
-        "logos-nix": "logos-nix_265",
-        "logos-plugin-qt": "logos-plugin-qt_35",
-        "logos-protocol": "logos-protocol_44",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-nix": "logos-nix_257",
         "logos-plugin-qt": "logos-plugin-qt_33",
         "logos-protocol": "logos-protocol_42",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62812,17 +49417,10 @@
     },
     "logos-view-module-runtime_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_28",
-        "logos-nix": "logos-nix_313",
-        "logos-plugin-qt": "logos-plugin-qt_41",
-        "logos-protocol": "logos-protocol_51",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_26",
         "logos-nix": "logos-nix_304",
         "logos-plugin-qt": "logos-plugin-qt_39",
         "logos-protocol": "logos-protocol_49",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -62855,17 +49453,10 @@
     },
     "logos-view-module-runtime_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-cpp-sdk": "logos-cpp-sdk_30",
-        "logos-nix": "logos-nix_346",
-        "logos-plugin-qt": "logos-plugin-qt_45",
-        "logos-protocol": "logos-protocol_56",
-=======
         "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-nix": "logos-nix_337",
         "logos-plugin-qt": "logos-plugin-qt_43",
         "logos-protocol": "logos-protocol_54",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -63822,11 +50413,7 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_273",
-=======
         "logos-nix": "logos-nix_265",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -63992,11 +50579,7 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_321",
-=======
         "logos-nix": "logos-nix_312",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -64032,11 +50615,7 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_334",
-=======
         "logos-nix": "logos-nix_325",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -64069,11 +50648,7 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_354",
-=======
         "logos-nix": "logos-nix_345",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -64105,11 +50680,7 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_363",
-=======
         "logos-nix": "logos-nix_354",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -64138,11 +50709,7 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_387",
-=======
         "logos-nix": "logos-nix_374",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -64170,13 +50737,8 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_395",
-        "nix-bundle-dir": "nix-bundle-dir_60",
-=======
         "logos-nix": "logos-nix_379",
         "nix-bundle-dir": "nix-bundle-dir_59",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -64201,13 +50763,8 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_400",
-        "nix-bundle-dir": "nix-bundle-dir_62",
-=======
         "logos-nix": "logos-nix_384",
         "nix-bundle-dir": "nix-bundle-dir_61",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -64342,13 +50899,8 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_445",
-        "nix-bundle-dir": "nix-bundle-dir_67",
-=======
         "logos-nix": "logos-nix_425",
         "nix-bundle-dir": "nix-bundle-dir_66",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64485,13 +51037,8 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_493",
-        "nix-bundle-dir": "nix-bundle-dir_73",
-=======
         "logos-nix": "logos-nix_473",
         "nix-bundle-dir": "nix-bundle-dir_72",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64526,13 +51073,8 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_506",
-        "nix-bundle-dir": "nix-bundle-dir_76",
-=======
         "logos-nix": "logos-nix_486",
         "nix-bundle-dir": "nix-bundle-dir_75",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64564,13 +51106,8 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_526",
-        "nix-bundle-dir": "nix-bundle-dir_79",
-=======
         "logos-nix": "logos-nix_506",
         "nix-bundle-dir": "nix-bundle-dir_78",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64601,13 +51138,8 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_535",
-        "nix-bundle-dir": "nix-bundle-dir_82",
-=======
         "logos-nix": "logos-nix_515",
         "nix-bundle-dir": "nix-bundle-dir_81",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64635,13 +51167,8 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_559",
-        "nix-bundle-dir": "nix-bundle-dir_85",
-=======
         "logos-nix": "logos-nix_539",
         "nix-bundle-dir": "nix-bundle-dir_84",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -64668,13 +51195,8 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_567",
-        "nix-bundle-dir": "nix-bundle-dir_88",
-=======
         "logos-nix": "logos-nix_544",
         "nix-bundle-dir": "nix-bundle-dir_86",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -64819,13 +51341,8 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_611",
-        "nix-bundle-dir": "nix-bundle-dir_93",
-=======
         "logos-nix": "logos-nix_581",
         "nix-bundle-dir": "nix-bundle-dir_91",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -64962,13 +51479,8 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_659",
-        "nix-bundle-dir": "nix-bundle-dir_99",
-=======
         "logos-nix": "logos-nix_628",
         "nix-bundle-dir": "nix-bundle-dir_97",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65003,13 +51515,8 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_672",
-        "nix-bundle-dir": "nix-bundle-dir_102",
-=======
         "logos-nix": "logos-nix_641",
         "nix-bundle-dir": "nix-bundle-dir_100",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65041,13 +51548,8 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_692",
-        "nix-bundle-dir": "nix-bundle-dir_105",
-=======
         "logos-nix": "logos-nix_661",
         "nix-bundle-dir": "nix-bundle-dir_103",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65078,13 +51580,8 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_701",
-        "nix-bundle-dir": "nix-bundle-dir_108",
-=======
         "logos-nix": "logos-nix_670",
         "nix-bundle-dir": "nix-bundle-dir_106",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65112,13 +51609,8 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_725",
-        "nix-bundle-dir": "nix-bundle-dir_111",
-=======
         "logos-nix": "logos-nix_690",
         "nix-bundle-dir": "nix-bundle-dir_109",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65145,13 +51637,8 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_738",
-        "nix-bundle-dir": "nix-bundle-dir_114",
-=======
         "logos-nix": "logos-nix_700",
         "nix-bundle-dir": "nix-bundle-dir_111",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-appimage",
           "logos-nix",
@@ -65203,13 +51690,8 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_744",
-        "nix-bundle-dir": "nix-bundle-dir_116",
-=======
         "logos-nix": "logos-nix_706",
         "nix-bundle-dir": "nix-bundle-dir_113",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -65442,11 +51924,7 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_661",
-=======
         "logos-nix": "logos-nix_642",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65477,11 +51955,7 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_664",
-=======
         "logos-nix": "logos-nix_643",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65513,11 +51987,7 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_673",
-=======
         "logos-nix": "logos-nix_657",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65525,44 +51995,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-<<<<<<< HEAD
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_103": {
-      "inputs": {
-        "logos-nix": "logos-nix_674",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-package-manager",
-=======
           "nix-bundle-lgx",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -65584,11 +52017,7 @@
     },
     "nix-bundle-dir_103": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_688",
-=======
         "logos-nix": "logos-nix_662",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65649,72 +52078,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_693",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1773961179,
-        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_106": {
-      "inputs": {
-        "logos-nix": "logos-nix_694",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_107": {
-      "inputs": {
-        "logos-nix": "logos-nix_697",
-=======
         "logos-nix": "logos-nix_666",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65745,11 +52109,7 @@
     },
     "nix-bundle-dir_106": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_702",
-=======
         "logos-nix": "logos-nix_671",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65776,11 +52136,7 @@
     },
     "nix-bundle-dir_107": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_703",
-=======
         "logos-nix": "logos-nix_672",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65888,11 +52244,7 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_721",
-=======
         "logos-nix": "logos-nix_692",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -65919,11 +52271,7 @@
     },
     "nix-bundle-dir_111": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_726",
-=======
         "logos-nix": "logos-nix_701",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -65945,11 +52293,7 @@
     },
     "nix-bundle-dir_112": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_727",
-=======
         "logos-nix": "logos-nix_702",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-dir",
           "logos-nix",
@@ -65972,11 +52316,7 @@
     },
     "nix-bundle-dir_113": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_730",
-=======
         "logos-nix": "logos-nix_707",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -66000,11 +52340,7 @@
     },
     "nix-bundle-dir_114": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_739",
-=======
         "logos-nix": "logos-nix_708",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -66029,83 +52365,7 @@
     },
     "nix-bundle-dir_115": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_740",
-        "nixpkgs": [
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786576773,
-        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_116": {
-      "inputs": {
-        "logos-nix": "logos-nix_745",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_117": {
-      "inputs": {
-        "logos-nix": "logos-nix_746",
-        "nixpkgs": [
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786576773,
-        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_118": {
-      "inputs": {
-        "logos-nix": "logos-nix_749",
-=======
         "logos-nix": "logos-nix_711",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -66960,11 +53220,7 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_269",
-=======
         "logos-nix": "logos-nix_261",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -66994,11 +53250,7 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_274",
-=======
         "logos-nix": "logos-nix_266",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67055,11 +53307,7 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_275",
-=======
         "logos-nix": "logos-nix_267",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67090,11 +53338,7 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_278",
-=======
         "logos-nix": "logos-nix_270",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67207,11 +53451,7 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_317",
-=======
         "logos-nix": "logos-nix_308",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67245,11 +53485,7 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_322",
-=======
         "logos-nix": "logos-nix_313",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67283,11 +53519,7 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_323",
-=======
         "logos-nix": "logos-nix_314",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67322,11 +53554,7 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_326",
-=======
         "logos-nix": "logos-nix_317",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67361,11 +53589,7 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_335",
-=======
         "logos-nix": "logos-nix_326",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67396,11 +53620,7 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_336",
-=======
         "logos-nix": "logos-nix_327",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67459,11 +53679,7 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_350",
-=======
         "logos-nix": "logos-nix_341",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67493,11 +53709,7 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_355",
-=======
         "logos-nix": "logos-nix_346",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67527,11 +53739,7 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_356",
-=======
         "logos-nix": "logos-nix_347",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67562,11 +53770,7 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_359",
-=======
         "logos-nix": "logos-nix_350",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67597,11 +53801,7 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_364",
-=======
         "logos-nix": "logos-nix_355",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67628,11 +53828,7 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_365",
-=======
         "logos-nix": "logos-nix_356",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67660,11 +53856,7 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_383",
-=======
         "logos-nix": "logos-nix_370",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67690,11 +53882,7 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_388",
-=======
         "logos-nix": "logos-nix_375",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67720,11 +53908,7 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_389",
-=======
         "logos-nix": "logos-nix_376",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -67751,11 +53935,7 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_392",
-=======
         "logos-nix": "logos-nix_380",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -67804,11 +53984,7 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_396",
-=======
         "logos-nix": "logos-nix_381",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -67833,36 +54009,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_397",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-package-downloader",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786576773,
-        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_401",
-=======
         "logos-nix": "logos-nix_385",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -67885,11 +54032,7 @@
     },
     "nix-bundle-dir_62": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_402",
-=======
         "logos-nix": "logos-nix_386",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-dir",
@@ -67979,48 +54122,7 @@
     },
     "nix-bundle-dir_65": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_66": {
-      "inputs": {
-        "logos-nix": "logos-nix_441",
-=======
         "logos-nix": "logos-nix_421",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68050,11 +54152,7 @@
     },
     "nix-bundle-dir_66": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_446",
-=======
         "logos-nix": "logos-nix_426",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68084,11 +54182,7 @@
     },
     "nix-bundle-dir_67": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_447",
-=======
         "logos-nix": "logos-nix_427",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68119,11 +54213,7 @@
     },
     "nix-bundle-dir_68": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_450",
-=======
         "logos-nix": "logos-nix_430",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68267,56 +54357,7 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_72": {
-      "inputs": {
-        "logos-nix": "logos-nix_489",
-=======
         "logos-nix": "logos-nix_469",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68350,11 +54391,7 @@
     },
     "nix-bundle-dir_72": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_494",
-=======
         "logos-nix": "logos-nix_474",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68388,11 +54425,7 @@
     },
     "nix-bundle-dir_73": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_495",
-=======
         "logos-nix": "logos-nix_475",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68462,46 +54495,7 @@
     },
     "nix-bundle-dir_75": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_498",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_507",
-=======
         "logos-nix": "logos-nix_487",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68532,11 +54526,7 @@
     },
     "nix-bundle-dir_76": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_508",
-=======
         "logos-nix": "logos-nix_488",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68598,41 +54588,7 @@
     },
     "nix-bundle-dir_78": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_522",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_79": {
-      "inputs": {
-        "logos-nix": "logos-nix_527",
-=======
         "logos-nix": "logos-nix_507",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68720,11 +54676,7 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_528",
-=======
         "logos-nix": "logos-nix_511",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68755,11 +54707,7 @@
     },
     "nix-bundle-dir_81": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_531",
-=======
         "logos-nix": "logos-nix_516",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68786,11 +54734,7 @@
     },
     "nix-bundle-dir_82": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_536",
-=======
         "logos-nix": "logos-nix_517",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68818,11 +54762,7 @@
     },
     "nix-bundle-dir_83": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_537",
-=======
         "logos-nix": "logos-nix_535",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68848,11 +54788,7 @@
     },
     "nix-bundle-dir_84": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_555",
-=======
         "logos-nix": "logos-nix_540",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68878,37 +54814,7 @@
     },
     "nix-bundle-dir_85": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_560",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_86": {
-      "inputs": {
-        "logos-nix": "logos-nix_561",
-=======
         "logos-nix": "logos-nix_541",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -68935,11 +54841,7 @@
     },
     "nix-bundle-dir_86": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_564",
-=======
         "logos-nix": "logos-nix_545",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -69015,35 +54917,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "nix-bundle-dir_88": {
-      "inputs": {
-        "logos-nix": "logos-nix_568",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_89": {
-      "inputs": {
-        "logos-nix": "logos-nix_569",
-=======
     "nix-bundle-dir_89": {
       "inputs": {
         "logos-nix": [
@@ -69056,7 +54929,6 @@
           "logos-design-system",
           "logos-nix"
         ],
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69111,77 +54983,7 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_91": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_92": {
-      "inputs": {
-        "logos-nix": "logos-nix_607",
-=======
         "logos-nix": "logos-nix_577",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69211,11 +55013,7 @@
     },
     "nix-bundle-dir_91": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_612",
-=======
         "logos-nix": "logos-nix_582",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69245,11 +55043,7 @@
     },
     "nix-bundle-dir_92": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_613",
-=======
         "logos-nix": "logos-nix_583",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69280,11 +55074,7 @@
     },
     "nix-bundle-dir_93": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_616",
-=======
         "logos-nix": "logos-nix_586",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69397,93 +55187,7 @@
     },
     "nix-bundle-dir_96": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_97": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-design-system",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_98": {
-      "inputs": {
-        "logos-nix": "logos-nix_655",
-=======
         "logos-nix": "logos-nix_624",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69517,11 +55221,7 @@
     },
     "nix-bundle-dir_97": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_660",
-=======
         "logos-nix": "logos-nix_629",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -69739,11 +55439,7 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_267",
-=======
         "logos-nix": "logos-nix_259",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_24",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -69774,11 +55470,7 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_276",
-=======
         "logos-nix": "logos-nix_268",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_26",
         "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
@@ -69810,13 +55502,8 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_315",
-        "logos-package": "logos-package_27",
-=======
         "logos-nix": "logos-nix_306",
         "logos-package": "logos-package_28",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -69850,13 +55537,8 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_324",
-        "logos-package": "logos-package_29",
-=======
         "logos-nix": "logos-nix_315",
         "logos-package": "logos-package_30",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -69891,13 +55573,8 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_348",
-        "logos-package": "logos-package_31",
-=======
         "logos-nix": "logos-nix_339",
         "logos-package": "logos-package_32",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -69927,13 +55604,8 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_357",
-        "logos-package": "logos-package_33",
-=======
         "logos-nix": "logos-nix_348",
         "logos-package": "logos-package_34",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -69964,13 +55636,8 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_381",
-        "logos-package": "logos-package_35",
-=======
         "logos-nix": "logos-nix_368",
         "logos-package": "logos-package_36",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -70024,15 +55691,9 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_390",
-        "logos-package": "logos-package_37",
-        "nix-bundle-dir": "nix-bundle-dir_59",
-=======
         "logos-nix": "logos-nix_419",
         "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_65",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -70061,42 +55722,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_439",
-        "logos-package": "logos-package_40",
-        "nix-bundle-dir": "nix-bundle-dir_66",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_22": {
-      "inputs": {
-        "logos-nix": "logos-nix_448",
-=======
         "logos-nix": "logos-nix_428",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_42",
         "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
@@ -70128,11 +55754,7 @@
     },
     "nix-bundle-lgx_22": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_487",
-=======
         "logos-nix": "logos-nix_467",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_43",
         "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
@@ -70203,15 +55825,9 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_496",
-        "logos-package": "logos-package_45",
-        "nix-bundle-dir": "nix-bundle-dir_75",
-=======
         "logos-nix": "logos-nix_500",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_77",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -70240,15 +55856,9 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_520",
-        "logos-package": "logos-package_47",
-        "nix-bundle-dir": "nix-bundle-dir_78",
-=======
         "logos-nix": "logos-nix_509",
         "logos-package": "logos-package_49",
         "nix-bundle-dir": "nix-bundle-dir_80",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -70278,15 +55888,9 @@
     },
     "nix-bundle-lgx_26": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_529",
-        "logos-package": "logos-package_49",
-        "nix-bundle-dir": "nix-bundle-dir_81",
-=======
         "logos-nix": "logos-nix_533",
         "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_83",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -70311,70 +55915,9 @@
     },
     "nix-bundle-lgx_27": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_553",
-        "logos-package": "logos-package_51",
-        "nix-bundle-dir": "nix-bundle-dir_84",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_28": {
-      "inputs": {
-        "logos-nix": "logos-nix_562",
-        "logos-package": "logos-package_53",
-        "nix-bundle-dir": "nix-bundle-dir_87",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_29": {
-      "inputs": {
-        "logos-nix": "logos-nix_605",
-        "logos-package": "logos-package_55",
-        "nix-bundle-dir": "nix-bundle-dir_92",
-=======
         "logos-nix": "logos-nix_575",
         "logos-package": "logos-package_54",
         "nix-bundle-dir": "nix-bundle-dir_90",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -70498,15 +56041,9 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_614",
-        "logos-package": "logos-package_57",
-        "nix-bundle-dir": "nix-bundle-dir_95",
-=======
         "logos-nix": "logos-nix_631",
         "logos-package": "logos-package_60",
         "nix-bundle-dir": "nix-bundle-dir_99",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -70540,15 +56077,9 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_653",
-        "logos-package": "logos-package_58",
-        "nix-bundle-dir": "nix-bundle-dir_98",
-=======
         "logos-nix": "logos-nix_655",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_102",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -70577,15 +56108,9 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_662",
-        "logos-package": "logos-package_60",
-        "nix-bundle-dir": "nix-bundle-dir_101",
-=======
         "logos-nix": "logos-nix_664",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_105",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -70615,15 +56140,9 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_686",
-        "logos-package": "logos-package_62",
-        "nix-bundle-dir": "nix-bundle-dir_104",
-=======
         "logos-nix": "logos-nix_684",
         "logos-package": "logos-package_66",
         "nix-bundle-dir": "nix-bundle-dir_108",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -70648,102 +56167,9 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_695",
-        "logos-package": "logos-package_64",
-        "nix-bundle-dir": "nix-bundle-dir_107",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_35": {
-      "inputs": {
-        "logos-nix": "logos-nix_719",
-        "logos-package": "logos-package_66",
-        "nix-bundle-dir": "nix-bundle-dir_110",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_36": {
-      "inputs": {
-        "logos-nix": "logos-nix_728",
-        "logos-package": "logos-package_68",
-        "nix-bundle-dir": "nix-bundle-dir_113",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_37": {
-      "inputs": {
-        "logos-nix": "logos-nix_747",
-        "logos-package": "logos-package_71",
-        "nix-bundle-dir": "nix-bundle-dir_118",
-=======
         "logos-nix": "logos-nix_709",
         "logos-package": "logos-package_70",
         "nix-bundle-dir": "nix-bundle-dir_115",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -70976,11 +56402,7 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_384",
-=======
         "logos-nix": "logos-nix_371",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_14",
         "nix-bundle-lgx": [
           "logos-package-downloader-module",
@@ -71011,11 +56433,7 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_442",
-=======
         "logos-nix": "logos-nix_422",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_16",
         "nix-bundle-lgx": "nix-bundle-lgx_21",
         "nixpkgs": [
@@ -71046,11 +56464,7 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_490",
-=======
         "logos-nix": "logos-nix_470",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_17",
         "nix-bundle-lgx": "nix-bundle-lgx_23",
         "nixpkgs": [
@@ -71085,11 +56499,7 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_523",
-=======
         "logos-nix": "logos-nix_503",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_19",
         "nix-bundle-lgx": "nix-bundle-lgx_25",
         "nixpkgs": [
@@ -71120,11 +56530,7 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_556",
-=======
         "logos-nix": "logos-nix_536",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_21",
         "nix-bundle-lgx": [
           "logos-package-manager-module",
@@ -71155,11 +56561,7 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_608",
-=======
         "logos-nix": "logos-nix_578",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_23",
         "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
@@ -71190,11 +56592,7 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_656",
-=======
         "logos-nix": "logos-nix_625",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_24",
         "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
@@ -71229,11 +56627,7 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_689",
-=======
         "logos-nix": "logos-nix_658",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_26",
         "nix-bundle-lgx": "nix-bundle-lgx_32",
         "nixpkgs": [
@@ -71264,11 +56658,7 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_722",
-=======
         "logos-nix": "logos-nix_687",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_28",
         "nix-bundle-lgx": [
           "logos-package-manager-ui",
@@ -71299,11 +56689,7 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_741",
-=======
         "logos-nix": "logos-nix_703",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_29",
         "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
@@ -71474,11 +56860,7 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_270",
-=======
         "logos-nix": "logos-nix_262",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_9",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
@@ -71509,11 +56891,7 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_318",
-=======
         "logos-nix": "logos-nix_309",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
@@ -71548,11 +56926,7 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_351",
-=======
         "logos-nix": "logos-nix_342",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -72129,11 +57503,7 @@
     },
     "nix-bundle-macos-app_20": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_750",
-=======
         "logos-nix": "logos-nix_712",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -82141,153 +67511,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "nixpkgs-windows_670": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_671": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_672": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_673": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_674": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_675": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_676": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_677": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_678": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "nixpkgs-windows_68": {
       "locked": {
         "lastModified": 1782723713,
@@ -93808,25 +79031,6 @@
         "type": "github"
       }
     },
-<<<<<<< HEAD
-    "nixpkgs_750": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-=======
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "nixpkgs_76": {
       "locked": {
         "lastModified": 1759036355,
@@ -94324,11 +79528,7 @@
     },
     "process-stats_4": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_340",
-=======
         "logos-nix": "logos-nix_331",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -94359,11 +79559,7 @@
     },
     "process-stats_5": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_371",
-=======
         "logos-nix": "logos-nix_358",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -94390,11 +79586,7 @@
     },
     "process-stats_6": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_512",
-=======
         "logos-nix": "logos-nix_492",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -94425,11 +79617,7 @@
     },
     "process-stats_7": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_543",
-=======
         "logos-nix": "logos-nix_523",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -94456,11 +79644,7 @@
     },
     "process-stats_8": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_678",
-=======
         "logos-nix": "logos-nix_647",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -94491,11 +79675,7 @@
     },
     "process-stats_9": {
       "inputs": {
-<<<<<<< HEAD
-        "logos-nix": "logos-nix_709",
-=======
         "logos-nix": "logos-nix_674",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -94535,17 +79715,10 @@
         "logos-package-manager": "logos-package-manager_15",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
-<<<<<<< HEAD
-        "logos-plugin-qt": "logos-plugin-qt_94",
-        "logos-protocol": "logos-protocol_123",
-        "logos-qt-mcp": "logos-qt-mcp_9",
-        "logos-qt-sdk": "logos-qt-sdk_49",
-=======
         "logos-plugin-qt": "logos-plugin-qt_86",
         "logos-protocol": "logos-protocol_109",
         "logos-qt-mcp": "logos-qt-mcp_9",
         "logos-qt-sdk": "logos-qt-sdk_47",
->>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-appimage": "nix-bundle-appimage_49",
         "nix-bundle-dir": "nix-bundle-dir_112",

--- a/flake.lock
+++ b/flake.lock
@@ -85,7 +85,11 @@
     "default-container_4": {
       "inputs": {
         "logos-container": "logos-container_18",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_243",
+=======
+        "logos-nix": "logos-nix_239",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -97,11 +101,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787083717,
-        "narHash": "sha256-RUvjm4Imiri8cmSFm1wO4oBGaGiN18vitW+t7gleZWM=",
+        "lastModified": 1789077426,
+        "narHash": "sha256-ZHkDEiEt8FE+59I7y2/5rfxV4RcDmUVCRmTmqx22KuA=",
         "owner": "logos-co",
         "repo": "logos-container-subprocess",
-        "rev": "c6f7ec62792beda0480f8f4a095dbacadd06910a",
+        "rev": "1919ef3509147f058cd8e18d41f074af51b97362",
         "type": "github"
       },
       "original": {
@@ -113,7 +117,11 @@
     "default-container_5": {
       "inputs": {
         "logos-container": "logos-container_23",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_295",
+=======
+        "logos-nix": "logos-nix_286",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -145,7 +153,11 @@
     "default-container_6": {
       "inputs": {
         "logos-container": "logos-container_28",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_415",
+=======
+        "logos-nix": "logos-nix_395",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -173,7 +185,11 @@
     "default-container_7": {
       "inputs": {
         "logos-container": "logos-container_33",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_467",
+=======
+        "logos-nix": "logos-nix_447",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -205,7 +221,11 @@
     "default-container_8": {
       "inputs": {
         "logos-container": "logos-container_38",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_581",
+=======
+        "logos-nix": "logos-nix_555",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -217,11 +237,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787083717,
-        "narHash": "sha256-RUvjm4Imiri8cmSFm1wO4oBGaGiN18vitW+t7gleZWM=",
+        "lastModified": 1789077426,
+        "narHash": "sha256-ZHkDEiEt8FE+59I7y2/5rfxV4RcDmUVCRmTmqx22KuA=",
         "owner": "logos-co",
         "repo": "logos-container-subprocess",
-        "rev": "c6f7ec62792beda0480f8f4a095dbacadd06910a",
+        "rev": "1919ef3509147f058cd8e18d41f074af51b97362",
         "type": "github"
       },
       "original": {
@@ -233,7 +253,11 @@
     "default-container_9": {
       "inputs": {
         "logos-container": "logos-container_43",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_633",
+=======
+        "logos-nix": "logos-nix_602",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -410,12 +434,39 @@
     "default-module-loader_4": {
       "inputs": {
         "logos-container": "logos-container_19",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_21",
         "logos-module": "logos-module_53",
         "logos-module-loader": "logos-module-loader_8",
         "logos-nix": "logos-nix_248",
         "logos-protocol": "logos-protocol_39",
         "logos-qt-sdk": "logos-qt-sdk_17",
+=======
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_52",
+        "logos-module-loader": "logos-module-loader_8",
+        "logos-nix": "logos-nix_243",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -427,11 +478,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787668839,
-        "narHash": "sha256-l7Ij/BBc/3MvLRGRr4+D/mcJeRFija0NI4+XGIVLSrI=",
+        "lastModified": 1789108040,
+        "narHash": "sha256-3V//OwqhLDNHBAfWkH92dmBAW1xjk01Uts7MdqXc1e4=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "3e65e088df45bc2c68451933464bfbe3f63f88b1",
+        "rev": "1d31cd7099d93fe8db84127118905da65d0bc666",
         "type": "github"
       },
       "original": {
@@ -454,9 +505,15 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_66",
         "logos-module-loader": "logos-module-loader_10",
         "logos-nix": "logos-nix_299",
+=======
+        "logos-module": "logos-module_64",
+        "logos-module-loader": "logos-module-loader_10",
+        "logos-nix": "logos-nix_290",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -510,12 +567,21 @@
     "default-module-loader_6": {
       "inputs": {
         "logos-container": "logos-container_29",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_35",
         "logos-module": "logos-module_87",
         "logos-module-loader": "logos-module-loader_12",
         "logos-nix": "logos-nix_420",
         "logos-protocol": "logos-protocol_68",
         "logos-qt-sdk": "logos-qt-sdk_28",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_33",
+        "logos-module": "logos-module_82",
+        "logos-module-loader": "logos-module-loader_12",
+        "logos-nix": "logos-nix_400",
+        "logos-protocol": "logos-protocol_61",
+        "logos-qt-sdk": "logos-qt-sdk_27",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -554,9 +620,15 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_100",
         "logos-module-loader": "logos-module-loader_14",
         "logos-nix": "logos-nix_471",
+=======
+        "logos-module": "logos-module_95",
+        "logos-module-loader": "logos-module-loader_14",
+        "logos-nix": "logos-nix_451",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -610,12 +682,39 @@
     "default-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_39",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_49",
         "logos-module": "logos-module_120",
         "logos-module-loader": "logos-module-loader_16",
         "logos-nix": "logos-nix_586",
         "logos-protocol": "logos-protocol_97",
         "logos-qt-sdk": "logos-qt-sdk_39",
+=======
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_115",
+        "logos-module-loader": "logos-module-loader_16",
+        "logos-nix": "logos-nix_559",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -627,11 +726,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787668839,
-        "narHash": "sha256-l7Ij/BBc/3MvLRGRr4+D/mcJeRFija0NI4+XGIVLSrI=",
+        "lastModified": 1789108040,
+        "narHash": "sha256-3V//OwqhLDNHBAfWkH92dmBAW1xjk01Uts7MdqXc1e4=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "3e65e088df45bc2c68451933464bfbe3f63f88b1",
+        "rev": "1d31cd7099d93fe8db84127118905da65d0bc666",
         "type": "github"
       },
       "original": {
@@ -654,9 +753,15 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_133",
         "logos-module-loader": "logos-module-loader_18",
         "logos-nix": "logos-nix_637",
+=======
+        "logos-module": "logos-module_127",
+        "logos-module-loader": "logos-module-loader_18",
+        "logos-nix": "logos-nix_606",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -1190,11 +1295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -1205,7 +1310,11 @@
     },
     "logos-container_19": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_244",
+=======
+        "logos-nix": "logos-nix_240",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1218,11 +1327,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -1295,7 +1404,11 @@
     },
     "logos-container_21": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_279",
+=======
+        "logos-nix": "logos-nix_271",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1307,11 +1420,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -1400,7 +1513,11 @@
     },
     "logos-container_24": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_296",
+=======
+        "logos-nix": "logos-nix_287",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1477,7 +1594,11 @@
     },
     "logos-container_26": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_327",
+=======
+        "logos-nix": "logos-nix_318",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -1586,7 +1707,11 @@
     },
     "logos-container_29": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_416",
+=======
+        "logos-nix": "logos-nix_396",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1682,7 +1807,11 @@
     },
     "logos-container_31": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_451",
+=======
+        "logos-nix": "logos-nix_431",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1787,7 +1916,11 @@
     },
     "logos-container_34": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_468",
+=======
+        "logos-nix": "logos-nix_448",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1864,7 +1997,11 @@
     },
     "logos-container_36": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_499",
+=======
+        "logos-nix": "logos-nix_479",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -1958,11 +2095,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -1973,7 +2110,11 @@
     },
     "logos-container_39": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_582",
+=======
+        "logos-nix": "logos-nix_556",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -1986,11 +2127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -2062,7 +2203,11 @@
     },
     "logos-container_41": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_617",
+=======
+        "logos-nix": "logos-nix_587",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2074,11 +2219,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415287,
-        "narHash": "sha256-6odZMp0sV4EsZgwo6R8Sh+PvYCT2BvBsG79MQ5xDbuk=",
+        "lastModified": 1788383494,
+        "narHash": "sha256-5v+cBtuoYoywVn6OquuuwJRRIxqWQGBFvru9+IhfrJw=",
         "owner": "logos-co",
         "repo": "logos-container",
-        "rev": "06d43aeda169fffe1bb07a7cf9f375d5bc049184",
+        "rev": "641d21108781a353eed9f0567f15776fee06af40",
         "type": "github"
       },
       "original": {
@@ -2167,7 +2312,11 @@
     },
     "logos-container_44": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_634",
+=======
+        "logos-nix": "logos-nix_603",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2244,7 +2393,11 @@
     },
     "logos-container_46": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_665",
+=======
+        "logos-nix": "logos-nix_634",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -2597,11 +2750,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787605334,
         "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+=======
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -2820,12 +2981,25 @@
     "logos-cpp-sdk_19": {
       "inputs": {
         "logos-lidl": "logos-lidl_68",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_231",
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-protocol"
         ],
+=======
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2835,11 +3009,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787605334,
         "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+=======
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -2884,8 +3066,18 @@
     "logos-cpp-sdk_20": {
       "inputs": {
         "logos-lidl": "logos-lidl_73",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_242",
         "logos-protocol": "logos-protocol_38",
+=======
+        "logos-nix": "logos-nix_238",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -2896,11 +3088,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
         "type": "github"
       },
       "original": {
@@ -2912,13 +3104,22 @@
     "logos-cpp-sdk_21": {
       "inputs": {
         "logos-lidl": "logos-lidl_74",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_245",
+=======
+        "logos-nix": "logos-nix_244",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -2926,7 +3127,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -2948,57 +3154,28 @@
     },
     "logos-cpp-sdk_22": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_76",
         "logos-nix": "logos-nix_252",
         "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_23": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_83",
+=======
+        "logos-lidl": "logos-lidl_81",
         "logos-nix": [
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+          "logos-protocol"
+=======
           "logos-view-module-runtime",
           "logos-nix"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         ],
-        "logos-protocol": "logos-protocol_43",
+        "logos-protocol": "logos-protocol_41",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3006,7 +3183,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
           "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3026,15 +3206,29 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_24": {
+    "logos-cpp-sdk_23": {
       "inputs": {
-        "logos-lidl": "logos-lidl_85",
-        "logos-nix": "logos-nix_280",
+        "logos-lidl": "logos-lidl_83",
+<<<<<<< HEAD
+        "logos-nix": [
+=======
+        "logos-nix": "logos-nix_274",
         "logos-protocol": [
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_43",
+=======
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3042,6 +3236,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3053,6 +3249,91 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_24": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_88",
+        "logos-nix": "logos-nix_285",
+        "logos-protocol": "logos-protocol_45",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_24": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_85",
+        "logos-nix": "logos-nix_280",
+=======
+        "logos-lidl": "logos-lidl_89",
+        "logos-nix": "logos-nix_291",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3102,6 +3383,7 @@
     },
     "logos-cpp-sdk_26": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_91",
         "logos-nix": "logos-nix_294",
         "logos-protocol": "logos-protocol_47",
@@ -3182,6 +3464,9 @@
     "logos-cpp-sdk_28": {
       "inputs": {
         "logos-lidl": "logos-lidl_99",
+=======
+        "logos-lidl": "logos-lidl_96",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3196,7 +3481,11 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_50",
+=======
+        "logos-protocol": "logos-protocol_48",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -3207,6 +3496,99 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-cpp-sdk_29": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_101",
+        "logos-nix": "logos-nix_328",
+=======
+    "logos-cpp-sdk_27": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_98",
+        "logos-nix": "logos-nix_319",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+=======
+    "logos-cpp-sdk_28": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_104",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_53",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -3229,117 +3611,6 @@
       }
     },
     "logos-cpp-sdk_29": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_101",
-        "logos-nix": "logos-nix_328",
-        "logos-protocol": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_3": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_10",
-        "logos-nix": "logos-nix_27",
-        "logos-protocol": [
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1789102469,
-        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_30": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_107",
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "logos-protocol": "logos-protocol_55",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_31": {
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -3377,6 +3648,183 @@
         ]
       },
       "locked": {
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+    "logos-cpp-sdk_3": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_10",
+        "logos-nix": "logos-nix_27",
+        "logos-protocol": [
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_30": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_107",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+=======
+        "logos-lidl": "logos-lidl_110",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        ],
+        "logos-protocol": "logos-protocol_55",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_31": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+=======
+        "logos-lidl": "logos-lidl_112",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788740226,
+        "narHash": "sha256-gLxNuXAgpIye4qbSoCrK3KeNqv1eweOKOjnIumfsOBE=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e1d6bf202d2d22a0a5987868aa30b2dfe16e3b75",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_32": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_117",
+        "logos-nix": "logos-nix_394",
+        "logos-protocol": "logos-protocol_60",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1787605334,
         "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
@@ -3392,29 +3840,43 @@
     },
     "logos-cpp-sdk_32": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_114",
         "logos-nix": [
           "logos-package-downloader-module",
+=======
+        "logos-lidl": "logos-lidl_118",
+        "logos-nix": "logos-nix_397",
+        "logos-protocol": [
+          "logos-package-manager-module",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_63",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -3425,15 +3887,28 @@
     },
     "logos-cpp-sdk_33": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_116",
         "logos-nix": "logos-nix_403",
+=======
+        "logos-lidl": "logos-lidl_120",
+        "logos-nix": "logos-nix_404",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
@@ -3456,24 +3931,43 @@
     },
     "logos-cpp-sdk_34": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_121",
         "logos-nix": "logos-nix_414",
         "logos-protocol": "logos-protocol_67",
+=======
+        "logos-lidl": "logos-lidl_127",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_65",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3521,15 +4015,23 @@
     },
     "logos-cpp-sdk_36": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_124",
         "logos-nix": "logos-nix_424",
+=======
+        "logos-lidl": "logos-lidl_129",
+        "logos-nix": "logos-nix_432",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3537,8 +4039,11 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3560,54 +4065,28 @@
     },
     "logos-cpp-sdk_37": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_131",
         "logos-nix": [
+=======
+        "logos-lidl": "logos-lidl_130",
+        "logos-nix": "logos-nix_435",
+        "logos-protocol": [
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_72",
-        "nixpkgs": [
-          "logos-package-manager-module",
+=======
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786467089,
-        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-cpp-sdk",
-        "type": "github"
-      }
-    },
-    "logos-cpp-sdk_38": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_133",
-        "logos-nix": "logos-nix_452",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -3615,6 +4094,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -3626,6 +4107,90 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_38": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_135",
+        "logos-nix": "logos-nix_446",
+        "logos-protocol": "logos-protocol_69",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_38": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_133",
+=======
+        "logos-lidl": "logos-lidl_136",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": "logos-nix_452",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -3708,9 +4273,28 @@
     },
     "logos-cpp-sdk_40": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_139",
         "logos-nix": "logos-nix_466",
         "logos-protocol": "logos-protocol_76",
+=======
+        "logos-lidl": "logos-lidl_143",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_72",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3719,17 +4303,64 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165370,
-        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_41": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_145",
+        "logos-nix": "logos-nix_480",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -3787,7 +4418,11 @@
     },
     "logos-cpp-sdk_42": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_147",
+=======
+        "logos-lidl": "logos-lidl_151",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3795,6 +4430,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -3803,6 +4439,12 @@
           "logos-nix"
         ],
         "logos-protocol": "logos-protocol_79",
+=======
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_77",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3810,10 +4452,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix",
@@ -3836,6 +4481,7 @@
     },
     "logos-cpp-sdk_43": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_149",
         "logos-nix": "logos-nix_500",
         "logos-protocol": [
@@ -3920,6 +4566,8 @@
     },
     "logos-cpp-sdk_45": {
       "inputs": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -3969,16 +4617,26 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-cpp-sdk_46": {
       "inputs": {
         "logos-lidl": "logos-lidl_162",
+=======
+    "logos-cpp-sdk_44": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_158",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_92",
+=======
+        "logos-protocol": "logos-protocol_85",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -4002,10 +4660,21 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-cpp-sdk_47": {
       "inputs": {
         "logos-lidl": "logos-lidl_164",
         "logos-nix": "logos-nix_570",
+=======
+    "logos-cpp-sdk_45": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_160",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4020,11 +4689,83 @@
         ]
       },
       "locked": {
-        "lastModified": 1788740226,
-        "narHash": "sha256-gLxNuXAgpIye4qbSoCrK3KeNqv1eweOKOjnIumfsOBE=",
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "e1d6bf202d2d22a0a5987868aa30b2dfe16e3b75",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_46": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_165",
+        "logos-nix": "logos-nix_554",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_47": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_166",
+        "logos-nix": "logos-nix_560",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787605334,
+        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
         "type": "github"
       },
       "original": {
@@ -4035,13 +4776,71 @@
     },
     "logos-cpp-sdk_48": {
       "inputs": {
-        "logos-lidl": "logos-lidl_169",
-        "logos-nix": "logos-nix_580",
-        "logos-protocol": "logos-protocol_96",
+        "logos-lidl": "logos-lidl_173",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_92",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_48": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_169",
+        "logos-nix": "logos-nix_580",
+        "logos-protocol": "logos-protocol_96",
+=======
+        "logos-lidl": "logos-lidl_175",
+        "logos-nix": "logos-nix_590",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
@@ -4135,10 +4934,68 @@
     },
     "logos-cpp-sdk_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_172",
         "logos-nix": "logos-nix_590",
         "logos-protocol": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+=======
+        "logos-lidl": "logos-lidl_180",
+        "logos-nix": "logos-nix_601",
+        "logos-protocol": "logos-protocol_96",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+<<<<<<< HEAD
+          "logos-capability-module",
+          "logos-module-builder",
+=======
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_51": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_179",
+=======
+        "logos-lidl": "logos-lidl_181",
+        "logos-nix": "logos-nix_607",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4151,6 +5008,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk",
@@ -4159,11 +5020,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1787165370,
+        "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
         "type": "github"
       },
       "original": {
@@ -4172,11 +5033,16 @@
         "type": "github"
       }
     },
-    "logos-cpp-sdk_51": {
+    "logos-cpp-sdk_52": {
       "inputs": {
-        "logos-lidl": "logos-lidl_179",
+        "logos-lidl": "logos-lidl_188",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4185,9 +5051,17 @@
           "logos-view-module-runtime",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_101",
+=======
+        "logos-protocol": "logos-protocol_99",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4215,10 +5089,19 @@
     },
     "logos-cpp-sdk_52": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_181",
         "logos-nix": "logos-nix_618",
+=======
+        "logos-lidl": "logos-lidl_190",
+        "logos-nix": "logos-nix_635",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -4229,17 +5112,21 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -4289,9 +5176,24 @@
     },
     "logos-cpp-sdk_54": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_187",
         "logos-nix": "logos-nix_632",
         "logos-protocol": "logos-protocol_105",
+=======
+        "logos-lidl": "logos-lidl_196",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_104",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4299,18 +5201,30 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787165370,
         "narHash": "sha256-FR42+iUeeF+UEmwKZ7a0GPHyJTcuhzq0bsBo3ggUZUg=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+=======
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -4321,6 +5235,7 @@
     },
     "logos-cpp-sdk_55": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_188",
         "logos-nix": "logos-nix_638",
         "logos-protocol": [
@@ -4501,6 +5416,8 @@
     },
     "logos-cpp-sdk_59": {
       "inputs": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -4537,11 +5454,53 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605334,
-        "narHash": "sha256-S+lAYBjIncdrexm2jMApnLTplM7SjPuOo0tsKMxacxY=",
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
-        "rev": "937f17ed018fb942ad6902456e871ce5e8b9becc",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-cpp-sdk_6": {
+      "inputs": {
+=======
+    "logos-cpp-sdk_56": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_202",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789102469,
+        "narHash": "sha256-xJM6wKap8yN++KSp/PotC8q+0Cy5gwlZzGRg4Etu4hk=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "fb88c7d551a04e35c39fac6c7b12d6b5ce2d9950",
         "type": "github"
       },
       "original": {
@@ -4552,6 +5511,7 @@
     },
     "logos-cpp-sdk_6": {
       "inputs": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_20",
         "logos-nix": "logos-nix_64",
         "logos-protocol": [
@@ -4583,6 +5543,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-cpp-sdk_60": {
       "inputs": {
         "logos-lidl": "logos-lidl_210",
@@ -4618,6 +5579,10 @@
     },
     "logos-cpp-sdk_7": {
       "inputs": {
+=======
+    "logos-cpp-sdk_7": {
+      "inputs": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_25",
         "logos-nix": "logos-nix_75",
         "logos-protocol": "logos-protocol_13",
@@ -4646,6 +5611,12 @@
       }
     },
     "logos-cpp-sdk_8": {
+<<<<<<< HEAD
+      "inputs": {
+        "logos-lidl": "logos-lidl_26",
+        "logos-nix": "logos-nix_81",
+        "logos-protocol": [
+=======
       "inputs": {
         "logos-lidl": "logos-lidl_26",
         "logos-nix": "logos-nix_81",
@@ -4678,6 +5649,50 @@
         "owner": "logos-co",
         "repo": "logos-cpp-sdk",
         "rev": "95d7b3a9c5ef845bdc31f12f1d8222a12eda916d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "type": "github"
+      }
+    },
+    "logos-cpp-sdk_9": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_33",
+        "logos-nix": [
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": "logos-protocol_16",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786467089,
+        "narHash": "sha256-225xM64Ym9loeIOgS8W3Qc0iKHtpLbQVAaO9ppBpLQc=",
+        "owner": "logos-co",
+        "repo": "logos-cpp-sdk",
+        "rev": "e3744fb84ceff2dc7cb1630a1301bb93c64d7a8a",
         "type": "github"
       },
       "original": {
@@ -4759,7 +5774,11 @@
     },
     "logos-design-system_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_284",
+=======
+        "logos-nix": "logos-nix_275",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_19",
         "nix-bundle-dir": "nix-bundle-dir_42",
         "nix-bundle-macos-app": "nix-bundle-macos-app_10",
@@ -4791,7 +5810,11 @@
     },
     "logos-design-system_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_301",
+=======
+        "logos-nix": "logos-nix_292",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_20",
         "nix-bundle-dir": "nix-bundle-dir_43",
         "nix-bundle-macos-app": "nix-bundle-macos-app_11",
@@ -4827,9 +5850,13 @@
     },
     "logos-design-system_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_404",
+=======
+        "logos-nix": "logos-nix_387",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_28",
-        "nix-bundle-dir": "nix-bundle-dir_64",
+        "nix-bundle-dir": "nix-bundle-dir_63",
         "nix-bundle-macos-app": "nix-bundle-macos-app_12",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4840,11 +5867,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787211886,
-        "narHash": "sha256-zHPfxY0EOxTJBwQA8V0gtBRljq6QkqN1M5ELhCLpVsM=",
+        "lastModified": 1788789466,
+        "narHash": "sha256-PSCRnM8CxSylrdzmBZroa7GN5QLXXC6y3aiM7NhKg8k=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "3312444e96076b8786e3e21a000676fc4e851350",
+        "rev": "46324608062cc3c8d906b4ce91f4f20f4a3cd8cb",
         "type": "github"
       },
       "original": {
@@ -4855,9 +5882,13 @@
     },
     "logos-design-system_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_425",
+=======
+        "logos-nix": "logos-nix_405",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_29",
-        "nix-bundle-dir": "nix-bundle-dir_65",
+        "nix-bundle-dir": "nix-bundle-dir_64",
         "nix-bundle-macos-app": "nix-bundle-macos-app_13",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4887,9 +5918,13 @@
     },
     "logos-design-system_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_456",
+=======
+        "logos-nix": "logos-nix_436",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_31",
-        "nix-bundle-dir": "nix-bundle-dir_70",
+        "nix-bundle-dir": "nix-bundle-dir_69",
         "nix-bundle-macos-app": "nix-bundle-macos-app_14",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4919,9 +5954,13 @@
     },
     "logos-design-system_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_473",
+=======
+        "logos-nix": "logos-nix_453",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_32",
-        "nix-bundle-dir": "nix-bundle-dir_71",
+        "nix-bundle-dir": "nix-bundle-dir_70",
         "nix-bundle-macos-app": "nix-bundle-macos-app_15",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -4955,9 +5994,13 @@
     },
     "logos-design-system_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_571",
+=======
+        "logos-nix": "logos-nix_547",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_39",
-        "nix-bundle-dir": "nix-bundle-dir_90",
+        "nix-bundle-dir": "nix-bundle-dir_88",
         "nix-bundle-macos-app": "nix-bundle-macos-app_16",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -4983,9 +6026,13 @@
     },
     "logos-design-system_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_591",
+=======
+        "logos-nix": "logos-nix_561",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_40",
-        "nix-bundle-dir": "nix-bundle-dir_91",
+        "nix-bundle-dir": "nix-bundle-dir_89",
         "nix-bundle-macos-app": "nix-bundle-macos-app_17",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5015,9 +6062,13 @@
     },
     "logos-design-system_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_622",
+=======
+        "logos-nix": "logos-nix_591",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_42",
-        "nix-bundle-dir": "nix-bundle-dir_96",
+        "nix-bundle-dir": "nix-bundle-dir_94",
         "nix-bundle-macos-app": "nix-bundle-macos-app_18",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5047,9 +6098,13 @@
     },
     "logos-design-system_19": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_639",
+=======
+        "logos-nix": "logos-nix_608",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_43",
-        "nix-bundle-dir": "nix-bundle-dir_97",
+        "nix-bundle-dir": "nix-bundle-dir_95",
         "nix-bundle-macos-app": "nix-bundle-macos-app_19",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -5260,7 +6315,11 @@
     },
     "logos-design-system_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_232",
+=======
+        "logos-nix": "logos-nix_231",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_16",
         "nix-bundle-dir": "nix-bundle-dir_36",
         "nix-bundle-macos-app": "nix-bundle-macos-app_8",
@@ -5273,11 +6332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787211886,
-        "narHash": "sha256-zHPfxY0EOxTJBwQA8V0gtBRljq6QkqN1M5ELhCLpVsM=",
+        "lastModified": 1788789466,
+        "narHash": "sha256-PSCRnM8CxSylrdzmBZroa7GN5QLXXC6y3aiM7NhKg8k=",
         "owner": "logos-co",
         "repo": "logos-design-system",
-        "rev": "3312444e96076b8786e3e21a000676fc4e851350",
+        "rev": "46324608062cc3c8d906b4ce91f4f20f4a3cd8cb",
         "type": "github"
       },
       "original": {
@@ -5288,7 +6347,11 @@
     },
     "logos-design-system_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_253",
+=======
+        "logos-nix": "logos-nix_245",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_17",
         "nix-bundle-dir": "nix-bundle-dir_37",
         "nix-bundle-macos-app": "nix-bundle-macos-app_9",
@@ -5447,6 +6510,7 @@
         "default-module-loader": "default-module-loader_4",
         "logos-capability-module": "logos-capability-module_5",
         "logos-container": "logos-container_21",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_24",
         "logos-module": "logos-module_61",
         "logos-module-loader": "logos-module-loader_9",
@@ -5456,6 +6520,32 @@
         "logos-plugin-qt": "logos-plugin-qt_46",
         "logos-protocol": "logos-protocol_58",
         "logos-qt-sdk": "logos-qt-sdk_25",
+=======
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_59",
+        "logos-module-loader": "logos-module-loader_9",
+        "logos-modules-state-module": "logos-modules-state-module_3",
+        "logos-nix": "logos-nix_351",
+        "logos-package-manager": "logos-package-manager_13",
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": "logos-qt-sdk_24",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5467,11 +6557,11 @@
         "process-stats": "process-stats_5"
       },
       "locked": {
-        "lastModified": 1787829932,
-        "narHash": "sha256-qLE8M1wXH7Ac6kHenPqpD/aKdEAnPQDJOAA0P9422cc=",
+        "lastModified": 1789123116,
+        "narHash": "sha256-QFAZrnCDNmoQRbZ8h9z6dI71NYKsp/SbBsnhRVnjxQM=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "e477befff111142f34b4b45b7cbfe487123e72f9",
+        "rev": "34a83419b027e8390f1e898038047245039f1e6d",
         "type": "github"
       },
       "original": {
@@ -5486,6 +6576,7 @@
         "default-module-loader": "default-module-loader_5",
         "logos-capability-module": "logos-capability-module_6",
         "logos-container": "logos-container_26",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_29",
         "logos-module": "logos-module_73",
         "logos-module-loader": "logos-module-loader_11",
@@ -5494,6 +6585,16 @@
         "logos-plugin-qt": "logos-plugin-qt_42",
         "logos-protocol": "logos-protocol_52",
         "logos-qt-sdk": "logos-qt-sdk_23",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_27",
+        "logos-module": "logos-module_71",
+        "logos-module-loader": "logos-module-loader_11",
+        "logos-nix": "logos-nix_322",
+        "logos-package-manager": "logos-package-manager_11",
+        "logos-plugin-qt": "logos-plugin-qt_40",
+        "logos-protocol": "logos-protocol_50",
+        "logos-qt-sdk": "logos-qt-sdk_22",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -5528,6 +6629,7 @@
         "default-module-loader": "default-module-loader_6",
         "logos-capability-module": "logos-capability-module_7",
         "logos-container": "logos-container_31",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_38",
         "logos-module": "logos-module_95",
         "logos-module-loader": "logos-module-loader_13",
@@ -5537,6 +6639,17 @@
         "logos-plugin-qt": "logos-plugin-qt_68",
         "logos-protocol": "logos-protocol_87",
         "logos-qt-sdk": "logos-qt-sdk_36",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_36",
+        "logos-module": "logos-module_90",
+        "logos-module-loader": "logos-module-loader_13",
+        "logos-modules-state-module": "logos-modules-state-module_4",
+        "logos-nix": "logos-nix_512",
+        "logos-package-manager": "logos-package-manager_20",
+        "logos-plugin-qt": "logos-plugin-qt_63",
+        "logos-protocol": "logos-protocol_80",
+        "logos-qt-sdk": "logos-qt-sdk_35",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5567,6 +6680,7 @@
         "default-module-loader": "default-module-loader_7",
         "logos-capability-module": "logos-capability-module_8",
         "logos-container": "logos-container_36",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_43",
         "logos-module": "logos-module_107",
         "logos-module-loader": "logos-module-loader_15",
@@ -5575,6 +6689,16 @@
         "logos-plugin-qt": "logos-plugin-qt_64",
         "logos-protocol": "logos-protocol_81",
         "logos-qt-sdk": "logos-qt-sdk_34",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_41",
+        "logos-module": "logos-module_102",
+        "logos-module-loader": "logos-module-loader_15",
+        "logos-nix": "logos-nix_483",
+        "logos-package-manager": "logos-package-manager_18",
+        "logos-plugin-qt": "logos-plugin-qt_59",
+        "logos-protocol": "logos-protocol_74",
+        "logos-qt-sdk": "logos-qt-sdk_33",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -5609,6 +6733,7 @@
         "default-module-loader": "default-module-loader_8",
         "logos-capability-module": "logos-capability-module_9",
         "logos-container": "logos-container_41",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_52",
         "logos-module": "logos-module_128",
         "logos-module-loader": "logos-module-loader_17",
@@ -5618,6 +6743,32 @@
         "logos-plugin-qt": "logos-plugin-qt_89",
         "logos-protocol": "logos-protocol_116",
         "logos-qt-sdk": "logos-qt-sdk_47",
+=======
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk"
+        ],
+        "logos-module": "logos-module_122",
+        "logos-module-loader": "logos-module-loader_17",
+        "logos-modules-state-module": "logos-modules-state-module_5",
+        "logos-nix": "logos-nix_667",
+        "logos-package-manager": "logos-package-manager_27",
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "logos-qt-sdk": "logos-qt-sdk_45",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5629,11 +6780,11 @@
         "process-stats": "process-stats_9"
       },
       "locked": {
-        "lastModified": 1787829932,
-        "narHash": "sha256-qLE8M1wXH7Ac6kHenPqpD/aKdEAnPQDJOAA0P9422cc=",
+        "lastModified": 1789123116,
+        "narHash": "sha256-QFAZrnCDNmoQRbZ8h9z6dI71NYKsp/SbBsnhRVnjxQM=",
         "owner": "logos-co",
         "repo": "logos-liblogos",
-        "rev": "e477befff111142f34b4b45b7cbfe487123e72f9",
+        "rev": "34a83419b027e8390f1e898038047245039f1e6d",
         "type": "github"
       },
       "original": {
@@ -5648,6 +6799,7 @@
         "default-module-loader": "default-module-loader_9",
         "logos-capability-module": "logos-capability-module_10",
         "logos-container": "logos-container_46",
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_57",
         "logos-module": "logos-module_140",
         "logos-module-loader": "logos-module-loader_19",
@@ -5656,6 +6808,16 @@
         "logos-plugin-qt": "logos-plugin-qt_85",
         "logos-protocol": "logos-protocol_110",
         "logos-qt-sdk": "logos-qt-sdk_45",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_53",
+        "logos-module": "logos-module_134",
+        "logos-module-loader": "logos-module-loader_19",
+        "logos-nix": "logos-nix_638",
+        "logos-package-manager": "logos-package-manager_25",
+        "logos-plugin-qt": "logos-plugin-qt_79",
+        "logos-protocol": "logos-protocol_101",
+        "logos-qt-sdk": "logos-qt-sdk_43",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -5753,10 +6915,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5768,10 +6934,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5801,8 +6971,12 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5813,8 +6987,12 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5843,8 +7021,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -5855,8 +7037,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -5886,8 +7072,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -5898,8 +7088,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -5929,8 +7123,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -5940,8 +7139,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -5970,7 +7174,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -5981,7 +7189,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6009,9 +7221,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -6020,9 +7235,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6030,11 +7248,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -6049,33 +7267,41 @@
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -6089,22 +7315,30 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6130,17 +7364,27 @@
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6173,6 +7417,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6193,6 +7439,41 @@
         "type": "github"
       }
     },
+    "logos-lidl_110": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
     "logos-lidl_110": {
       "inputs": {
         "logos-nix": [
@@ -6228,19 +7509,29 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-lidl_111": {
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -6264,17 +7555,25 @@
     "logos-lidl_112": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6297,17 +7596,25 @@
     "logos-lidl_113": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6330,50 +7637,25 @@
     "logos-lidl_114": {
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
-          "logos-lidl",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-lidl",
-        "type": "github"
-      }
-    },
-    "logos-lidl_115": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
+=======
           "logos-plugin-qt",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6385,6 +7667,55 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_115": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+<<<<<<< HEAD
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+=======
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -6398,24 +7729,40 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787248041,
         "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+=======
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -6429,13 +7776,23 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6460,13 +7817,27 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6491,12 +7862,24 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6555,13 +7938,29 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6587,14 +7986,28 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6621,8 +8034,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-cpp-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6630,8 +8049,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-cpp-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6658,7 +8083,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -6667,7 +8097,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -6697,7 +8132,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6707,7 +8146,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6736,7 +8179,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6746,18 +8194,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6775,7 +8228,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6785,18 +8243,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6814,7 +8277,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6824,18 +8292,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -6853,7 +8326,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6863,7 +8341,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6890,10 +8373,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6901,10 +8388,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -6964,10 +8455,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -6975,10 +8470,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7005,10 +8504,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7016,21 +8519,25 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -7046,9 +8553,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
+          "logos-plugin-qt",
+=======
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7057,9 +8567,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7087,7 +8596,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7095,7 +8606,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7107,6 +8620,87 @@
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_134": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_133": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7202,7 +8796,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7212,18 +8814,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7241,7 +8851,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7251,18 +8869,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7280,7 +8906,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7290,18 +8924,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -7320,7 +8962,14 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7331,7 +8980,14 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7397,7 +9053,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7411,18 +9071,30 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786415321,
         "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+=======
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -7444,7 +9116,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7458,7 +9135,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7491,7 +9173,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7505,7 +9192,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7538,7 +9230,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7552,7 +9249,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7585,7 +9287,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7599,7 +9306,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7630,10 +9342,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7645,10 +9361,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7679,10 +9399,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7694,10 +9418,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7728,10 +9456,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7743,10 +9475,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7776,10 +9512,13 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7791,10 +9530,13 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -7824,9 +9566,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7836,9 +9583,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7900,9 +9652,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7912,9 +9669,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7943,9 +9705,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -7955,9 +9722,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -7986,7 +9758,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -7997,7 +9773,11 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8025,9 +9805,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8036,9 +9819,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8046,11 +9832,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8066,9 +9852,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -8077,9 +9866,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
@@ -8087,11 +9879,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8106,33 +9898,41 @@
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -8146,22 +9946,30 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8187,17 +9995,27 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8222,17 +10040,27 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8257,14 +10085,22 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8323,28 +10159,44 @@
     "logos-lidl_160": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786415321,
         "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+=======
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -8356,17 +10208,25 @@
     "logos-lidl_161": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8389,15 +10249,20 @@
     "logos-lidl_162": {
       "inputs": {
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-lidl",
@@ -8495,6 +10360,9 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-plugin-core",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8514,18 +10382,129 @@
         "type": "github"
       }
     },
-    "logos-lidl_166": {
+    "logos-lidl_163": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
-          "logos-plugin-qt",
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_164": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_165": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_166": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8550,13 +10529,29 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8581,13 +10576,29 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8613,14 +10624,28 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8682,8 +10707,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-cpp-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8691,8 +10722,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-cpp-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8719,8 +10756,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-qt-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8728,19 +10772,26 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-qt-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8758,7 +10809,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8768,18 +10824,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8797,7 +10858,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8807,18 +10873,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -8836,6 +10907,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8846,6 +10921,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8873,9 +10952,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8883,9 +10966,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8912,9 +10999,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -8922,9 +11013,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -8951,9 +11046,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
+          "logos-plugin-qt",
+=======
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -8962,9 +11060,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -8972,11 +11069,90 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_178": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_179": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -9109,10 +11285,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9120,21 +11300,21 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9150,6 +11330,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -9158,6 +11344,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9165,11 +11357,106 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_182": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_181": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9265,7 +11552,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9275,18 +11570,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9304,7 +11607,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9314,18 +11625,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1785470541,
+        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
         "type": "github"
       },
       "original": {
@@ -9343,7 +11662,16 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9353,18 +11681,27 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9383,7 +11720,15 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9394,7 +11739,15 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9427,6 +11780,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -9441,6 +11798,10 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -9474,7 +11835,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9488,7 +11854,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9554,9 +11925,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9568,9 +11943,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
+=======
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9601,9 +11980,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9615,9 +11998,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9648,9 +12035,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-rust-sdk",
+=======
+          "logos-qt-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9662,20 +12052,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785470541,
-        "narHash": "sha256-5fVAbSGMRhEfRXfhaoq26LZeJuziRT/NMFsfhtd0ogA=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "35f33d87b7d6c22d9d4658c58855ae887ce515f1",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -9694,10 +12082,6 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
           "logos-plugin-qt",
           "logos-nix"
         ],
@@ -9709,11 +12093,90 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_194": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_193": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9840,12 +12303,17 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9855,12 +12323,17 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9889,9 +12362,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9901,9 +12379,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -9930,11 +12413,15 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -9942,22 +12429,26 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-plugin-qt",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -9972,35 +12463,43 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-qt-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10078,22 +12577,30 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10119,23 +12626,33 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -10160,34 +12677,44 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -10201,34 +12728,44 @@
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10240,6 +12777,7 @@
     "logos-lidl_204": {
       "inputs": {
         "logos-nix": [
+<<<<<<< HEAD
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
@@ -10247,10 +12785,13 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
+<<<<<<< HEAD
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
@@ -10258,6 +12799,8 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -10265,11 +12808,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -10281,6 +12824,7 @@
     "logos-lidl_205": {
       "inputs": {
         "logos-nix": [
+<<<<<<< HEAD
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
@@ -10576,6 +13120,8 @@
     "logos-lidl_213": {
       "inputs": {
         "logos-nix": [
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -10600,6 +13146,45 @@
         "type": "github"
       }
     },
+    "logos-lidl_21": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-plugin-qt",
+=======
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+=======
+          "logos-plugin-core",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
     "logos-lidl_22": {
       "inputs": {
         "logos-nix": [
@@ -10613,6 +13198,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -11463,11 +14049,74 @@
       "inputs": {
         "logos-nix": [
           "logos-module-loader-qt",
+<<<<<<< HEAD
+=======
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-module-loader-qt",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_44": {
+      "inputs": {
+        "logos-nix": [
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-module-loader-qt",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_45": {
+      "inputs": {
+        "logos-nix": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -11491,13 +14140,15 @@
     "logos-lidl_44": {
       "inputs": {
         "logos-nix": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-module-loader-qt",
-          "logos-qt-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12416,11 +15067,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787248041,
         "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
         "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+=======
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -12542,11 +15201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -12573,11 +15232,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -12606,11 +15265,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1788811494,
+        "narHash": "sha256-YlAyFHHTu7TTQWqL8f1ouGejwbwokmIixiXNisiyTFs=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "c0d9f9c9711cdf6fab194324bbd486e76ce711cd",
         "type": "github"
       },
       "original": {
@@ -12626,7 +15285,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -12635,7 +15299,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -12663,8 +15332,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-qt-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12672,8 +15347,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-qt-sdk",
+=======
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12702,7 +15383,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12712,7 +15397,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12741,7 +15430,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12751,7 +15444,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12780,7 +15477,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12790,7 +15491,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-rust-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12819,7 +15524,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12829,18 +15539,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12891,7 +15606,12 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12901,18 +15621,23 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-test-framework",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -12930,8 +15655,13 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12941,8 +15671,13 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-plugin-qt",
+=======
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -12971,8 +15706,13 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -12982,8 +15722,13 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-test-framework",
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13010,9 +15755,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-nix"
         ],
@@ -13021,9 +15769,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
@@ -13031,11 +15782,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786415321,
-        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
         "type": "github"
       },
       "original": {
@@ -13051,10 +15802,13 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-view-module-runtime",
           "logos-plugin-qt",
+=======
+          "logos-plugin-core",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13062,10 +15816,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
+          "logos-plugin-core",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13092,7 +15845,9 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13100,7 +15855,88 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-cpp-sdk",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_86": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787248041,
+        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_85": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13207,7 +16043,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13217,18 +16058,23 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13246,7 +16092,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13256,18 +16110,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13318,7 +16180,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13328,18 +16198,26 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-rust-sdk",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787248041,
-        "narHash": "sha256-WHmisUvYA8DQ2ZxSF2mM2INTEuxfyF07ypPOf+lOik4=",
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
         "owner": "logos-co",
         "repo": "logos-lidl",
-        "rev": "ae3ffe0fe9e7e020dc259208a67ca8823fcab93a",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
         "type": "github"
       },
       "original": {
@@ -13358,7 +16236,14 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13369,7 +16254,14 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13402,7 +16294,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13416,7 +16312,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13449,6 +16349,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-plugin-core",
           "logos-nix"
         ],
@@ -13590,6 +16491,8 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-rust-sdk",
           "logos-nix"
         ],
@@ -13624,7 +16527,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-lidl_97": {
+=======
+    "logos-lidl_94": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -13653,6 +16560,159 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-lidl_98": {
+=======
+    "logos-lidl_95": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-qt-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+=======
+    "logos-lidl_96": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-lidl",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415321,
+        "narHash": "sha256-Oe98SavQSVGBIY7WIc8RQ5l+Bl4KLsdmjb+PyscfdNw=",
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "rev": "ffeebf2e90fa0c65e8c486988271fe0ca029d1e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-lidl",
+        "type": "github"
+      }
+    },
+    "logos-lidl_97": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-lidl",
           "logos-nix",
@@ -13684,10 +16744,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13699,10 +16756,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-test-framework",
-          "logos-qt-sdk",
+          "logos-cpp-sdk",
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13722,6 +16776,7 @@
         "type": "github"
       }
     },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-lidl_99": {
       "inputs": {
         "logos-nix": [
@@ -13733,10 +16788,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "nixpkgs": [
@@ -13748,10 +16807,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-lidl",
           "logos-nix",
           "nixpkgs"
@@ -13839,6 +16902,7 @@
     },
     "logos-module-builder_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_27",
         "logos-design-system": "logos-design-system_11",
         "logos-module": "logos-module_67",
@@ -13847,6 +16911,16 @@
         "logos-plugin-qt": "logos-plugin-qt_38",
         "logos-protocol": "logos-protocol_48",
         "logos-qt-sdk": "logos-qt-sdk_21",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_25",
+        "logos-design-system": "logos-design-system_11",
+        "logos-module": "logos-module_65",
+        "logos-nix": "logos-nix_294",
+        "logos-plugin-core": "logos-plugin-core_10",
+        "logos-plugin-qt": "logos-plugin-qt_36",
+        "logos-protocol": "logos-protocol_46",
+        "logos-qt-sdk": "logos-qt-sdk_20",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_10",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -13896,6 +16970,7 @@
     },
     "logos-module-builder_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_33",
         "logos-design-system": "logos-design-system_12",
         "logos-module": "logos-module_83",
@@ -13904,12 +16979,22 @@
         "logos-plugin-qt": "logos-plugin-qt_51",
         "logos-protocol": "logos-protocol_65",
         "logos-qt-sdk": "logos-qt-sdk_27",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_31",
+        "logos-design-system": "logos-design-system_12",
+        "logos-module": "logos-module_79",
+        "logos-nix": "logos-nix_389",
+        "logos-plugin-core": "logos-plugin-core_11",
+        "logos-plugin-qt": "logos-plugin-qt_47",
+        "logos-protocol": "logos-protocol_58",
+        "logos-qt-sdk": "logos-qt-sdk_26",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_11",
         "logos-standalone-app": "logos-standalone-app_5",
         "logos-test-framework": "logos-test-framework_14",
         "logos-view-module": "logos-view-module_14",
         "logos-view-module-runtime": "logos-view-module-runtime_14",
-        "nix-bundle-lgx": "nix-bundle-lgx_27",
+        "nix-bundle-lgx": "nix-bundle-lgx_26",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_14",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -13920,11 +17005,11 @@
         "rust-overlay": "rust-overlay_14"
       },
       "locked": {
-        "lastModified": 1787831749,
-        "narHash": "sha256-pNS997L9U9rX01/xKTBEHQUGN1vNtI6UXZ0f+XAAzBA=",
+        "lastModified": 1789066091,
+        "narHash": "sha256-IJtHUMjZ8TOsFIQVl+IlxSnyCS9dzIijisBLX7/4m7c=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "2c51ff366f9118b21653d74f208bd000841d96e2",
+        "rev": "62861b943147128346f81978b3b9a471bd82f3fa",
         "type": "github"
       },
       "original": {
@@ -13935,6 +17020,7 @@
     },
     "logos-module-builder_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_36",
         "logos-design-system": "logos-design-system_13",
         "logos-module": "logos-module_89",
@@ -13943,6 +17029,16 @@
         "logos-plugin-qt": "logos-plugin-qt_54",
         "logos-protocol": "logos-protocol_69",
         "logos-qt-sdk": "logos-qt-sdk_29",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_34",
+        "logos-design-system": "logos-design-system_13",
+        "logos-module": "logos-module_84",
+        "logos-nix": "logos-nix_407",
+        "logos-plugin-core": "logos-plugin-core_12",
+        "logos-plugin-qt": "logos-plugin-qt_49",
+        "logos-protocol": "logos-protocol_62",
+        "logos-qt-sdk": "logos-qt-sdk_28",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_12",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -13954,7 +17050,7 @@
         "logos-test-framework": "logos-test-framework_11",
         "logos-view-module": "logos-view-module_11",
         "logos-view-module-runtime": "logos-view-module-runtime_11",
-        "nix-bundle-lgx": "nix-bundle-lgx_21",
+        "nix-bundle-lgx": "nix-bundle-lgx_20",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_11",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -13984,6 +17080,7 @@
     },
     "logos-module-builder_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_39",
         "logos-design-system": "logos-design-system_14",
         "logos-module": "logos-module_96",
@@ -13992,12 +17089,22 @@
         "logos-plugin-qt": "logos-plugin-qt_58",
         "logos-protocol": "logos-protocol_74",
         "logos-qt-sdk": "logos-qt-sdk_31",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_37",
+        "logos-design-system": "logos-design-system_14",
+        "logos-module": "logos-module_91",
+        "logos-nix": "logos-nix_438",
+        "logos-plugin-core": "logos-plugin-core_13",
+        "logos-plugin-qt": "logos-plugin-qt_53",
+        "logos-protocol": "logos-protocol_67",
+        "logos-qt-sdk": "logos-qt-sdk_30",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_13",
         "logos-standalone-app": "logos-standalone-app_6",
         "logos-test-framework": "logos-test-framework_13",
         "logos-view-module": "logos-view-module_13",
         "logos-view-module-runtime": "logos-view-module-runtime_13",
-        "nix-bundle-lgx": "nix-bundle-lgx_25",
+        "nix-bundle-lgx": "nix-bundle-lgx_24",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_13",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -14027,6 +17134,7 @@
     },
     "logos-module-builder_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_41",
         "logos-design-system": "logos-design-system_15",
         "logos-module": "logos-module_101",
@@ -14035,6 +17143,16 @@
         "logos-plugin-qt": "logos-plugin-qt_60",
         "logos-protocol": "logos-protocol_77",
         "logos-qt-sdk": "logos-qt-sdk_32",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_39",
+        "logos-design-system": "logos-design-system_15",
+        "logos-module": "logos-module_96",
+        "logos-nix": "logos-nix_455",
+        "logos-plugin-core": "logos-plugin-core_14",
+        "logos-plugin-qt": "logos-plugin-qt_55",
+        "logos-protocol": "logos-protocol_70",
+        "logos-qt-sdk": "logos-qt-sdk_31",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_14",
         "logos-standalone-app": [
           "logos-package-manager-module",
@@ -14050,7 +17168,7 @@
         "logos-test-framework": "logos-test-framework_12",
         "logos-view-module": "logos-view-module_12",
         "logos-view-module-runtime": "logos-view-module-runtime_12",
-        "nix-bundle-lgx": "nix-bundle-lgx_23",
+        "nix-bundle-lgx": "nix-bundle-lgx_22",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_12",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -14084,6 +17202,7 @@
     },
     "logos-module-builder_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_47",
         "logos-design-system": "logos-design-system_16",
         "logos-module": "logos-module_117",
@@ -14092,12 +17211,22 @@
         "logos-plugin-qt": "logos-plugin-qt_73",
         "logos-protocol": "logos-protocol_94",
         "logos-qt-sdk": "logos-qt-sdk_38",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_45",
+        "logos-design-system": "logos-design-system_16",
+        "logos-module": "logos-module_112",
+        "logos-nix": "logos-nix_549",
+        "logos-plugin-core": "logos-plugin-core_15",
+        "logos-plugin-qt": "logos-plugin-qt_68",
+        "logos-protocol": "logos-protocol_87",
+        "logos-qt-sdk": "logos-qt-sdk_37",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_15",
         "logos-standalone-app": "logos-standalone-app_7",
         "logos-test-framework": "logos-test-framework_18",
         "logos-view-module": "logos-view-module_18",
         "logos-view-module-runtime": "logos-view-module-runtime_18",
-        "nix-bundle-lgx": "nix-bundle-lgx_35",
+        "nix-bundle-lgx": "nix-bundle-lgx_33",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_18",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -14108,11 +17237,11 @@
         "rust-overlay": "rust-overlay_18"
       },
       "locked": {
-        "lastModified": 1788789525,
-        "narHash": "sha256-vK1QPDGyESqdTbryPJNo0nvyR3y4CXHdIaoSYgetOpM=",
+        "lastModified": 1789126031,
+        "narHash": "sha256-QtumPbRkJkyKWe4xOdF1O4l3rf7Y8roTn0sPLRRDiSk=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "8879bd27cb12e13f78eda37af44a39a5a66014bd",
+        "rev": "1adcfb86d80daab42d49bb72ab06ac9737b28575",
         "type": "github"
       },
       "original": {
@@ -14123,6 +17252,7 @@
     },
     "logos-module-builder_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_50",
         "logos-design-system": "logos-design-system_17",
         "logos-module": "logos-module_122",
@@ -14131,6 +17261,16 @@
         "logos-plugin-qt": "logos-plugin-qt_75",
         "logos-protocol": "logos-protocol_98",
         "logos-qt-sdk": "logos-qt-sdk_40",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_47",
+        "logos-design-system": "logos-design-system_17",
+        "logos-module": "logos-module_116",
+        "logos-nix": "logos-nix_563",
+        "logos-plugin-core": "logos-plugin-core_16",
+        "logos-plugin-qt": "logos-plugin-qt_69",
+        "logos-protocol": "logos-protocol_89",
+        "logos-qt-sdk": "logos-qt-sdk_38",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_16",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14142,7 +17282,7 @@
         "logos-test-framework": "logos-test-framework_15",
         "logos-view-module": "logos-view-module_15",
         "logos-view-module-runtime": "logos-view-module-runtime_15",
-        "nix-bundle-lgx": "nix-bundle-lgx_29",
+        "nix-bundle-lgx": "nix-bundle-lgx_27",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_15",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -14172,6 +17312,7 @@
     },
     "logos-module-builder_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_53",
         "logos-design-system": "logos-design-system_18",
         "logos-module": "logos-module_129",
@@ -14180,12 +17321,22 @@
         "logos-plugin-qt": "logos-plugin-qt_79",
         "logos-protocol": "logos-protocol_103",
         "logos-qt-sdk": "logos-qt-sdk_42",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_49",
+        "logos-design-system": "logos-design-system_18",
+        "logos-module": "logos-module_123",
+        "logos-nix": "logos-nix_593",
+        "logos-plugin-core": "logos-plugin-core_17",
+        "logos-plugin-qt": "logos-plugin-qt_73",
+        "logos-protocol": "logos-protocol_94",
+        "logos-qt-sdk": "logos-qt-sdk_40",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_17",
         "logos-standalone-app": "logos-standalone-app_8",
         "logos-test-framework": "logos-test-framework_17",
         "logos-view-module": "logos-view-module_17",
         "logos-view-module-runtime": "logos-view-module-runtime_17",
-        "nix-bundle-lgx": "nix-bundle-lgx_33",
+        "nix-bundle-lgx": "nix-bundle-lgx_31",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_17",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -14215,6 +17366,7 @@
     },
     "logos-module-builder_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_55",
         "logos-design-system": "logos-design-system_19",
         "logos-module": "logos-module_134",
@@ -14223,6 +17375,16 @@
         "logos-plugin-qt": "logos-plugin-qt_81",
         "logos-protocol": "logos-protocol_106",
         "logos-qt-sdk": "logos-qt-sdk_43",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_51",
+        "logos-design-system": "logos-design-system_19",
+        "logos-module": "logos-module_128",
+        "logos-nix": "logos-nix_610",
+        "logos-plugin-core": "logos-plugin-core_18",
+        "logos-plugin-qt": "logos-plugin-qt_75",
+        "logos-protocol": "logos-protocol_97",
+        "logos-qt-sdk": "logos-qt-sdk_41",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_18",
         "logos-standalone-app": [
           "logos-package-manager-ui",
@@ -14238,7 +17400,7 @@
         "logos-test-framework": "logos-test-framework_16",
         "logos-view-module": "logos-view-module_16",
         "logos-view-module-runtime": "logos-view-module-runtime_16",
-        "nix-bundle-lgx": "nix-bundle-lgx_31",
+        "nix-bundle-lgx": "nix-bundle-lgx_29",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_16",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -14497,7 +17659,11 @@
         "logos-cpp-sdk": "logos-cpp-sdk_19",
         "logos-design-system": "logos-design-system_8",
         "logos-module": "logos-module_49",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_234",
+=======
+        "logos-nix": "logos-nix_233",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-core": "logos-plugin-core_7",
         "logos-plugin-qt": "logos-plugin-qt_29",
         "logos-protocol": "logos-protocol_36",
@@ -14518,11 +17684,11 @@
         "rust-overlay": "rust-overlay_10"
       },
       "locked": {
-        "lastModified": 1787831749,
-        "narHash": "sha256-pNS997L9U9rX01/xKTBEHQUGN1vNtI6UXZ0f+XAAzBA=",
+        "lastModified": 1789126031,
+        "narHash": "sha256-QtumPbRkJkyKWe4xOdF1O4l3rf7Y8roTn0sPLRRDiSk=",
         "owner": "logos-co",
         "repo": "logos-module-builder",
-        "rev": "2c51ff366f9118b21653d74f208bd000841d96e2",
+        "rev": "1adcfb86d80daab42d49bb72ab06ac9737b28575",
         "type": "github"
       },
       "original": {
@@ -14533,6 +17699,7 @@
     },
     "logos-module-builder_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_22",
         "logos-design-system": "logos-design-system_9",
         "logos-module": "logos-module_55",
@@ -14541,6 +17708,16 @@
         "logos-plugin-qt": "logos-plugin-qt_32",
         "logos-protocol": "logos-protocol_40",
         "logos-qt-sdk": "logos-qt-sdk_18",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_21",
+        "logos-design-system": "logos-design-system_9",
+        "logos-module": "logos-module_53",
+        "logos-nix": "logos-nix_247",
+        "logos-plugin-core": "logos-plugin-core_8",
+        "logos-plugin-qt": "logos-plugin-qt_30",
+        "logos-protocol": "logos-protocol_38",
+        "logos-qt-sdk": "logos-qt-sdk_17",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_8",
         "logos-standalone-app": [
           "logos-package-downloader-module",
@@ -14582,6 +17759,7 @@
     },
     "logos-module-builder_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_25",
         "logos-design-system": "logos-design-system_10",
         "logos-module": "logos-module_62",
@@ -14590,6 +17768,16 @@
         "logos-plugin-qt": "logos-plugin-qt_36",
         "logos-protocol": "logos-protocol_45",
         "logos-qt-sdk": "logos-qt-sdk_20",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_23",
+        "logos-design-system": "logos-design-system_10",
+        "logos-module": "logos-module_60",
+        "logos-nix": "logos-nix_277",
+        "logos-plugin-core": "logos-plugin-core_9",
+        "logos-plugin-qt": "logos-plugin-qt_34",
+        "logos-protocol": "logos-protocol_43",
+        "logos-qt-sdk": "logos-qt-sdk_19",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-rust-sdk": "logos-rust-sdk_9",
         "logos-standalone-app": "logos-standalone-app_4",
         "logos-test-framework": "logos-test-framework_9",
@@ -14665,11 +17853,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788486878,
-        "narHash": "sha256-gP8iRHh8tUcX7TeRz4u+bRdxjFNkHkE8HzbKEwKXXwQ=",
+        "lastModified": 1789108040,
+        "narHash": "sha256-3V//OwqhLDNHBAfWkH92dmBAW1xjk01Uts7MdqXc1e4=",
         "owner": "logos-co",
         "repo": "logos-module-loader-qt",
-        "rev": "1eadfec1b401932473e09b59db5989fe2e06d5e1",
+        "rev": "1d31cd7099d93fe8db84127118905da65d0bc666",
         "type": "github"
       },
       "original": {
@@ -14681,7 +17869,11 @@
     "logos-module-loader_10": {
       "inputs": {
         "logos-container": "logos-container_25",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_298",
+=======
+        "logos-nix": "logos-nix_289",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -14714,7 +17906,11 @@
     "logos-module-loader_11": {
       "inputs": {
         "logos-container": "logos-container_27",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_330",
+=======
+        "logos-nix": "logos-nix_321",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -14746,7 +17942,11 @@
     "logos-module-loader_12": {
       "inputs": {
         "logos-container": "logos-container_30",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_419",
+=======
+        "logos-nix": "logos-nix_399",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14775,7 +17975,11 @@
     "logos-module-loader_13": {
       "inputs": {
         "logos-container": "logos-container_32",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_454",
+=======
+        "logos-nix": "logos-nix_434",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14803,7 +18007,11 @@
     "logos-module-loader_14": {
       "inputs": {
         "logos-container": "logos-container_35",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_470",
+=======
+        "logos-nix": "logos-nix_450",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14836,7 +18044,11 @@
     "logos-module-loader_15": {
       "inputs": {
         "logos-container": "logos-container_37",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_502",
+=======
+        "logos-nix": "logos-nix_482",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -14868,7 +18080,11 @@
     "logos-module-loader_16": {
       "inputs": {
         "logos-container": "logos-container_40",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_585",
+=======
+        "logos-nix": "logos-nix_558",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -14897,7 +18113,11 @@
     "logos-module-loader_17": {
       "inputs": {
         "logos-container": "logos-container_42",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_620",
+=======
+        "logos-nix": "logos-nix_589",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -14925,7 +18145,11 @@
     "logos-module-loader_18": {
       "inputs": {
         "logos-container": "logos-container_45",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_636",
+=======
+        "logos-nix": "logos-nix_605",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -14958,7 +18182,11 @@
     "logos-module-loader_19": {
       "inputs": {
         "logos-container": "logos-container_47",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_668",
+=======
+        "logos-nix": "logos-nix_637",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15156,7 +18384,11 @@
     "logos-module-loader_8": {
       "inputs": {
         "logos-container": "logos-container_20",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_247",
+=======
+        "logos-nix": "logos-nix_242",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15185,7 +18417,11 @@
     "logos-module-loader_9": {
       "inputs": {
         "logos-container": "logos-container_22",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_282",
+=======
+        "logos-nix": "logos-nix_273",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -15240,7 +18476,7 @@
     },
     "logos-module_100": {
       "inputs": {
-        "logos-nix": "logos-nix_469",
+        "logos-nix": "logos-nix_464",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15248,9 +18484,14 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15272,7 +18513,47 @@
     },
     "logos-module_101": {
       "inputs": {
+        "logos-nix": "logos-nix_466",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_101": {
+      "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_474",
+=======
+        "logos-nix": "logos-nix_481",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15282,8 +18563,6 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15305,7 +18584,11 @@
     },
     "logos-module_102": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_476",
+=======
+        "logos-nix": "logos-nix_489",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15315,9 +18598,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15373,7 +18654,7 @@
     },
     "logos-module_104": {
       "inputs": {
-        "logos-nix": "logos-nix_482",
+        "logos-nix": "logos-nix_494",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15382,10 +18663,13 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15408,7 +18692,11 @@
     },
     "logos-module_105": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_484",
+=======
+        "logos-nix": "logos-nix_497",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15416,10 +18704,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-test-framework",
           "logos-plugin-qt",
           "logos-module",
@@ -15443,7 +18734,11 @@
     },
     "logos-module_106": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_486",
+=======
+        "logos-nix": "logos-nix_499",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -15451,10 +18746,13 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
@@ -15478,16 +18776,24 @@
     },
     "logos-module_107": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_501",
+=======
+        "logos-nix": "logos-nix_518",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15509,16 +18815,24 @@
     },
     "logos-module_108": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_509",
+=======
+        "logos-nix": "logos-nix_522",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-qt-sdk",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15541,15 +18855,22 @@
     },
     "logos-module_109": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_514",
+=======
+        "logos-nix": "logos-nix_525",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15600,13 +18921,12 @@
     },
     "logos-module_110": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_517",
+=======
+        "logos-nix": "logos-nix_530",
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-plugin-qt",
@@ -15631,6 +18951,35 @@
     },
     "logos-module_111": {
       "inputs": {
+        "logos-nix": "logos-nix_532",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_111": {
+      "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_519",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -15801,6 +19150,9 @@
     "logos-module_117": {
       "inputs": {
         "logos-nix": "logos-nix_572",
+=======
+        "logos-nix": "logos-nix_548",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15823,9 +19175,15 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_118": {
       "inputs": {
         "logos-nix": "logos-nix_574",
+=======
+    "logos-module_113": {
+      "inputs": {
+        "logos-nix": "logos-nix_550",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15849,9 +19207,17 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_119": {
       "inputs": {
         "logos-nix": "logos-nix_576",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+=======
+    "logos-module_114": {
+      "inputs": {
+        "logos-nix": "logos-nix_552",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -15875,6 +19241,184 @@
         "type": "github"
       }
     },
+    "logos-module_115": {
+      "inputs": {
+        "logos-nix": "logos-nix_557",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_116": {
+      "inputs": {
+        "logos-nix": "logos-nix_562",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_117": {
+      "inputs": {
+        "logos-nix": "logos-nix_564",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_118": {
+      "inputs": {
+        "logos-nix": "logos-nix_566",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_119": {
+      "inputs": {
+        "logos-nix": "logos-nix_570",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_12": {
+      "inputs": {
+        "logos-nix": "logos-nix_48",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
     "logos-module_12": {
       "inputs": {
         "logos-nix": "logos-nix_48",
@@ -15906,12 +19450,19 @@
     "logos-module_120": {
       "inputs": {
         "logos-nix": "logos-nix_584",
+=======
+    "logos-module_120": {
+      "inputs": {
+        "logos-nix": "logos-nix_572",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -15933,14 +19484,16 @@
     },
     "logos-module_121": {
       "inputs": {
-        "logos-nix": "logos-nix_589",
+        "logos-nix": "logos-nix_574",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -15961,6 +19514,38 @@
         "type": "github"
       }
     },
+    "logos-module_121": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_589",
+=======
+        "logos-nix": "logos-nix_588",
+        "logos-package": "logos-package_57",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788740724,
+        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
     "logos-module_122": {
       "inputs": {
         "logos-nix": "logos-nix_592",
@@ -15969,7 +19554,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-module",
           "logos-nix",
@@ -15998,7 +19583,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
           "logos-module",
@@ -16052,9 +19637,237 @@
     },
     "logos-module_125": {
       "inputs": {
+        "logos-nix": "logos-nix_596",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_126": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_602",
+=======
         "logos-nix": "logos-nix_600",
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_127": {
+      "inputs": {
+        "logos-nix": "logos-nix_604",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_128": {
+      "inputs": {
+        "logos-nix": "logos-nix_609",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_129": {
+      "inputs": {
+        "logos-nix": "logos-nix_611",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_13": {
+      "inputs": {
+        "logos-nix": "logos-nix_62",
+        "logos-package": "logos-package_7",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788740724,
+        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_130": {
+      "inputs": {
+        "logos-nix": "logos-nix_613",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_131": {
+      "inputs": {
+        "logos-nix": "logos-nix_617",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -16081,11 +19894,15 @@
         "type": "github"
       }
     },
-    "logos-module_126": {
+    "logos-module_132": {
       "inputs": {
-        "logos-nix": "logos-nix_602",
+        "logos-nix": "logos-nix_619",
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -16112,6 +19929,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_127": {
       "inputs": {
         "logos-nix": "logos-nix_604",
@@ -16315,9 +20133,11 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-module_133": {
       "inputs": {
-        "logos-nix": "logos-nix_635",
+        "logos-nix": "logos-nix_621",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16325,9 +20145,46 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
+=======
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_134": {
+      "inputs": {
+        "logos-nix": "logos-nix_636",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16359,8 +20216,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16382,7 +20238,11 @@
     },
     "logos-module_135": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_642",
+=======
+        "logos-nix": "logos-nix_649",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16391,10 +20251,7 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-core",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16450,7 +20307,7 @@
     },
     "logos-module_137": {
       "inputs": {
-        "logos-nix": "logos-nix_648",
+        "logos-nix": "logos-nix_652",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16458,11 +20315,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16485,7 +20346,11 @@
     },
     "logos-module_138": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_650",
+=======
+        "logos-nix": "logos-nix_654",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -16493,11 +20358,15 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16520,11 +20389,16 @@
     },
     "logos-module_139": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_652",
+=======
+        "logos-nix": "logos-nix_676",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+<<<<<<< HEAD
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
@@ -16533,6 +20407,8 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16581,6 +20457,7 @@
     },
     "logos-module_140": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_667",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -16591,6 +20468,14 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+=======
+        "logos-nix": "logos-nix_681",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16612,6 +20497,7 @@
     },
     "logos-module_141": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_675",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -16714,6 +20600,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+        "logos-nix": "logos-nix_683",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-plugin-qt",
           "logos-module",
@@ -16735,6 +20627,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_145": {
       "inputs": {
         "logos-nix": "logos-nix_704",
@@ -16764,9 +20657,13 @@
       }
     },
     "logos-module_146": {
+=======
+    "logos-module_142": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": "logos-nix_708",
+        "logos-nix": "logos-nix_694",
         "nixpkgs": [
+<<<<<<< HEAD
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
@@ -16826,6 +20723,8 @@
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-test-framework",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-plugin-qt",
           "logos-module",
           "logos-nix",
@@ -16848,6 +20747,7 @@
     },
     "logos-module_149": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_718",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -16875,12 +20775,15 @@
     },
     "logos-module_15": {
       "inputs": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": "logos-nix_68",
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-core",
+<<<<<<< HEAD
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -16905,6 +20808,8 @@
         "logos-nix": "logos-nix_732",
         "nixpkgs": [
           "logos-plugin-qt",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -17942,7 +21847,11 @@
     },
     "logos-module_49": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_233",
+=======
+        "logos-nix": "logos-nix_232",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -17994,7 +21903,11 @@
     },
     "logos-module_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_235",
+=======
+        "logos-nix": "logos-nix_234",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18020,7 +21933,11 @@
     },
     "logos-module_51": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_237",
+=======
+        "logos-nix": "logos-nix_236",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18050,8 +21967,14 @@
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
           "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18074,6 +21997,7 @@
     "logos-module_53": {
       "inputs": {
         "logos-nix": "logos-nix_246",
+<<<<<<< HEAD
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18132,6 +22056,8 @@
     "logos-module_55": {
       "inputs": {
         "logos-nix": "logos-nix_254",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18158,9 +22084,15 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_56": {
       "inputs": {
         "logos-nix": "logos-nix_256",
+=======
+    "logos-module_54": {
+      "inputs": {
+        "logos-nix": "logos-nix_248",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18188,6 +22120,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_57": {
       "inputs": {
         "logos-nix": "logos-nix_258",
@@ -18219,8 +22152,11 @@
       }
     },
     "logos-module_58": {
+=======
+    "logos-module_55": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": "logos-nix_262",
+        "logos-nix": "logos-nix_250",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18249,9 +22185,44 @@
         "type": "github"
       }
     },
-    "logos-module_59": {
+    "logos-module_56": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_264",
+=======
+        "logos-nix": "logos-nix_254",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_57": {
+      "inputs": {
+        "logos-nix": "logos-nix_256",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18272,6 +22243,129 @@
         "owner": "logos-co",
         "repo": "logos-module",
         "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-module_6": {
+      "inputs": {
+        "logos-nix": "logos-nix_31",
+        "nixpkgs": [
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_60": {
+      "inputs": {
+        "logos-nix": "logos-nix_266",
+=======
+    "logos-module_58": {
+      "inputs": {
+        "logos-nix": "logos-nix_258",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-module_61": {
+      "inputs": {
+        "logos-nix": "logos-nix_281",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_62": {
+=======
+    "logos-module_59": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      "inputs": {
+        "logos-nix": "logos-nix_272",
+        "logos-package": "logos-package_27",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788740724,
+        "narHash": "sha256-dZkwODDIDZzI06YTGiZ4fz/0MTlXFiqnPvYN1v+J3gQ=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "f71d16ddc5779b50b188b3a3928a37c9ce90b2a1",
         "type": "github"
       },
       "original": {
@@ -18307,65 +22401,7 @@
     },
     "logos-module_60": {
       "inputs": {
-        "logos-nix": "logos-nix_266",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_61": {
-      "inputs": {
-        "logos-nix": "logos-nix_281",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_62": {
-      "inputs": {
-        "logos-nix": "logos-nix_285",
+        "logos-nix": "logos-nix_276",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18392,9 +22428,9 @@
         "type": "github"
       }
     },
-    "logos-module_63": {
+    "logos-module_61": {
       "inputs": {
-        "logos-nix": "logos-nix_287",
+        "logos-nix": "logos-nix_278",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18422,9 +22458,9 @@
         "type": "github"
       }
     },
-    "logos-module_64": {
+    "logos-module_62": {
       "inputs": {
-        "logos-nix": "logos-nix_289",
+        "logos-nix": "logos-nix_280",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18433,6 +22469,85 @@
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_63": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_287",
+=======
+        "logos-nix": "logos-nix_284",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-plugin-core",
+=======
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_64": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_289",
+=======
+        "logos-nix": "logos-nix_288",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-plugin-qt",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18462,6 +22577,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-module",
@@ -18525,6 +22641,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -18548,9 +22666,15 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_68": {
       "inputs": {
         "logos-nix": "logos-nix_304",
+=======
+    "logos-module_66": {
+      "inputs": {
+        "logos-nix": "logos-nix_295",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18582,6 +22706,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_69": {
       "inputs": {
         "logos-nix": "logos-nix_306",
@@ -18645,6 +22770,11 @@
     "logos-module_70": {
       "inputs": {
         "logos-nix": "logos-nix_310",
+=======
+    "logos-module_67": {
+      "inputs": {
+        "logos-nix": "logos-nix_297",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18677,9 +22807,13 @@
         "type": "github"
       }
     },
-    "logos-module_71": {
+    "logos-module_68": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_312",
+=======
+        "logos-nix": "logos-nix_301",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18712,9 +22846,13 @@
         "type": "github"
       }
     },
-    "logos-module_72": {
+    "logos-module_69": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_314",
+=======
+        "logos-nix": "logos-nix_303",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18747,9 +22885,39 @@
         "type": "github"
       }
     },
-    "logos-module_73": {
+    "logos-module_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_329",
+=======
+        "logos-nix": "logos-nix_36",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_70": {
+      "inputs": {
+        "logos-nix": "logos-nix_305",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18759,6 +22927,111 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_71": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_337",
+=======
+        "logos-nix": "logos-nix_320",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_72": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_342",
+=======
+        "logos-nix": "logos-nix_328",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_73": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_345",
+=======
+        "logos-nix": "logos-nix_333",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -18780,70 +23053,7 @@
     },
     "logos-module_74": {
       "inputs": {
-        "logos-nix": "logos-nix_337",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_75": {
-      "inputs": {
-        "logos-nix": "logos-nix_342",
-        "nixpkgs": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-plugin-qt",
-          "logos-module",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415910,
-        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-module",
-        "type": "github"
-      }
-    },
-    "logos-module_76": {
-      "inputs": {
-        "logos-nix": "logos-nix_345",
+        "logos-nix": "logos-nix_336",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -18872,15 +23082,101 @@
         "type": "github"
       }
     },
-    "logos-module_77": {
+    "logos-module_75": {
       "inputs": {
-        "logos-nix": "logos-nix_347",
+        "logos-nix": "logos-nix_338",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_76": {
+      "inputs": {
+        "logos-nix": "logos-nix_360",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_365",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_77": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_347",
+=======
+        "logos-nix": "logos-nix_367",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-plugin-qt",
@@ -18933,6 +23229,7 @@
     },
     "logos-module_79": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_370",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -19071,6 +23368,9 @@
     "logos-module_83": {
       "inputs": {
         "logos-nix": "logos-nix_405",
+=======
+        "logos-nix": "logos-nix_388",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19093,9 +23393,42 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_84": {
       "inputs": {
         "logos-nix": "logos-nix_407",
+=======
+    "logos-module_8": {
+      "inputs": {
+        "logos-nix": "logos-nix_38",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_80": {
+      "inputs": {
+        "logos-nix": "logos-nix_390",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19119,6 +23452,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_85": {
       "inputs": {
         "logos-nix": "logos-nix_409",
@@ -19146,8 +23480,11 @@
       }
     },
     "logos-module_86": {
+=======
+    "logos-module_81": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": "logos-nix_413",
+        "logos-nix": "logos-nix_392",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19172,15 +23509,172 @@
         "type": "github"
       }
     },
-    "logos-module_87": {
+    "logos-module_82": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_418",
+=======
+        "logos-nix": "logos-nix_398",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
+<<<<<<< HEAD
+=======
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_83": {
+      "inputs": {
+        "logos-nix": "logos-nix_403",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_84": {
+      "inputs": {
+        "logos-nix": "logos-nix_406",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_85": {
+      "inputs": {
+        "logos-nix": "logos-nix_408",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_86": {
+      "inputs": {
+        "logos-nix": "logos-nix_410",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_87": {
+      "inputs": {
+        "logos-nix": "logos-nix_414",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-module",
           "logos-nix",
           "nixpkgs"
@@ -19202,6 +23696,7 @@
     },
     "logos-module_88": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_423",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -19380,6 +23875,9 @@
     "logos-module_93": {
       "inputs": {
         "logos-nix": "logos-nix_436",
+=======
+        "logos-nix": "logos-nix_416",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19408,9 +23906,15 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_94": {
       "inputs": {
         "logos-nix": "logos-nix_438",
+=======
+    "logos-module_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_418",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19439,6 +23943,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-module_95": {
       "inputs": {
         "logos-nix": "logos-nix_453",
@@ -19467,8 +23972,38 @@
       }
     },
     "logos-module_96": {
+=======
+    "logos-module_9": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": "logos-nix_457",
+        "logos-nix": "logos-nix_40",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_90": {
+      "inputs": {
+        "logos-nix": "logos-nix_433",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19495,9 +24030,13 @@
         "type": "github"
       }
     },
-    "logos-module_97": {
+    "logos-module_91": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_459",
+=======
+        "logos-nix": "logos-nix_437",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19525,9 +24064,13 @@
         "type": "github"
       }
     },
-    "logos-module_98": {
+    "logos-module_92": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_461",
+=======
+        "logos-nix": "logos-nix_439",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -19555,15 +24098,214 @@
         "type": "github"
       }
     },
-    "logos-module_99": {
+    "logos-module_93": {
       "inputs": {
-        "logos-nix": "logos-nix_465",
+        "logos-nix": "logos-nix_441",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_94": {
+      "inputs": {
+        "logos-nix": "logos-nix_445",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_95": {
+      "inputs": {
+        "logos-nix": "logos-nix_449",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_96": {
+      "inputs": {
+        "logos-nix": "logos-nix_454",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_97": {
+      "inputs": {
+        "logos-nix": "logos-nix_456",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-core",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_458",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-module",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415910,
+        "narHash": "sha256-7zcTkY6r0iXXaFnZaWKNBMHh53RkQh2P455421TX7Gk=",
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "rev": "9812dc8c69cfbfed3eea06510a5c1ff33c1fcf7f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-module",
+        "type": "github"
+      }
+    },
+    "logos-module_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_462",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -20758,11 +25500,11 @@
         "nixpkgs-windows": "nixpkgs-windows_139"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
         "type": "github"
       },
       "original": {
@@ -22402,11 +27144,19 @@
         "nixpkgs-windows": "nixpkgs-windows_211"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1788961777,
         "narHash": "sha256-p3bCNBLWks0Z7OoJaBhkTPpXtfgX59rtUefcbC59gM8=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "5378de595fa5d200d3e2f950b9a3a4c193170528",
+=======
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -22497,11 +27247,19 @@
         "nixpkgs-windows": "nixpkgs-windows_215"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -22573,11 +27331,11 @@
         "nixpkgs-windows": "nixpkgs-windows_219"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
         "type": "github"
       },
       "original": {
@@ -22706,11 +27464,11 @@
         "nixpkgs-windows": "nixpkgs-windows_225"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -22782,11 +27540,11 @@
         "nixpkgs-windows": "nixpkgs-windows_229"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23105,11 +27863,11 @@
         "nixpkgs-windows": "nixpkgs-windows_244"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23124,11 +27882,11 @@
         "nixpkgs-windows": "nixpkgs-windows_245"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -23158,15 +27916,14 @@
     },
     "logos-nix_265": {
       "inputs": {
-        "nixpkgs": "nixpkgs_265",
-        "nixpkgs-windows": "nixpkgs-windows_247"
+        "nixpkgs": "nixpkgs_265"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -23177,15 +27934,14 @@
     },
     "logos-nix_266": {
       "inputs": {
-        "nixpkgs": "nixpkgs_266",
-        "nixpkgs-windows": "nixpkgs-windows_248"
+        "nixpkgs": "nixpkgs_266"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -23197,7 +27953,7 @@
     "logos-nix_267": {
       "inputs": {
         "nixpkgs": "nixpkgs_267",
-        "nixpkgs-windows": "nixpkgs-windows_249"
+        "nixpkgs-windows": "nixpkgs-windows_247"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23216,7 +27972,7 @@
     "logos-nix_268": {
       "inputs": {
         "nixpkgs": "nixpkgs_268",
-        "nixpkgs-windows": "nixpkgs-windows_250"
+        "nixpkgs-windows": "nixpkgs-windows_248"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23235,7 +27991,7 @@
     "logos-nix_269": {
       "inputs": {
         "nixpkgs": "nixpkgs_269",
-        "nixpkgs-windows": "nixpkgs-windows_251"
+        "nixpkgs-windows": "nixpkgs-windows_249"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23273,7 +28029,7 @@
     "logos-nix_270": {
       "inputs": {
         "nixpkgs": "nixpkgs_270",
-        "nixpkgs-windows": "nixpkgs-windows_252"
+        "nixpkgs-windows": "nixpkgs-windows_250"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -23292,7 +28048,7 @@
     "logos-nix_271": {
       "inputs": {
         "nixpkgs": "nixpkgs_271",
-        "nixpkgs-windows": "nixpkgs-windows_253"
+        "nixpkgs-windows": "nixpkgs-windows_251"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -23311,7 +28067,7 @@
     "logos-nix_272": {
       "inputs": {
         "nixpkgs": "nixpkgs_272",
-        "nixpkgs-windows": "nixpkgs-windows_254"
+        "nixpkgs-windows": "nixpkgs-windows_252"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23329,6 +28085,7 @@
     },
     "logos-nix_273": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_273"
       },
       "locked": {
@@ -23367,6 +28124,10 @@
       "inputs": {
         "nixpkgs": "nixpkgs_275",
         "nixpkgs-windows": "nixpkgs-windows_255"
+=======
+        "nixpkgs": "nixpkgs_273",
+        "nixpkgs-windows": "nixpkgs-windows_253"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -23382,6 +28143,47 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "logos-nix_274": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_274",
+        "nixpkgs-windows": "nixpkgs-windows_254"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_275": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_275",
+        "nixpkgs-windows": "nixpkgs-windows_255"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_276": {
       "inputs": {
         "nixpkgs": "nixpkgs_276",
@@ -23692,11 +28494,11 @@
         "nixpkgs-windows": "nixpkgs-windows_270"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24163,15 +28965,14 @@
     },
     "logos-nix_312": {
       "inputs": {
-        "nixpkgs": "nixpkgs_312",
-        "nixpkgs-windows": "nixpkgs-windows_292"
+        "nixpkgs": "nixpkgs_312"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24182,15 +28983,14 @@
     },
     "logos-nix_313": {
       "inputs": {
-        "nixpkgs": "nixpkgs_313",
-        "nixpkgs-windows": "nixpkgs-windows_293"
+        "nixpkgs": "nixpkgs_313"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -24202,7 +29002,7 @@
     "logos-nix_314": {
       "inputs": {
         "nixpkgs": "nixpkgs_314",
-        "nixpkgs-windows": "nixpkgs-windows_294"
+        "nixpkgs-windows": "nixpkgs-windows_292"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24221,7 +29021,7 @@
     "logos-nix_315": {
       "inputs": {
         "nixpkgs": "nixpkgs_315",
-        "nixpkgs-windows": "nixpkgs-windows_295"
+        "nixpkgs-windows": "nixpkgs-windows_293"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24240,7 +29040,7 @@
     "logos-nix_316": {
       "inputs": {
         "nixpkgs": "nixpkgs_316",
-        "nixpkgs-windows": "nixpkgs-windows_296"
+        "nixpkgs-windows": "nixpkgs-windows_294"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24259,7 +29059,7 @@
     "logos-nix_317": {
       "inputs": {
         "nixpkgs": "nixpkgs_317",
-        "nixpkgs-windows": "nixpkgs-windows_297"
+        "nixpkgs-windows": "nixpkgs-windows_295"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24278,7 +29078,7 @@
     "logos-nix_318": {
       "inputs": {
         "nixpkgs": "nixpkgs_318",
-        "nixpkgs-windows": "nixpkgs-windows_298"
+        "nixpkgs-windows": "nixpkgs-windows_296"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24297,7 +29097,7 @@
     "logos-nix_319": {
       "inputs": {
         "nixpkgs": "nixpkgs_319",
-        "nixpkgs-windows": "nixpkgs-windows_299"
+        "nixpkgs-windows": "nixpkgs-windows_297"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24335,7 +29135,7 @@
     "logos-nix_320": {
       "inputs": {
         "nixpkgs": "nixpkgs_320",
-        "nixpkgs-windows": "nixpkgs-windows_300"
+        "nixpkgs-windows": "nixpkgs-windows_298"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24353,7 +29153,12 @@
     },
     "logos-nix_321": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_321"
+=======
+        "nixpkgs": "nixpkgs_321",
+        "nixpkgs-windows": "nixpkgs-windows_299"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24371,7 +29176,12 @@
     },
     "logos-nix_322": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_322"
+=======
+        "nixpkgs": "nixpkgs_322",
+        "nixpkgs-windows": "nixpkgs-windows_300"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24466,7 +29276,7 @@
     "logos-nix_327": {
       "inputs": {
         "nixpkgs": "nixpkgs_327",
-        "nixpkgs-windows": "nixpkgs-windows_305"
+        "nixpkgs-windows": "nixpkgs-windows_303"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24485,7 +29295,7 @@
     "logos-nix_328": {
       "inputs": {
         "nixpkgs": "nixpkgs_328",
-        "nixpkgs-windows": "nixpkgs-windows_306"
+        "nixpkgs-windows": "nixpkgs-windows_304"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24504,7 +29314,7 @@
     "logos-nix_329": {
       "inputs": {
         "nixpkgs": "nixpkgs_329",
-        "nixpkgs-windows": "nixpkgs-windows_307"
+        "nixpkgs-windows": "nixpkgs-windows_305"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24542,7 +29352,7 @@
     "logos-nix_330": {
       "inputs": {
         "nixpkgs": "nixpkgs_330",
-        "nixpkgs-windows": "nixpkgs-windows_308"
+        "nixpkgs-windows": "nixpkgs-windows_306"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24561,7 +29371,7 @@
     "logos-nix_331": {
       "inputs": {
         "nixpkgs": "nixpkgs_331",
-        "nixpkgs-windows": "nixpkgs-windows_309"
+        "nixpkgs-windows": "nixpkgs-windows_307"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24580,14 +29390,14 @@
     "logos-nix_332": {
       "inputs": {
         "nixpkgs": "nixpkgs_332",
-        "nixpkgs-windows": "nixpkgs-windows_310"
+        "nixpkgs-windows": "nixpkgs-windows_308"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24599,7 +29409,7 @@
     "logos-nix_333": {
       "inputs": {
         "nixpkgs": "nixpkgs_333",
-        "nixpkgs-windows": "nixpkgs-windows_311"
+        "nixpkgs-windows": "nixpkgs-windows_309"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24635,7 +29445,12 @@
     },
     "logos-nix_335": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_335"
+=======
+        "nixpkgs": "nixpkgs_335",
+        "nixpkgs-windows": "nixpkgs-windows_310"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24654,7 +29469,11 @@
     "logos-nix_336": {
       "inputs": {
         "nixpkgs": "nixpkgs_336",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_312"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_311"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24673,7 +29492,11 @@
     "logos-nix_337": {
       "inputs": {
         "nixpkgs": "nixpkgs_337",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_313"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_312"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24692,7 +29515,11 @@
     "logos-nix_338": {
       "inputs": {
         "nixpkgs": "nixpkgs_338",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_314"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_313"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24711,7 +29538,11 @@
     "logos-nix_339": {
       "inputs": {
         "nixpkgs": "nixpkgs_339",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_315"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_314"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24749,7 +29580,7 @@
     "logos-nix_340": {
       "inputs": {
         "nixpkgs": "nixpkgs_340",
-        "nixpkgs-windows": "nixpkgs-windows_316"
+        "nixpkgs-windows": "nixpkgs-windows_315"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24768,7 +29599,7 @@
     "logos-nix_341": {
       "inputs": {
         "nixpkgs": "nixpkgs_341",
-        "nixpkgs-windows": "nixpkgs-windows_317"
+        "nixpkgs-windows": "nixpkgs-windows_316"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -24787,7 +29618,7 @@
     "logos-nix_342": {
       "inputs": {
         "nixpkgs": "nixpkgs_342",
-        "nixpkgs-windows": "nixpkgs-windows_318"
+        "nixpkgs-windows": "nixpkgs-windows_317"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24805,7 +29636,12 @@
     },
     "logos-nix_343": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_343"
+=======
+        "nixpkgs": "nixpkgs_343",
+        "nixpkgs-windows": "nixpkgs-windows_318"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -24842,6 +29678,7 @@
     },
     "logos-nix_345": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_345",
         "nixpkgs-windows": "nixpkgs-windows_320"
       },
@@ -24882,6 +29719,46 @@
       "inputs": {
         "nixpkgs": "nixpkgs_347",
         "nixpkgs-windows": "nixpkgs-windows_322"
+=======
+        "nixpkgs": "nixpkgs_345"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_346": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_346"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_347": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_347",
+        "nixpkgs-windows": "nixpkgs-windows_320"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24900,7 +29777,7 @@
     "logos-nix_348": {
       "inputs": {
         "nixpkgs": "nixpkgs_348",
-        "nixpkgs-windows": "nixpkgs-windows_323"
+        "nixpkgs-windows": "nixpkgs-windows_321"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24919,7 +29796,7 @@
     "logos-nix_349": {
       "inputs": {
         "nixpkgs": "nixpkgs_349",
-        "nixpkgs-windows": "nixpkgs-windows_324"
+        "nixpkgs-windows": "nixpkgs-windows_322"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24957,7 +29834,7 @@
     "logos-nix_350": {
       "inputs": {
         "nixpkgs": "nixpkgs_350",
-        "nixpkgs-windows": "nixpkgs-windows_325"
+        "nixpkgs-windows": "nixpkgs-windows_323"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -24976,14 +29853,14 @@
     "logos-nix_351": {
       "inputs": {
         "nixpkgs": "nixpkgs_351",
-        "nixpkgs-windows": "nixpkgs-windows_326"
+        "nixpkgs-windows": "nixpkgs-windows_324"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -24995,14 +29872,14 @@
     "logos-nix_352": {
       "inputs": {
         "nixpkgs": "nixpkgs_352",
-        "nixpkgs-windows": "nixpkgs-windows_327"
+        "nixpkgs-windows": "nixpkgs-windows_325"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25014,7 +29891,7 @@
     "logos-nix_353": {
       "inputs": {
         "nixpkgs": "nixpkgs_353",
-        "nixpkgs-windows": "nixpkgs-windows_328"
+        "nixpkgs-windows": "nixpkgs-windows_326"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25035,11 +29912,19 @@
         "nixpkgs": "nixpkgs_354"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25069,7 +29954,11 @@
     "logos-nix_356": {
       "inputs": {
         "nixpkgs": "nixpkgs_356",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_329"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_327"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25088,7 +29977,30 @@
     "logos-nix_357": {
       "inputs": {
         "nixpkgs": "nixpkgs_357",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_330"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_328"
+      },
+      "locked": {
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_358": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_358",
+        "nixpkgs-windows": "nixpkgs-windows_329"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25104,6 +30016,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_358": {
       "inputs": {
         "nixpkgs": "nixpkgs_358",
@@ -25134,6 +30047,19 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+    "logos-nix_359": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_359",
+        "nixpkgs-windows": "nixpkgs-windows_330"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25164,7 +30090,7 @@
     "logos-nix_360": {
       "inputs": {
         "nixpkgs": "nixpkgs_360",
-        "nixpkgs-windows": "nixpkgs-windows_333"
+        "nixpkgs-windows": "nixpkgs-windows_331"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -25183,7 +30109,7 @@
     "logos-nix_361": {
       "inputs": {
         "nixpkgs": "nixpkgs_361",
-        "nixpkgs-windows": "nixpkgs-windows_334"
+        "nixpkgs-windows": "nixpkgs-windows_332"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -25202,7 +30128,7 @@
     "logos-nix_362": {
       "inputs": {
         "nixpkgs": "nixpkgs_362",
-        "nixpkgs-windows": "nixpkgs-windows_335"
+        "nixpkgs-windows": "nixpkgs-windows_333"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25223,6 +30149,7 @@
         "nixpkgs": "nixpkgs_363"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -25241,6 +30168,8 @@
         "nixpkgs": "nixpkgs_364"
       },
       "locked": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -25254,10 +30183,42 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_365": {
       "inputs": {
         "nixpkgs": "nixpkgs_365",
         "nixpkgs-windows": "nixpkgs-windows_336"
+=======
+    "logos-nix_364": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_364",
+        "nixpkgs-windows": "nixpkgs-windows_334"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-nix_366": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_366",
+        "nixpkgs-windows": "nixpkgs-windows_337"
+=======
+    "logos-nix_365": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_365",
+        "nixpkgs-windows": "nixpkgs-windows_335"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25276,7 +30237,8 @@
     "logos-nix_366": {
       "inputs": {
         "nixpkgs": "nixpkgs_366",
-        "nixpkgs-windows": "nixpkgs-windows_337"
+        "nixpkgs-windows": "nixpkgs-windows_336"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25295,7 +30257,11 @@
     "logos-nix_367": {
       "inputs": {
         "nixpkgs": "nixpkgs_367",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_338"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_337"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25314,7 +30280,11 @@
     "logos-nix_368": {
       "inputs": {
         "nixpkgs": "nixpkgs_368",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_339"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_338"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25333,7 +30303,7 @@
     "logos-nix_369": {
       "inputs": {
         "nixpkgs": "nixpkgs_369",
-        "nixpkgs-windows": "nixpkgs-windows_340"
+        "nixpkgs-windows": "nixpkgs-windows_339"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25371,7 +30341,7 @@
     "logos-nix_370": {
       "inputs": {
         "nixpkgs": "nixpkgs_370",
-        "nixpkgs-windows": "nixpkgs-windows_341"
+        "nixpkgs-windows": "nixpkgs-windows_340"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25390,14 +30360,14 @@
     "logos-nix_371": {
       "inputs": {
         "nixpkgs": "nixpkgs_371",
-        "nixpkgs-windows": "nixpkgs-windows_342"
+        "nixpkgs-windows": "nixpkgs-windows_341"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
         "type": "github"
       },
       "original": {
@@ -25409,7 +30379,7 @@
     "logos-nix_372": {
       "inputs": {
         "nixpkgs": "nixpkgs_372",
-        "nixpkgs-windows": "nixpkgs-windows_343"
+        "nixpkgs-windows": "nixpkgs-windows_342"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -25428,7 +30398,7 @@
     "logos-nix_373": {
       "inputs": {
         "nixpkgs": "nixpkgs_373",
-        "nixpkgs-windows": "nixpkgs-windows_344"
+        "nixpkgs-windows": "nixpkgs-windows_343"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25446,15 +30416,14 @@
     },
     "logos-nix_374": {
       "inputs": {
-        "nixpkgs": "nixpkgs_374",
-        "nixpkgs-windows": "nixpkgs-windows_345"
+        "nixpkgs": "nixpkgs_374"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25465,26 +30434,7 @@
     },
     "logos-nix_375": {
       "inputs": {
-        "nixpkgs": "nixpkgs_375",
-        "nixpkgs-windows": "nixpkgs-windows_346"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_376": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_376"
+        "nixpkgs": "nixpkgs_375"
       },
       "locked": {
         "lastModified": 1773955630,
@@ -25500,6 +30450,49 @@
         "type": "github"
       }
     },
+    "logos-nix_376": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_376"
+=======
+        "nixpkgs": "nixpkgs_376",
+        "nixpkgs-windows": "nixpkgs-windows_344"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_377": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_377",
+        "nixpkgs-windows": "nixpkgs-windows_345"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
     "logos-nix_377": {
       "inputs": {
         "nixpkgs": "nixpkgs_377",
@@ -25523,6 +30516,12 @@
       "inputs": {
         "nixpkgs": "nixpkgs_378",
         "nixpkgs-windows": "nixpkgs-windows_348"
+=======
+    "logos-nix_378": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_378",
+        "nixpkgs-windows": "nixpkgs-windows_346"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25540,15 +30539,19 @@
     },
     "logos-nix_379": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_379",
         "nixpkgs-windows": "nixpkgs-windows_349"
+=======
+        "nixpkgs": "nixpkgs_379"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -25598,7 +30601,7 @@
     "logos-nix_381": {
       "inputs": {
         "nixpkgs": "nixpkgs_381",
-        "nixpkgs-windows": "nixpkgs-windows_351"
+        "nixpkgs-windows": "nixpkgs-windows_347"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25617,14 +30620,14 @@
     "logos-nix_382": {
       "inputs": {
         "nixpkgs": "nixpkgs_382",
-        "nixpkgs-windows": "nixpkgs-windows_352"
+        "nixpkgs-windows": "nixpkgs-windows_348"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -25636,7 +30639,7 @@
     "logos-nix_383": {
       "inputs": {
         "nixpkgs": "nixpkgs_383",
-        "nixpkgs-windows": "nixpkgs-windows_353"
+        "nixpkgs-windows": "nixpkgs-windows_349"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25654,15 +30657,22 @@
     },
     "logos-nix_384": {
       "inputs": {
-        "nixpkgs": "nixpkgs_384",
-        "nixpkgs-windows": "nixpkgs-windows_354"
+        "nixpkgs": "nixpkgs_384"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+=======
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25673,15 +30683,22 @@
     },
     "logos-nix_385": {
       "inputs": {
-        "nixpkgs": "nixpkgs_385",
-        "nixpkgs-windows": "nixpkgs-windows_355"
+        "nixpkgs": "nixpkgs_385"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+=======
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25693,7 +30710,7 @@
     "logos-nix_386": {
       "inputs": {
         "nixpkgs": "nixpkgs_386",
-        "nixpkgs-windows": "nixpkgs-windows_356"
+        "nixpkgs-windows": "nixpkgs-windows_350"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25711,7 +30728,12 @@
     },
     "logos-nix_387": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_387"
+=======
+        "nixpkgs": "nixpkgs_387",
+        "nixpkgs-windows": "nixpkgs-windows_351"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1774455309,
@@ -25729,6 +30751,7 @@
     },
     "logos-nix_388": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_388"
       },
       "locked": {
@@ -25737,6 +30760,17 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "nixpkgs": "nixpkgs_388",
+        "nixpkgs-windows": "nixpkgs-windows_352"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25748,6 +30782,7 @@
     "logos-nix_389": {
       "inputs": {
         "nixpkgs": "nixpkgs_389",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_357"
       },
       "locked": {
@@ -25756,6 +30791,16 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+        "nixpkgs-windows": "nixpkgs-windows_353"
+      },
+      "locked": {
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -25786,7 +30831,11 @@
     "logos-nix_390": {
       "inputs": {
         "nixpkgs": "nixpkgs_390",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_358"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_354"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25805,6 +30854,7 @@
     "logos-nix_391": {
       "inputs": {
         "nixpkgs": "nixpkgs_391",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_359"
       },
       "locked": {
@@ -25844,6 +30894,9 @@
       "inputs": {
         "nixpkgs": "nixpkgs_393",
         "nixpkgs-windows": "nixpkgs-windows_361"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_355"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786729772,
@@ -25859,10 +30912,48 @@
         "type": "github"
       }
     },
+    "logos-nix_392": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_392",
+        "nixpkgs-windows": "nixpkgs-windows_356"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_393": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_393",
+        "nixpkgs-windows": "nixpkgs-windows_357"
+      },
+      "locked": {
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_394": {
       "inputs": {
         "nixpkgs": "nixpkgs_394",
-        "nixpkgs-windows": "nixpkgs-windows_362"
+        "nixpkgs-windows": "nixpkgs-windows_358"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25880,6 +30971,7 @@
     },
     "logos-nix_395": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_395"
       },
       "locked": {
@@ -25918,6 +31010,10 @@
       "inputs": {
         "nixpkgs": "nixpkgs_397",
         "nixpkgs-windows": "nixpkgs-windows_363"
+=======
+        "nixpkgs": "nixpkgs_395",
+        "nixpkgs-windows": "nixpkgs-windows_359"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25935,27 +31031,16 @@
     },
     "logos-nix_398": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_398",
         "nixpkgs-windows": "nixpkgs-windows_364"
       },
       "locked": {
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
-    "logos-nix_399": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_399",
-        "nixpkgs-windows": "nixpkgs-windows_365"
+=======
+        "nixpkgs": "nixpkgs_396",
+        "nixpkgs-windows": "nixpkgs-windows_360"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -25971,6 +31056,72 @@
         "type": "github"
       }
     },
+    "logos-nix_397": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_397",
+        "nixpkgs-windows": "nixpkgs-windows_361"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_399": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_399",
+        "nixpkgs-windows": "nixpkgs-windows_365"
+=======
+        "nixpkgs": "nixpkgs_398",
+        "nixpkgs-windows": "nixpkgs-windows_362"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+=======
+    "logos-nix_399": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_399",
+        "nixpkgs-windows": "nixpkgs-windows_363"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_4": {
       "inputs": {
         "nixpkgs": "nixpkgs_4",
@@ -26011,9 +31162,11 @@
     },
     "logos-nix_400": {
       "inputs": {
-        "nixpkgs": "nixpkgs_400"
+        "nixpkgs": "nixpkgs_400",
+        "nixpkgs-windows": "nixpkgs-windows_364"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1774455309,
         "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
@@ -26034,9 +31187,13 @@
       "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+=======
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26045,6 +31202,32 @@
         "type": "github"
       }
     },
+    "logos-nix_402": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_402",
+        "nixpkgs-windows": "nixpkgs-windows_366"
+=======
+        "nixpkgs": "nixpkgs_401",
+        "nixpkgs-windows": "nixpkgs-windows_365"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+=======
     "logos-nix_402": {
       "inputs": {
         "nixpkgs": "nixpkgs_402",
@@ -26064,6 +31247,7 @@
         "type": "github"
       }
     },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_403": {
       "inputs": {
         "nixpkgs": "nixpkgs_403",
@@ -26146,11 +31330,11 @@
         "nixpkgs-windows": "nixpkgs-windows_371"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26469,11 +31653,11 @@
         "nixpkgs-windows": "nixpkgs-windows_386"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -26488,8 +31672,32 @@
         "nixpkgs-windows": "nixpkgs-windows_387"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_424": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_424",
+        "nixpkgs-windows": "nixpkgs-windows_388"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+=======
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
@@ -26522,15 +31730,14 @@
     },
     "logos-nix_425": {
       "inputs": {
-        "nixpkgs": "nixpkgs_425",
-        "nixpkgs-windows": "nixpkgs-windows_389"
+        "nixpkgs": "nixpkgs_425"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -26541,15 +31748,14 @@
     },
     "logos-nix_426": {
       "inputs": {
-        "nixpkgs": "nixpkgs_426",
-        "nixpkgs-windows": "nixpkgs-windows_390"
+        "nixpkgs": "nixpkgs_426"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -26561,7 +31767,7 @@
     "logos-nix_427": {
       "inputs": {
         "nixpkgs": "nixpkgs_427",
-        "nixpkgs-windows": "nixpkgs-windows_391"
+        "nixpkgs-windows": "nixpkgs-windows_389"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -26580,7 +31786,7 @@
     "logos-nix_428": {
       "inputs": {
         "nixpkgs": "nixpkgs_428",
-        "nixpkgs-windows": "nixpkgs-windows_392"
+        "nixpkgs-windows": "nixpkgs-windows_390"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26599,7 +31805,7 @@
     "logos-nix_429": {
       "inputs": {
         "nixpkgs": "nixpkgs_429",
-        "nixpkgs-windows": "nixpkgs-windows_393"
+        "nixpkgs-windows": "nixpkgs-windows_391"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26637,7 +31843,7 @@
     "logos-nix_430": {
       "inputs": {
         "nixpkgs": "nixpkgs_430",
-        "nixpkgs-windows": "nixpkgs-windows_394"
+        "nixpkgs-windows": "nixpkgs-windows_392"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26656,7 +31862,7 @@
     "logos-nix_431": {
       "inputs": {
         "nixpkgs": "nixpkgs_431",
-        "nixpkgs-windows": "nixpkgs-windows_395"
+        "nixpkgs-windows": "nixpkgs-windows_393"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26675,7 +31881,7 @@
     "logos-nix_432": {
       "inputs": {
         "nixpkgs": "nixpkgs_432",
-        "nixpkgs-windows": "nixpkgs-windows_396"
+        "nixpkgs-windows": "nixpkgs-windows_394"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26694,7 +31900,7 @@
     "logos-nix_433": {
       "inputs": {
         "nixpkgs": "nixpkgs_433",
-        "nixpkgs-windows": "nixpkgs-windows_397"
+        "nixpkgs-windows": "nixpkgs-windows_395"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26713,7 +31919,7 @@
     "logos-nix_434": {
       "inputs": {
         "nixpkgs": "nixpkgs_434",
-        "nixpkgs-windows": "nixpkgs-windows_398"
+        "nixpkgs-windows": "nixpkgs-windows_396"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26732,7 +31938,7 @@
     "logos-nix_435": {
       "inputs": {
         "nixpkgs": "nixpkgs_435",
-        "nixpkgs-windows": "nixpkgs-windows_399"
+        "nixpkgs-windows": "nixpkgs-windows_397"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26751,7 +31957,7 @@
     "logos-nix_436": {
       "inputs": {
         "nixpkgs": "nixpkgs_436",
-        "nixpkgs-windows": "nixpkgs-windows_400"
+        "nixpkgs-windows": "nixpkgs-windows_398"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26770,7 +31976,7 @@
     "logos-nix_437": {
       "inputs": {
         "nixpkgs": "nixpkgs_437",
-        "nixpkgs-windows": "nixpkgs-windows_401"
+        "nixpkgs-windows": "nixpkgs-windows_399"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26789,7 +31995,7 @@
     "logos-nix_438": {
       "inputs": {
         "nixpkgs": "nixpkgs_438",
-        "nixpkgs-windows": "nixpkgs-windows_402"
+        "nixpkgs-windows": "nixpkgs-windows_400"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26808,7 +32014,7 @@
     "logos-nix_439": {
       "inputs": {
         "nixpkgs": "nixpkgs_439",
-        "nixpkgs-windows": "nixpkgs-windows_403"
+        "nixpkgs-windows": "nixpkgs-windows_401"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26846,7 +32052,7 @@
     "logos-nix_440": {
       "inputs": {
         "nixpkgs": "nixpkgs_440",
-        "nixpkgs-windows": "nixpkgs-windows_404"
+        "nixpkgs-windows": "nixpkgs-windows_402"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26865,7 +32071,7 @@
     "logos-nix_441": {
       "inputs": {
         "nixpkgs": "nixpkgs_441",
-        "nixpkgs-windows": "nixpkgs-windows_405"
+        "nixpkgs-windows": "nixpkgs-windows_403"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26884,7 +32090,7 @@
     "logos-nix_442": {
       "inputs": {
         "nixpkgs": "nixpkgs_442",
-        "nixpkgs-windows": "nixpkgs-windows_406"
+        "nixpkgs-windows": "nixpkgs-windows_404"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -26903,7 +32109,7 @@
     "logos-nix_443": {
       "inputs": {
         "nixpkgs": "nixpkgs_443",
-        "nixpkgs-windows": "nixpkgs-windows_407"
+        "nixpkgs-windows": "nixpkgs-windows_405"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -26922,7 +32128,7 @@
     "logos-nix_444": {
       "inputs": {
         "nixpkgs": "nixpkgs_444",
-        "nixpkgs-windows": "nixpkgs-windows_408"
+        "nixpkgs-windows": "nixpkgs-windows_406"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26940,6 +32146,7 @@
     },
     "logos-nix_445": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_445"
       },
       "locked": {
@@ -26978,6 +32185,10 @@
       "inputs": {
         "nixpkgs": "nixpkgs_447",
         "nixpkgs-windows": "nixpkgs-windows_409"
+=======
+        "nixpkgs": "nixpkgs_445",
+        "nixpkgs-windows": "nixpkgs-windows_407"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -26993,6 +32204,47 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "logos-nix_446": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_446",
+        "nixpkgs-windows": "nixpkgs-windows_408"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_447": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_447",
+        "nixpkgs-windows": "nixpkgs-windows_409"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_448": {
       "inputs": {
         "nixpkgs": "nixpkgs_448",
@@ -27075,11 +32327,11 @@
         "nixpkgs-windows": "nixpkgs-windows_413"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -27527,7 +32779,43 @@
     },
     "logos-nix_473": {
       "inputs": {
-        "nixpkgs": "nixpkgs_473",
+        "nixpkgs": "nixpkgs_473"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_474": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_474"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_475": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_475",
         "nixpkgs-windows": "nixpkgs-windows_435"
       },
       "locked": {
@@ -27544,6 +32832,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_474": {
       "inputs": {
         "nixpkgs": "nixpkgs_474",
@@ -27582,10 +32871,12 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_476": {
       "inputs": {
         "nixpkgs": "nixpkgs_476",
-        "nixpkgs-windows": "nixpkgs-windows_438"
+        "nixpkgs-windows": "nixpkgs-windows_436"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27604,7 +32895,7 @@
     "logos-nix_477": {
       "inputs": {
         "nixpkgs": "nixpkgs_477",
-        "nixpkgs-windows": "nixpkgs-windows_439"
+        "nixpkgs-windows": "nixpkgs-windows_437"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27623,7 +32914,7 @@
     "logos-nix_478": {
       "inputs": {
         "nixpkgs": "nixpkgs_478",
-        "nixpkgs-windows": "nixpkgs-windows_440"
+        "nixpkgs-windows": "nixpkgs-windows_438"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27642,7 +32933,7 @@
     "logos-nix_479": {
       "inputs": {
         "nixpkgs": "nixpkgs_479",
-        "nixpkgs-windows": "nixpkgs-windows_441"
+        "nixpkgs-windows": "nixpkgs-windows_439"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27680,7 +32971,7 @@
     "logos-nix_480": {
       "inputs": {
         "nixpkgs": "nixpkgs_480",
-        "nixpkgs-windows": "nixpkgs-windows_442"
+        "nixpkgs-windows": "nixpkgs-windows_440"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27699,7 +32990,7 @@
     "logos-nix_481": {
       "inputs": {
         "nixpkgs": "nixpkgs_481",
-        "nixpkgs-windows": "nixpkgs-windows_443"
+        "nixpkgs-windows": "nixpkgs-windows_441"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27718,7 +33009,7 @@
     "logos-nix_482": {
       "inputs": {
         "nixpkgs": "nixpkgs_482",
-        "nixpkgs-windows": "nixpkgs-windows_444"
+        "nixpkgs-windows": "nixpkgs-windows_442"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27737,7 +33028,7 @@
     "logos-nix_483": {
       "inputs": {
         "nixpkgs": "nixpkgs_483",
-        "nixpkgs-windows": "nixpkgs-windows_445"
+        "nixpkgs-windows": "nixpkgs-windows_443"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27756,7 +33047,7 @@
     "logos-nix_484": {
       "inputs": {
         "nixpkgs": "nixpkgs_484",
-        "nixpkgs-windows": "nixpkgs-windows_446"
+        "nixpkgs-windows": "nixpkgs-windows_444"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27775,7 +33066,7 @@
     "logos-nix_485": {
       "inputs": {
         "nixpkgs": "nixpkgs_485",
-        "nixpkgs-windows": "nixpkgs-windows_447"
+        "nixpkgs-windows": "nixpkgs-windows_445"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27793,15 +33084,14 @@
     },
     "logos-nix_486": {
       "inputs": {
-        "nixpkgs": "nixpkgs_486",
-        "nixpkgs-windows": "nixpkgs-windows_448"
+        "nixpkgs": "nixpkgs_486"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27812,15 +33102,14 @@
     },
     "logos-nix_487": {
       "inputs": {
-        "nixpkgs": "nixpkgs_487",
-        "nixpkgs-windows": "nixpkgs-windows_449"
+        "nixpkgs": "nixpkgs_487"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -27832,7 +33121,7 @@
     "logos-nix_488": {
       "inputs": {
         "nixpkgs": "nixpkgs_488",
-        "nixpkgs-windows": "nixpkgs-windows_450"
+        "nixpkgs-windows": "nixpkgs-windows_446"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27851,7 +33140,7 @@
     "logos-nix_489": {
       "inputs": {
         "nixpkgs": "nixpkgs_489",
-        "nixpkgs-windows": "nixpkgs-windows_451"
+        "nixpkgs-windows": "nixpkgs-windows_447"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27889,7 +33178,7 @@
     "logos-nix_490": {
       "inputs": {
         "nixpkgs": "nixpkgs_490",
-        "nixpkgs-windows": "nixpkgs-windows_452"
+        "nixpkgs-windows": "nixpkgs-windows_448"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27908,7 +33197,7 @@
     "logos-nix_491": {
       "inputs": {
         "nixpkgs": "nixpkgs_491",
-        "nixpkgs-windows": "nixpkgs-windows_453"
+        "nixpkgs-windows": "nixpkgs-windows_449"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27927,7 +33216,7 @@
     "logos-nix_492": {
       "inputs": {
         "nixpkgs": "nixpkgs_492",
-        "nixpkgs-windows": "nixpkgs-windows_454"
+        "nixpkgs-windows": "nixpkgs-windows_450"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -27945,6 +33234,7 @@
     },
     "logos-nix_493": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_493"
       },
       "locked": {
@@ -27953,6 +33243,17 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "nixpkgs": "nixpkgs_493",
+        "nixpkgs-windows": "nixpkgs-windows_451"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -27963,7 +33264,12 @@
     },
     "logos-nix_494": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_494"
+=======
+        "nixpkgs": "nixpkgs_494",
+        "nixpkgs-windows": "nixpkgs-windows_452"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -27981,15 +33287,19 @@
     },
     "logos-nix_495": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_495",
         "nixpkgs-windows": "nixpkgs-windows_455"
+=======
+        "nixpkgs": "nixpkgs_495"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28001,7 +33311,11 @@
     "logos-nix_496": {
       "inputs": {
         "nixpkgs": "nixpkgs_496",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_456"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_453"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28020,7 +33334,11 @@
     "logos-nix_497": {
       "inputs": {
         "nixpkgs": "nixpkgs_497",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_457"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_454"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28039,7 +33357,11 @@
     "logos-nix_498": {
       "inputs": {
         "nixpkgs": "nixpkgs_498",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_458"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_455"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28058,7 +33380,7 @@
     "logos-nix_499": {
       "inputs": {
         "nixpkgs": "nixpkgs_499",
-        "nixpkgs-windows": "nixpkgs-windows_459"
+        "nixpkgs-windows": "nixpkgs-windows_456"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28115,7 +33437,7 @@
     "logos-nix_500": {
       "inputs": {
         "nixpkgs": "nixpkgs_500",
-        "nixpkgs-windows": "nixpkgs-windows_460"
+        "nixpkgs-windows": "nixpkgs-windows_457"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28134,7 +33456,7 @@
     "logos-nix_501": {
       "inputs": {
         "nixpkgs": "nixpkgs_501",
-        "nixpkgs-windows": "nixpkgs-windows_461"
+        "nixpkgs-windows": "nixpkgs-windows_458"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28153,7 +33475,7 @@
     "logos-nix_502": {
       "inputs": {
         "nixpkgs": "nixpkgs_502",
-        "nixpkgs-windows": "nixpkgs-windows_462"
+        "nixpkgs-windows": "nixpkgs-windows_459"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28172,7 +33494,7 @@
     "logos-nix_503": {
       "inputs": {
         "nixpkgs": "nixpkgs_503",
-        "nixpkgs-windows": "nixpkgs-windows_463"
+        "nixpkgs-windows": "nixpkgs-windows_460"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28191,7 +33513,7 @@
     "logos-nix_504": {
       "inputs": {
         "nixpkgs": "nixpkgs_504",
-        "nixpkgs-windows": "nixpkgs-windows_464"
+        "nixpkgs-windows": "nixpkgs-windows_461"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28210,7 +33532,7 @@
     "logos-nix_505": {
       "inputs": {
         "nixpkgs": "nixpkgs_505",
-        "nixpkgs-windows": "nixpkgs-windows_465"
+        "nixpkgs-windows": "nixpkgs-windows_462"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28265,7 +33587,11 @@
     "logos-nix_508": {
       "inputs": {
         "nixpkgs": "nixpkgs_508",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_466"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_463"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28284,7 +33610,11 @@
     "logos-nix_509": {
       "inputs": {
         "nixpkgs": "nixpkgs_509",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_467"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_464"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28322,7 +33652,11 @@
     "logos-nix_510": {
       "inputs": {
         "nixpkgs": "nixpkgs_510",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_468"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_465"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28341,7 +33675,11 @@
     "logos-nix_511": {
       "inputs": {
         "nixpkgs": "nixpkgs_511",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_469"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_466"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28360,14 +33698,14 @@
     "logos-nix_512": {
       "inputs": {
         "nixpkgs": "nixpkgs_512",
-        "nixpkgs-windows": "nixpkgs-windows_470"
+        "nixpkgs-windows": "nixpkgs-windows_467"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28379,7 +33717,7 @@
     "logos-nix_513": {
       "inputs": {
         "nixpkgs": "nixpkgs_513",
-        "nixpkgs-windows": "nixpkgs-windows_471"
+        "nixpkgs-windows": "nixpkgs-windows_468"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -28398,7 +33736,7 @@
     "logos-nix_514": {
       "inputs": {
         "nixpkgs": "nixpkgs_514",
-        "nixpkgs-windows": "nixpkgs-windows_472"
+        "nixpkgs-windows": "nixpkgs-windows_469"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28419,6 +33757,37 @@
         "nixpkgs": "nixpkgs_515"
       },
       "locked": {
+<<<<<<< HEAD
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_516": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_516",
+        "nixpkgs-windows": "nixpkgs-windows_473"
+=======
+        "nixpkgs": "nixpkgs_516"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
         "lastModified": 1773955630,
         "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
@@ -28432,29 +33801,14 @@
         "type": "github"
       }
     },
-    "logos-nix_516": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_516",
-        "nixpkgs-windows": "nixpkgs-windows_473"
-      },
-      "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-nix",
-        "type": "github"
-      }
-    },
     "logos-nix_517": {
       "inputs": {
         "nixpkgs": "nixpkgs_517",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_474"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_470"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28473,7 +33827,11 @@
     "logos-nix_518": {
       "inputs": {
         "nixpkgs": "nixpkgs_518",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_475"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_471"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28492,6 +33850,7 @@
     "logos-nix_519": {
       "inputs": {
         "nixpkgs": "nixpkgs_519",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_476"
       },
       "locked": {
@@ -28500,6 +33859,28 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_52": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_52",
+        "nixpkgs-windows": "nixpkgs-windows_50"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_472"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28530,7 +33911,7 @@
     "logos-nix_520": {
       "inputs": {
         "nixpkgs": "nixpkgs_520",
-        "nixpkgs-windows": "nixpkgs-windows_477"
+        "nixpkgs-windows": "nixpkgs-windows_473"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28549,7 +33930,7 @@
     "logos-nix_521": {
       "inputs": {
         "nixpkgs": "nixpkgs_521",
-        "nixpkgs-windows": "nixpkgs-windows_478"
+        "nixpkgs-windows": "nixpkgs-windows_474"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28568,7 +33949,7 @@
     "logos-nix_522": {
       "inputs": {
         "nixpkgs": "nixpkgs_522",
-        "nixpkgs-windows": "nixpkgs-windows_479"
+        "nixpkgs-windows": "nixpkgs-windows_475"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28587,7 +33968,7 @@
     "logos-nix_523": {
       "inputs": {
         "nixpkgs": "nixpkgs_523",
-        "nixpkgs-windows": "nixpkgs-windows_480"
+        "nixpkgs-windows": "nixpkgs-windows_476"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28606,14 +33987,14 @@
     "logos-nix_524": {
       "inputs": {
         "nixpkgs": "nixpkgs_524",
-        "nixpkgs-windows": "nixpkgs-windows_481"
+        "nixpkgs-windows": "nixpkgs-windows_477"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -28625,7 +34006,7 @@
     "logos-nix_525": {
       "inputs": {
         "nixpkgs": "nixpkgs_525",
-        "nixpkgs-windows": "nixpkgs-windows_482"
+        "nixpkgs-windows": "nixpkgs-windows_478"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28643,7 +34024,12 @@
     },
     "logos-nix_526": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_526"
+=======
+        "nixpkgs": "nixpkgs_526",
+        "nixpkgs-windows": "nixpkgs-windows_479"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -28661,7 +34047,12 @@
     },
     "logos-nix_527": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_527"
+=======
+        "nixpkgs": "nixpkgs_527",
+        "nixpkgs-windows": "nixpkgs-windows_480"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -28679,15 +34070,19 @@
     },
     "logos-nix_528": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_528",
         "nixpkgs-windows": "nixpkgs-windows_483"
+=======
+        "nixpkgs": "nixpkgs_528"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -28699,7 +34094,11 @@
     "logos-nix_529": {
       "inputs": {
         "nixpkgs": "nixpkgs_529",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_484"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_481"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28737,7 +34136,11 @@
     "logos-nix_530": {
       "inputs": {
         "nixpkgs": "nixpkgs_530",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_485"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_482"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28756,7 +34159,11 @@
     "logos-nix_531": {
       "inputs": {
         "nixpkgs": "nixpkgs_531",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_486"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_483"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28775,7 +34182,7 @@
     "logos-nix_532": {
       "inputs": {
         "nixpkgs": "nixpkgs_532",
-        "nixpkgs-windows": "nixpkgs-windows_487"
+        "nixpkgs-windows": "nixpkgs-windows_484"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -28794,7 +34201,7 @@
     "logos-nix_533": {
       "inputs": {
         "nixpkgs": "nixpkgs_533",
-        "nixpkgs-windows": "nixpkgs-windows_488"
+        "nixpkgs-windows": "nixpkgs-windows_485"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -28813,7 +34220,7 @@
     "logos-nix_534": {
       "inputs": {
         "nixpkgs": "nixpkgs_534",
-        "nixpkgs-windows": "nixpkgs-windows_489"
+        "nixpkgs-windows": "nixpkgs-windows_486"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28831,6 +34238,7 @@
     },
     "logos-nix_535": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_535"
       },
       "locked": {
@@ -28869,6 +34277,10 @@
       "inputs": {
         "nixpkgs": "nixpkgs_537",
         "nixpkgs-windows": "nixpkgs-windows_490"
+=======
+        "nixpkgs": "nixpkgs_535",
+        "nixpkgs-windows": "nixpkgs-windows_487"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28884,10 +34296,55 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_538": {
       "inputs": {
         "nixpkgs": "nixpkgs_538",
         "nixpkgs-windows": "nixpkgs-windows_491"
+=======
+    "logos-nix_536": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_536",
+        "nixpkgs-windows": "nixpkgs-windows_488"
+      },
+      "locked": {
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_537": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_537",
+        "nixpkgs-windows": "nixpkgs-windows_489"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_538": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_538",
+        "nixpkgs-windows": "nixpkgs-windows_490"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28963,7 +34420,7 @@
     "logos-nix_541": {
       "inputs": {
         "nixpkgs": "nixpkgs_541",
-        "nixpkgs-windows": "nixpkgs-windows_494"
+        "nixpkgs-windows": "nixpkgs-windows_491"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -28982,14 +34439,14 @@
     "logos-nix_542": {
       "inputs": {
         "nixpkgs": "nixpkgs_542",
-        "nixpkgs-windows": "nixpkgs-windows_495"
+        "nixpkgs-windows": "nixpkgs-windows_492"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29001,7 +34458,7 @@
     "logos-nix_543": {
       "inputs": {
         "nixpkgs": "nixpkgs_543",
-        "nixpkgs-windows": "nixpkgs-windows_496"
+        "nixpkgs-windows": "nixpkgs-windows_493"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29019,15 +34476,22 @@
     },
     "logos-nix_544": {
       "inputs": {
-        "nixpkgs": "nixpkgs_544",
-        "nixpkgs-windows": "nixpkgs-windows_497"
+        "nixpkgs": "nixpkgs_544"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+=======
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -29038,15 +34502,14 @@
     },
     "logos-nix_545": {
       "inputs": {
-        "nixpkgs": "nixpkgs_545",
-        "nixpkgs-windows": "nixpkgs-windows_498"
+        "nixpkgs": "nixpkgs_545"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29058,7 +34521,7 @@
     "logos-nix_546": {
       "inputs": {
         "nixpkgs": "nixpkgs_546",
-        "nixpkgs-windows": "nixpkgs-windows_499"
+        "nixpkgs-windows": "nixpkgs-windows_494"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29077,7 +34540,7 @@
     "logos-nix_547": {
       "inputs": {
         "nixpkgs": "nixpkgs_547",
-        "nixpkgs-windows": "nixpkgs-windows_500"
+        "nixpkgs-windows": "nixpkgs-windows_495"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29095,6 +34558,7 @@
     },
     "logos-nix_548": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_548"
       },
       "locked": {
@@ -29103,6 +34567,17 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "nixpkgs": "nixpkgs_548",
+        "nixpkgs-windows": "nixpkgs-windows_496"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -29114,14 +34589,18 @@
     "logos-nix_549": {
       "inputs": {
         "nixpkgs": "nixpkgs_549",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_501"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_497"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
         "type": "github"
       },
       "original": {
@@ -29151,7 +34630,11 @@
     "logos-nix_550": {
       "inputs": {
         "nixpkgs": "nixpkgs_550",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_502"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_498"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29170,7 +34653,11 @@
     "logos-nix_551": {
       "inputs": {
         "nixpkgs": "nixpkgs_551",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_503"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_499"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29189,6 +34676,7 @@
     "logos-nix_552": {
       "inputs": {
         "nixpkgs": "nixpkgs_552",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_504"
       },
       "locked": {
@@ -29209,6 +34697,9 @@
       "inputs": {
         "nixpkgs": "nixpkgs_553",
         "nixpkgs-windows": "nixpkgs-windows_505"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_500"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29224,10 +34715,29 @@
         "type": "github"
       }
     },
+    "logos-nix_553": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_553",
+        "nixpkgs-windows": "nixpkgs-windows_501"
+      },
+      "locked": {
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
     "logos-nix_554": {
       "inputs": {
         "nixpkgs": "nixpkgs_554",
-        "nixpkgs-windows": "nixpkgs-windows_506"
+        "nixpkgs-windows": "nixpkgs-windows_502"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29246,7 +34756,7 @@
     "logos-nix_555": {
       "inputs": {
         "nixpkgs": "nixpkgs_555",
-        "nixpkgs-windows": "nixpkgs-windows_507"
+        "nixpkgs-windows": "nixpkgs-windows_503"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29265,7 +34775,7 @@
     "logos-nix_556": {
       "inputs": {
         "nixpkgs": "nixpkgs_556",
-        "nixpkgs-windows": "nixpkgs-windows_508"
+        "nixpkgs-windows": "nixpkgs-windows_504"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -29284,7 +34794,7 @@
     "logos-nix_557": {
       "inputs": {
         "nixpkgs": "nixpkgs_557",
-        "nixpkgs-windows": "nixpkgs-windows_509"
+        "nixpkgs-windows": "nixpkgs-windows_505"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -29303,7 +34813,7 @@
     "logos-nix_558": {
       "inputs": {
         "nixpkgs": "nixpkgs_558",
-        "nixpkgs-windows": "nixpkgs-windows_510"
+        "nixpkgs-windows": "nixpkgs-windows_506"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29321,6 +34831,7 @@
     },
     "logos-nix_559": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_559"
       },
       "locked": {
@@ -29329,6 +34840,17 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+=======
+        "nixpkgs": "nixpkgs_559",
+        "nixpkgs-windows": "nixpkgs-windows_507"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -29357,6 +34879,7 @@
     },
     "logos-nix_560": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_560"
       },
       "locked": {
@@ -29377,6 +34900,35 @@
       "inputs": {
         "nixpkgs": "nixpkgs_561",
         "nixpkgs-windows": "nixpkgs-windows_511"
+=======
+        "nixpkgs": "nixpkgs_560",
+        "nixpkgs-windows": "nixpkgs-windows_508"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-nix_562": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_562",
+        "nixpkgs-windows": "nixpkgs-windows_512"
+=======
+    "logos-nix_561": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_561",
+        "nixpkgs-windows": "nixpkgs-windows_509"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29395,7 +34947,8 @@
     "logos-nix_562": {
       "inputs": {
         "nixpkgs": "nixpkgs_562",
-        "nixpkgs-windows": "nixpkgs-windows_512"
+        "nixpkgs-windows": "nixpkgs-windows_510"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29414,6 +34967,7 @@
     "logos-nix_563": {
       "inputs": {
         "nixpkgs": "nixpkgs_563",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
@@ -29422,6 +34976,16 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+        "nixpkgs-windows": "nixpkgs-windows_511"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -29433,7 +34997,11 @@
     "logos-nix_564": {
       "inputs": {
         "nixpkgs": "nixpkgs_564",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_514"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_512"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29452,7 +35020,7 @@
     "logos-nix_565": {
       "inputs": {
         "nixpkgs": "nixpkgs_565",
-        "nixpkgs-windows": "nixpkgs-windows_515"
+        "nixpkgs-windows": "nixpkgs-windows_513"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -29471,7 +35039,7 @@
     "logos-nix_566": {
       "inputs": {
         "nixpkgs": "nixpkgs_566",
-        "nixpkgs-windows": "nixpkgs-windows_516"
+        "nixpkgs-windows": "nixpkgs-windows_514"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29489,6 +35057,7 @@
     },
     "logos-nix_567": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_567"
       },
       "locked": {
@@ -29527,6 +35096,55 @@
       "inputs": {
         "nixpkgs": "nixpkgs_569",
         "nixpkgs-windows": "nixpkgs-windows_517"
+=======
+        "nixpkgs": "nixpkgs_567",
+        "nixpkgs-windows": "nixpkgs-windows_515"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_57": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_57",
+        "nixpkgs-windows": "nixpkgs-windows_53"
+=======
+        "nixpkgs": "nixpkgs_568",
+        "nixpkgs-windows": "nixpkgs-windows_516"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+=======
+    "logos-nix_569": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_569",
+        "nixpkgs-windows": "nixpkgs-windows_517"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29561,6 +35179,7 @@
         "type": "github"
       }
     },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_570": {
       "inputs": {
         "nixpkgs": "nixpkgs_570",
@@ -29719,11 +35338,11 @@
         "nixpkgs-windows": "nixpkgs-windows_526"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29738,11 +35357,11 @@
         "nixpkgs-windows": "nixpkgs-windows_527"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -29791,15 +35410,14 @@
     },
     "logos-nix_581": {
       "inputs": {
-        "nixpkgs": "nixpkgs_581",
-        "nixpkgs-windows": "nixpkgs-windows_529"
+        "nixpkgs": "nixpkgs_581"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -29810,15 +35428,14 @@
     },
     "logos-nix_582": {
       "inputs": {
-        "nixpkgs": "nixpkgs_582",
-        "nixpkgs-windows": "nixpkgs-windows_530"
+        "nixpkgs": "nixpkgs_582"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -29830,7 +35447,7 @@
     "logos-nix_583": {
       "inputs": {
         "nixpkgs": "nixpkgs_583",
-        "nixpkgs-windows": "nixpkgs-windows_531"
+        "nixpkgs-windows": "nixpkgs-windows_529"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29849,7 +35466,7 @@
     "logos-nix_584": {
       "inputs": {
         "nixpkgs": "nixpkgs_584",
-        "nixpkgs-windows": "nixpkgs-windows_532"
+        "nixpkgs-windows": "nixpkgs-windows_530"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29868,7 +35485,7 @@
     "logos-nix_585": {
       "inputs": {
         "nixpkgs": "nixpkgs_585",
-        "nixpkgs-windows": "nixpkgs-windows_533"
+        "nixpkgs-windows": "nixpkgs-windows_531"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29887,7 +35504,7 @@
     "logos-nix_586": {
       "inputs": {
         "nixpkgs": "nixpkgs_586",
-        "nixpkgs-windows": "nixpkgs-windows_534"
+        "nixpkgs-windows": "nixpkgs-windows_532"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -29906,7 +35523,7 @@
     "logos-nix_587": {
       "inputs": {
         "nixpkgs": "nixpkgs_587",
-        "nixpkgs-windows": "nixpkgs-windows_535"
+        "nixpkgs-windows": "nixpkgs-windows_533"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29925,7 +35542,7 @@
     "logos-nix_588": {
       "inputs": {
         "nixpkgs": "nixpkgs_588",
-        "nixpkgs-windows": "nixpkgs-windows_536"
+        "nixpkgs-windows": "nixpkgs-windows_534"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29944,7 +35561,7 @@
     "logos-nix_589": {
       "inputs": {
         "nixpkgs": "nixpkgs_589",
-        "nixpkgs-windows": "nixpkgs-windows_537"
+        "nixpkgs-windows": "nixpkgs-windows_535"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -29982,7 +35599,7 @@
     "logos-nix_590": {
       "inputs": {
         "nixpkgs": "nixpkgs_590",
-        "nixpkgs-windows": "nixpkgs-windows_538"
+        "nixpkgs-windows": "nixpkgs-windows_536"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30001,7 +35618,7 @@
     "logos-nix_591": {
       "inputs": {
         "nixpkgs": "nixpkgs_591",
-        "nixpkgs-windows": "nixpkgs-windows_539"
+        "nixpkgs-windows": "nixpkgs-windows_537"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30020,7 +35637,7 @@
     "logos-nix_592": {
       "inputs": {
         "nixpkgs": "nixpkgs_592",
-        "nixpkgs-windows": "nixpkgs-windows_540"
+        "nixpkgs-windows": "nixpkgs-windows_538"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30039,7 +35656,7 @@
     "logos-nix_593": {
       "inputs": {
         "nixpkgs": "nixpkgs_593",
-        "nixpkgs-windows": "nixpkgs-windows_541"
+        "nixpkgs-windows": "nixpkgs-windows_539"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -30058,7 +35675,7 @@
     "logos-nix_594": {
       "inputs": {
         "nixpkgs": "nixpkgs_594",
-        "nixpkgs-windows": "nixpkgs-windows_542"
+        "nixpkgs-windows": "nixpkgs-windows_540"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30077,7 +35694,7 @@
     "logos-nix_595": {
       "inputs": {
         "nixpkgs": "nixpkgs_595",
-        "nixpkgs-windows": "nixpkgs-windows_543"
+        "nixpkgs-windows": "nixpkgs-windows_541"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30096,7 +35713,7 @@
     "logos-nix_596": {
       "inputs": {
         "nixpkgs": "nixpkgs_596",
-        "nixpkgs-windows": "nixpkgs-windows_544"
+        "nixpkgs-windows": "nixpkgs-windows_542"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30115,7 +35732,7 @@
     "logos-nix_597": {
       "inputs": {
         "nixpkgs": "nixpkgs_597",
-        "nixpkgs-windows": "nixpkgs-windows_545"
+        "nixpkgs-windows": "nixpkgs-windows_543"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30134,7 +35751,7 @@
     "logos-nix_598": {
       "inputs": {
         "nixpkgs": "nixpkgs_598",
-        "nixpkgs-windows": "nixpkgs-windows_546"
+        "nixpkgs-windows": "nixpkgs-windows_544"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30153,7 +35770,7 @@
     "logos-nix_599": {
       "inputs": {
         "nixpkgs": "nixpkgs_599",
-        "nixpkgs-windows": "nixpkgs-windows_547"
+        "nixpkgs-windows": "nixpkgs-windows_545"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30210,7 +35827,7 @@
     "logos-nix_600": {
       "inputs": {
         "nixpkgs": "nixpkgs_600",
-        "nixpkgs-windows": "nixpkgs-windows_548"
+        "nixpkgs-windows": "nixpkgs-windows_546"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30229,7 +35846,7 @@
     "logos-nix_601": {
       "inputs": {
         "nixpkgs": "nixpkgs_601",
-        "nixpkgs-windows": "nixpkgs-windows_549"
+        "nixpkgs-windows": "nixpkgs-windows_547"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30248,7 +35865,7 @@
     "logos-nix_602": {
       "inputs": {
         "nixpkgs": "nixpkgs_602",
-        "nixpkgs-windows": "nixpkgs-windows_550"
+        "nixpkgs-windows": "nixpkgs-windows_548"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30267,7 +35884,7 @@
     "logos-nix_603": {
       "inputs": {
         "nixpkgs": "nixpkgs_603",
-        "nixpkgs-windows": "nixpkgs-windows_551"
+        "nixpkgs-windows": "nixpkgs-windows_549"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30286,7 +35903,7 @@
     "logos-nix_604": {
       "inputs": {
         "nixpkgs": "nixpkgs_604",
-        "nixpkgs-windows": "nixpkgs-windows_552"
+        "nixpkgs-windows": "nixpkgs-windows_550"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30305,7 +35922,7 @@
     "logos-nix_605": {
       "inputs": {
         "nixpkgs": "nixpkgs_605",
-        "nixpkgs-windows": "nixpkgs-windows_553"
+        "nixpkgs-windows": "nixpkgs-windows_551"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30324,14 +35941,14 @@
     "logos-nix_606": {
       "inputs": {
         "nixpkgs": "nixpkgs_606",
-        "nixpkgs-windows": "nixpkgs-windows_554"
+        "nixpkgs-windows": "nixpkgs-windows_552"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -30343,7 +35960,7 @@
     "logos-nix_607": {
       "inputs": {
         "nixpkgs": "nixpkgs_607",
-        "nixpkgs-windows": "nixpkgs-windows_555"
+        "nixpkgs-windows": "nixpkgs-windows_553"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30362,7 +35979,7 @@
     "logos-nix_608": {
       "inputs": {
         "nixpkgs": "nixpkgs_608",
-        "nixpkgs-windows": "nixpkgs-windows_556"
+        "nixpkgs-windows": "nixpkgs-windows_554"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -30381,7 +35998,7 @@
     "logos-nix_609": {
       "inputs": {
         "nixpkgs": "nixpkgs_609",
-        "nixpkgs-windows": "nixpkgs-windows_557"
+        "nixpkgs-windows": "nixpkgs-windows_555"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -30419,7 +36036,7 @@
     "logos-nix_610": {
       "inputs": {
         "nixpkgs": "nixpkgs_610",
-        "nixpkgs-windows": "nixpkgs-windows_558"
+        "nixpkgs-windows": "nixpkgs-windows_556"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30437,6 +36054,7 @@
     },
     "logos-nix_611": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_611"
       },
       "locked": {
@@ -30475,6 +36093,10 @@
       "inputs": {
         "nixpkgs": "nixpkgs_613",
         "nixpkgs-windows": "nixpkgs-windows_559"
+=======
+        "nixpkgs": "nixpkgs_611",
+        "nixpkgs-windows": "nixpkgs-windows_557"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30490,6 +36112,47 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "logos-nix_612": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_612",
+        "nixpkgs-windows": "nixpkgs-windows_558"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_613": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_613",
+        "nixpkgs-windows": "nixpkgs-windows_559"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_614": {
       "inputs": {
         "nixpkgs": "nixpkgs_614",
@@ -30777,15 +36440,14 @@
     },
     "logos-nix_628": {
       "inputs": {
-        "nixpkgs": "nixpkgs_628",
-        "nixpkgs-windows": "nixpkgs-windows_574"
+        "nixpkgs": "nixpkgs_628"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -30796,15 +36458,14 @@
     },
     "logos-nix_629": {
       "inputs": {
-        "nixpkgs": "nixpkgs_629",
-        "nixpkgs-windows": "nixpkgs-windows_575"
+        "nixpkgs": "nixpkgs_629"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -30835,7 +36496,7 @@
     "logos-nix_630": {
       "inputs": {
         "nixpkgs": "nixpkgs_630",
-        "nixpkgs-windows": "nixpkgs-windows_576"
+        "nixpkgs-windows": "nixpkgs-windows_574"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30854,7 +36515,7 @@
     "logos-nix_631": {
       "inputs": {
         "nixpkgs": "nixpkgs_631",
-        "nixpkgs-windows": "nixpkgs-windows_577"
+        "nixpkgs-windows": "nixpkgs-windows_575"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30873,7 +36534,7 @@
     "logos-nix_632": {
       "inputs": {
         "nixpkgs": "nixpkgs_632",
-        "nixpkgs-windows": "nixpkgs-windows_578"
+        "nixpkgs-windows": "nixpkgs-windows_576"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30892,7 +36553,7 @@
     "logos-nix_633": {
       "inputs": {
         "nixpkgs": "nixpkgs_633",
-        "nixpkgs-windows": "nixpkgs-windows_579"
+        "nixpkgs-windows": "nixpkgs-windows_577"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30911,7 +36572,7 @@
     "logos-nix_634": {
       "inputs": {
         "nixpkgs": "nixpkgs_634",
-        "nixpkgs-windows": "nixpkgs-windows_580"
+        "nixpkgs-windows": "nixpkgs-windows_578"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30930,7 +36591,7 @@
     "logos-nix_635": {
       "inputs": {
         "nixpkgs": "nixpkgs_635",
-        "nixpkgs-windows": "nixpkgs-windows_581"
+        "nixpkgs-windows": "nixpkgs-windows_579"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30949,7 +36610,7 @@
     "logos-nix_636": {
       "inputs": {
         "nixpkgs": "nixpkgs_636",
-        "nixpkgs-windows": "nixpkgs-windows_582"
+        "nixpkgs-windows": "nixpkgs-windows_580"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -30968,7 +36629,7 @@
     "logos-nix_637": {
       "inputs": {
         "nixpkgs": "nixpkgs_637",
-        "nixpkgs-windows": "nixpkgs-windows_583"
+        "nixpkgs-windows": "nixpkgs-windows_581"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -30987,7 +36648,7 @@
     "logos-nix_638": {
       "inputs": {
         "nixpkgs": "nixpkgs_638",
-        "nixpkgs-windows": "nixpkgs-windows_584"
+        "nixpkgs-windows": "nixpkgs-windows_582"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31006,7 +36667,7 @@
     "logos-nix_639": {
       "inputs": {
         "nixpkgs": "nixpkgs_639",
-        "nixpkgs-windows": "nixpkgs-windows_585"
+        "nixpkgs-windows": "nixpkgs-windows_583"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31044,7 +36705,7 @@
     "logos-nix_640": {
       "inputs": {
         "nixpkgs": "nixpkgs_640",
-        "nixpkgs-windows": "nixpkgs-windows_586"
+        "nixpkgs-windows": "nixpkgs-windows_584"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31062,15 +36723,22 @@
     },
     "logos-nix_641": {
       "inputs": {
-        "nixpkgs": "nixpkgs_641",
-        "nixpkgs-windows": "nixpkgs-windows_587"
+        "nixpkgs": "nixpkgs_641"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786399295,
         "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -31081,15 +36749,14 @@
     },
     "logos-nix_642": {
       "inputs": {
-        "nixpkgs": "nixpkgs_642",
-        "nixpkgs-windows": "nixpkgs-windows_588"
+        "nixpkgs": "nixpkgs_642"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31101,7 +36768,7 @@
     "logos-nix_643": {
       "inputs": {
         "nixpkgs": "nixpkgs_643",
-        "nixpkgs-windows": "nixpkgs-windows_589"
+        "nixpkgs-windows": "nixpkgs-windows_585"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31120,7 +36787,7 @@
     "logos-nix_644": {
       "inputs": {
         "nixpkgs": "nixpkgs_644",
-        "nixpkgs-windows": "nixpkgs-windows_590"
+        "nixpkgs-windows": "nixpkgs-windows_586"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31139,7 +36806,7 @@
     "logos-nix_645": {
       "inputs": {
         "nixpkgs": "nixpkgs_645",
-        "nixpkgs-windows": "nixpkgs-windows_591"
+        "nixpkgs-windows": "nixpkgs-windows_587"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31158,7 +36825,7 @@
     "logos-nix_646": {
       "inputs": {
         "nixpkgs": "nixpkgs_646",
-        "nixpkgs-windows": "nixpkgs-windows_592"
+        "nixpkgs-windows": "nixpkgs-windows_588"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31177,7 +36844,7 @@
     "logos-nix_647": {
       "inputs": {
         "nixpkgs": "nixpkgs_647",
-        "nixpkgs-windows": "nixpkgs-windows_593"
+        "nixpkgs-windows": "nixpkgs-windows_589"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31196,14 +36863,14 @@
     "logos-nix_648": {
       "inputs": {
         "nixpkgs": "nixpkgs_648",
-        "nixpkgs-windows": "nixpkgs-windows_594"
+        "nixpkgs-windows": "nixpkgs-windows_590"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31215,7 +36882,7 @@
     "logos-nix_649": {
       "inputs": {
         "nixpkgs": "nixpkgs_649",
-        "nixpkgs-windows": "nixpkgs-windows_595"
+        "nixpkgs-windows": "nixpkgs-windows_591"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31252,15 +36919,14 @@
     },
     "logos-nix_650": {
       "inputs": {
-        "nixpkgs": "nixpkgs_650",
-        "nixpkgs-windows": "nixpkgs-windows_596"
+        "nixpkgs": "nixpkgs_650"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31272,7 +36938,7 @@
     "logos-nix_651": {
       "inputs": {
         "nixpkgs": "nixpkgs_651",
-        "nixpkgs-windows": "nixpkgs-windows_597"
+        "nixpkgs-windows": "nixpkgs-windows_592"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31291,7 +36957,7 @@
     "logos-nix_652": {
       "inputs": {
         "nixpkgs": "nixpkgs_652",
-        "nixpkgs-windows": "nixpkgs-windows_598"
+        "nixpkgs-windows": "nixpkgs-windows_593"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31310,7 +36976,7 @@
     "logos-nix_653": {
       "inputs": {
         "nixpkgs": "nixpkgs_653",
-        "nixpkgs-windows": "nixpkgs-windows_599"
+        "nixpkgs-windows": "nixpkgs-windows_594"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31329,7 +36995,7 @@
     "logos-nix_654": {
       "inputs": {
         "nixpkgs": "nixpkgs_654",
-        "nixpkgs-windows": "nixpkgs-windows_600"
+        "nixpkgs-windows": "nixpkgs-windows_595"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31348,7 +37014,7 @@
     "logos-nix_655": {
       "inputs": {
         "nixpkgs": "nixpkgs_655",
-        "nixpkgs-windows": "nixpkgs-windows_601"
+        "nixpkgs-windows": "nixpkgs-windows_596"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31367,7 +37033,7 @@
     "logos-nix_656": {
       "inputs": {
         "nixpkgs": "nixpkgs_656",
-        "nixpkgs-windows": "nixpkgs-windows_602"
+        "nixpkgs-windows": "nixpkgs-windows_597"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31386,7 +37052,7 @@
     "logos-nix_657": {
       "inputs": {
         "nixpkgs": "nixpkgs_657",
-        "nixpkgs-windows": "nixpkgs-windows_603"
+        "nixpkgs-windows": "nixpkgs-windows_598"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31405,7 +37071,7 @@
     "logos-nix_658": {
       "inputs": {
         "nixpkgs": "nixpkgs_658",
-        "nixpkgs-windows": "nixpkgs-windows_604"
+        "nixpkgs-windows": "nixpkgs-windows_599"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31423,7 +37089,12 @@
     },
     "logos-nix_659": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_659"
+=======
+        "nixpkgs": "nixpkgs_659",
+        "nixpkgs-windows": "nixpkgs-windows_600"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -31460,7 +37131,12 @@
     },
     "logos-nix_660": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_660"
+=======
+        "nixpkgs": "nixpkgs_660",
+        "nixpkgs-windows": "nixpkgs-windows_601"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -31478,15 +37154,19 @@
     },
     "logos-nix_661": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_661",
         "nixpkgs-windows": "nixpkgs-windows_605"
+=======
+        "nixpkgs": "nixpkgs_661"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31497,8 +37177,31 @@
     },
     "logos-nix_662": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_662",
         "nixpkgs-windows": "nixpkgs-windows_606"
+=======
+        "nixpkgs": "nixpkgs_662"
+      },
+      "locked": {
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_663": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_663",
+        "nixpkgs-windows": "nixpkgs-windows_602"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31514,6 +37217,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_663": {
       "inputs": {
         "nixpkgs": "nixpkgs_663",
@@ -31537,6 +37241,12 @@
       "inputs": {
         "nixpkgs": "nixpkgs_664",
         "nixpkgs-windows": "nixpkgs-windows_608"
+=======
+    "logos-nix_664": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_664",
+        "nixpkgs-windows": "nixpkgs-windows_603"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31555,7 +37265,7 @@
     "logos-nix_665": {
       "inputs": {
         "nixpkgs": "nixpkgs_665",
-        "nixpkgs-windows": "nixpkgs-windows_609"
+        "nixpkgs-windows": "nixpkgs-windows_604"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31574,7 +37284,7 @@
     "logos-nix_666": {
       "inputs": {
         "nixpkgs": "nixpkgs_666",
-        "nixpkgs-windows": "nixpkgs-windows_610"
+        "nixpkgs-windows": "nixpkgs-windows_605"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31593,14 +37303,14 @@
     "logos-nix_667": {
       "inputs": {
         "nixpkgs": "nixpkgs_667",
-        "nixpkgs-windows": "nixpkgs-windows_611"
+        "nixpkgs-windows": "nixpkgs-windows_606"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31612,14 +37322,14 @@
     "logos-nix_668": {
       "inputs": {
         "nixpkgs": "nixpkgs_668",
-        "nixpkgs-windows": "nixpkgs-windows_612"
+        "nixpkgs-windows": "nixpkgs-windows_607"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -31631,7 +37341,7 @@
     "logos-nix_669": {
       "inputs": {
         "nixpkgs": "nixpkgs_669",
-        "nixpkgs-windows": "nixpkgs-windows_613"
+        "nixpkgs-windows": "nixpkgs-windows_608"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31668,15 +37378,14 @@
     },
     "logos-nix_670": {
       "inputs": {
-        "nixpkgs": "nixpkgs_670",
-        "nixpkgs-windows": "nixpkgs-windows_614"
+        "nixpkgs": "nixpkgs_670"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -31687,15 +37396,14 @@
     },
     "logos-nix_671": {
       "inputs": {
-        "nixpkgs": "nixpkgs_671",
-        "nixpkgs-windows": "nixpkgs-windows_615"
+        "nixpkgs": "nixpkgs_671"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -31706,7 +37414,12 @@
     },
     "logos-nix_672": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_672"
+=======
+        "nixpkgs": "nixpkgs_672",
+        "nixpkgs-windows": "nixpkgs-windows_609"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -31724,6 +37437,7 @@
     },
     "logos-nix_673": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_673"
       },
       "locked": {
@@ -31732,6 +37446,17 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+=======
+        "nixpkgs": "nixpkgs_673",
+        "nixpkgs-windows": "nixpkgs-windows_610"
+      },
+      "locked": {
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -31743,7 +37468,11 @@
     "logos-nix_674": {
       "inputs": {
         "nixpkgs": "nixpkgs_674",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_616"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_611"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31762,7 +37491,30 @@
     "logos-nix_675": {
       "inputs": {
         "nixpkgs": "nixpkgs_675",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_617"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_612"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_676": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_676",
+        "nixpkgs-windows": "nixpkgs-windows_613"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31778,6 +37530,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_676": {
       "inputs": {
         "nixpkgs": "nixpkgs_676",
@@ -31801,6 +37554,12 @@
       "inputs": {
         "nixpkgs": "nixpkgs_677",
         "nixpkgs-windows": "nixpkgs-windows_619"
+=======
+    "logos-nix_677": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_677",
+        "nixpkgs-windows": "nixpkgs-windows_614"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31819,7 +37578,7 @@
     "logos-nix_678": {
       "inputs": {
         "nixpkgs": "nixpkgs_678",
-        "nixpkgs-windows": "nixpkgs-windows_620"
+        "nixpkgs-windows": "nixpkgs-windows_615"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31837,15 +37596,22 @@
     },
     "logos-nix_679": {
       "inputs": {
-        "nixpkgs": "nixpkgs_679",
-        "nixpkgs-windows": "nixpkgs-windows_621"
+        "nixpkgs": "nixpkgs_679"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+=======
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -31876,7 +37642,7 @@
     "logos-nix_680": {
       "inputs": {
         "nixpkgs": "nixpkgs_680",
-        "nixpkgs-windows": "nixpkgs-windows_622"
+        "nixpkgs-windows": "nixpkgs-windows_616"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31894,7 +37660,12 @@
     },
     "logos-nix_681": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_681"
+=======
+        "nixpkgs": "nixpkgs_681",
+        "nixpkgs-windows": "nixpkgs-windows_617"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -31913,7 +37684,11 @@
     "logos-nix_682": {
       "inputs": {
         "nixpkgs": "nixpkgs_682",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_623"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_618"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31932,7 +37707,11 @@
     "logos-nix_683": {
       "inputs": {
         "nixpkgs": "nixpkgs_683",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_624"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_619"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31951,7 +37730,11 @@
     "logos-nix_684": {
       "inputs": {
         "nixpkgs": "nixpkgs_684",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_625"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_620"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31970,7 +37753,11 @@
     "logos-nix_685": {
       "inputs": {
         "nixpkgs": "nixpkgs_685",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_626"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_621"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -31989,7 +37776,7 @@
     "logos-nix_686": {
       "inputs": {
         "nixpkgs": "nixpkgs_686",
-        "nixpkgs-windows": "nixpkgs-windows_627"
+        "nixpkgs-windows": "nixpkgs-windows_622"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32008,14 +37795,14 @@
     "logos-nix_687": {
       "inputs": {
         "nixpkgs": "nixpkgs_687",
-        "nixpkgs-windows": "nixpkgs-windows_628"
+        "nixpkgs-windows": "nixpkgs-windows_623"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
         "type": "github"
       },
       "original": {
@@ -32027,14 +37814,14 @@
     "logos-nix_688": {
       "inputs": {
         "nixpkgs": "nixpkgs_688",
-        "nixpkgs-windows": "nixpkgs-windows_629"
+        "nixpkgs-windows": "nixpkgs-windows_624"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
         "type": "github"
       },
       "original": {
@@ -32046,7 +37833,7 @@
     "logos-nix_689": {
       "inputs": {
         "nixpkgs": "nixpkgs_689",
-        "nixpkgs-windows": "nixpkgs-windows_630"
+        "nixpkgs-windows": "nixpkgs-windows_625"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32083,15 +37870,14 @@
     },
     "logos-nix_690": {
       "inputs": {
-        "nixpkgs": "nixpkgs_690",
-        "nixpkgs-windows": "nixpkgs-windows_631"
+        "nixpkgs": "nixpkgs_690"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -32102,15 +37888,14 @@
     },
     "logos-nix_691": {
       "inputs": {
-        "nixpkgs": "nixpkgs_691",
-        "nixpkgs-windows": "nixpkgs-windows_632"
+        "nixpkgs": "nixpkgs_691"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32121,7 +37906,12 @@
     },
     "logos-nix_692": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_692"
+=======
+        "nixpkgs": "nixpkgs_692",
+        "nixpkgs-windows": "nixpkgs-windows_626"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -32139,7 +37929,12 @@
     },
     "logos-nix_693": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_693"
+=======
+        "nixpkgs": "nixpkgs_693",
+        "nixpkgs-windows": "nixpkgs-windows_627"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1773955630,
@@ -32158,7 +37953,11 @@
     "logos-nix_694": {
       "inputs": {
         "nixpkgs": "nixpkgs_694",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_633"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_628"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32177,7 +37976,11 @@
     "logos-nix_695": {
       "inputs": {
         "nixpkgs": "nixpkgs_695",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_634"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_629"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32196,7 +37999,11 @@
     "logos-nix_696": {
       "inputs": {
         "nixpkgs": "nixpkgs_696",
+<<<<<<< HEAD
         "nixpkgs-windows": "nixpkgs-windows_635"
+=======
+        "nixpkgs-windows": "nixpkgs-windows_630"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32234,14 +38041,22 @@
     "logos-nix_698": {
       "inputs": {
         "nixpkgs": "nixpkgs_698",
-        "nixpkgs-windows": "nixpkgs-windows_637"
+        "nixpkgs-windows": "nixpkgs-windows_631"
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1786729772,
         "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+=======
+        "lastModified": 1788889549,
+        "narHash": "sha256-7HylwQZ9ywzlwAqwBboJJkV0r4RhRvnLatQR+Yv8sdE=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "30285b1025f053b0adca39a6a5c94f93df0619e2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -32253,7 +38068,7 @@
     "logos-nix_699": {
       "inputs": {
         "nixpkgs": "nixpkgs_699",
-        "nixpkgs-windows": "nixpkgs-windows_638"
+        "nixpkgs-windows": "nixpkgs-windows_632"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -32309,6 +38124,7 @@
     },
     "logos-nix_700": {
       "inputs": {
+<<<<<<< HEAD
         "nixpkgs": "nixpkgs_700",
         "nixpkgs-windows": "nixpkgs-windows_639"
       },
@@ -32404,6 +38220,108 @@
       "inputs": {
         "nixpkgs": "nixpkgs_705",
         "nixpkgs-windows": "nixpkgs-windows_642"
+=======
+        "nixpkgs": "nixpkgs_700"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_701": {
+      "inputs": {
+<<<<<<< HEAD
+        "nixpkgs": "nixpkgs_706",
+        "nixpkgs-windows": "nixpkgs-windows_643"
+=======
+        "nixpkgs": "nixpkgs_701"
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_702": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_702",
+        "nixpkgs-windows": "nixpkgs-windows_633"
+      },
+      "locked": {
+        "lastModified": 1786399295,
+        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_703": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_703",
+        "nixpkgs-windows": "nixpkgs-windows_634"
+      },
+      "locked": {
+        "lastModified": 1789054121,
+        "narHash": "sha256-EOG96lY4KnZadh2lczZFMPnfPP9tWXdWt1p1CP8Gvww=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "7c1eb8bc390546f32aaf134866a1c7db8e9311cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_704": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_704",
+        "nixpkgs-windows": "nixpkgs-windows_635"
+      },
+      "locked": {
+        "lastModified": 1786729772,
+        "narHash": "sha256-7qE/hchFHmaCxoFCI4dtCqv2eHyL6VttgedTas41Lgs=",
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "rev": "f55bf91b8a723ee5c27c39c773b034255538d280",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-nix",
+        "type": "github"
+      }
+    },
+    "logos-nix_705": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_705",
+        "nixpkgs-windows": "nixpkgs-windows_636"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32421,15 +38339,14 @@
     },
     "logos-nix_706": {
       "inputs": {
-        "nixpkgs": "nixpkgs_706",
-        "nixpkgs-windows": "nixpkgs-windows_643"
+        "nixpkgs": "nixpkgs_706"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
         "type": "github"
       },
       "original": {
@@ -32440,15 +38357,14 @@
     },
     "logos-nix_707": {
       "inputs": {
-        "nixpkgs": "nixpkgs_707",
-        "nixpkgs-windows": "nixpkgs-windows_644"
+        "nixpkgs": "nixpkgs_707"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1773955630,
+        "narHash": "sha256-KqzMoWYIVp2xMgphs7v02T/BE54RKMFxpdC2duhJKG0=",
         "owner": "logos-co",
         "repo": "logos-nix",
-        "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+        "rev": "0e9e6d66ab8eb34f59e45ed448f7dc29130feb88",
         "type": "github"
       },
       "original": {
@@ -32460,7 +38376,7 @@
     "logos-nix_708": {
       "inputs": {
         "nixpkgs": "nixpkgs_708",
-        "nixpkgs-windows": "nixpkgs-windows_645"
+        "nixpkgs-windows": "nixpkgs-windows_637"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32479,7 +38395,7 @@
     "logos-nix_709": {
       "inputs": {
         "nixpkgs": "nixpkgs_709",
-        "nixpkgs-windows": "nixpkgs-windows_646"
+        "nixpkgs-windows": "nixpkgs-windows_638"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32517,7 +38433,7 @@
     "logos-nix_710": {
       "inputs": {
         "nixpkgs": "nixpkgs_710",
-        "nixpkgs-windows": "nixpkgs-windows_647"
+        "nixpkgs-windows": "nixpkgs-windows_639"
       },
       "locked": {
         "lastModified": 1786729772,
@@ -32536,7 +38452,7 @@
     "logos-nix_711": {
       "inputs": {
         "nixpkgs": "nixpkgs_711",
-        "nixpkgs-windows": "nixpkgs-windows_648"
+        "nixpkgs-windows": "nixpkgs-windows_640"
       },
       "locked": {
         "lastModified": 1786399295,
@@ -32554,14 +38470,14 @@
     },
     "logos-nix_712": {
       "inputs": {
-        "nixpkgs": "nixpkgs_712",
-        "nixpkgs-windows": "nixpkgs-windows_649"
+        "nixpkgs": "nixpkgs_712"
       },
       "locked": {
-        "lastModified": 1786399295,
-        "narHash": "sha256-Bl1A0UgsIXioZw5uEW8Jl5u7FfZcFMnpYlpsdezFwK0=",
+        "lastModified": 1774455309,
+        "narHash": "sha256-3AN7aFnArdysrbQQ2UskWzjNSFADb4hDCsnx69Fa0ng=",
         "owner": "logos-co",
         "repo": "logos-nix",
+<<<<<<< HEAD
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
         "type": "github"
       },
@@ -32695,6 +38611,9 @@
         "owner": "logos-co",
         "repo": "logos-nix",
         "rev": "6e0f4a7120fced10829b0b3a698ff619a11d4605",
+=======
+        "rev": "e637a1f5e871244d1c2df1e3c52a067f2eb406f2",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -32722,6 +38641,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_720": {
       "inputs": {
         "nixpkgs": "nixpkgs_720",
@@ -32910,6 +38830,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_73": {
       "inputs": {
         "nixpkgs": "nixpkgs_73",
@@ -32929,6 +38851,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_730": {
       "inputs": {
         "nixpkgs": "nixpkgs_730",
@@ -33116,6 +39039,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_74": {
       "inputs": {
         "nixpkgs": "nixpkgs_74",
@@ -33135,6 +39060,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_740": {
       "inputs": {
         "nixpkgs": "nixpkgs_740",
@@ -33323,6 +39249,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_75": {
       "inputs": {
         "nixpkgs": "nixpkgs_75",
@@ -33342,6 +39270,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-nix_750": {
       "inputs": {
         "nixpkgs": "nixpkgs_750"
@@ -33360,6 +39289,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-nix_76": {
       "inputs": {
         "nixpkgs": "nixpkgs_76",
@@ -33882,10 +39813,14 @@
     },
     "logos-package-downloader": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_393",
+=======
+        "logos-nix": "logos-nix_377",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_38",
         "nix-bundle-appimage": "nix-bundle-appimage_26",
-        "nix-bundle-dir": "nix-bundle-dir_61",
+        "nix-bundle-dir": "nix-bundle-dir_60",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -33894,11 +39829,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1789076965,
-        "narHash": "sha256-7F10LKMf0OXNqKQTcKBfgnN8IjGXpMqbZEWKpQ/uihM=",
+        "lastModified": 1789113943,
+        "narHash": "sha256-Nx5oFMtdMy06YGx8Itmbt7rslT2EAaT7t2M6N9bHNLw=",
         "owner": "logos-co",
         "repo": "logos-package-downloader",
-        "rev": "9a7cdb4f979cb44b4aebe09e6b58c1aa9a58f534",
+        "rev": "a822afc404338d6437db23a7c74df842228bbb0a",
         "type": "github"
       },
       "original": {
@@ -33913,11 +39848,11 @@
         "logos-package-downloader": "logos-package-downloader"
       },
       "locked": {
-        "lastModified": 1789077644,
-        "narHash": "sha256-ROMJ9/nkkU3yNbMua/ebnJ46L3Lno3K71bEVkETH2Ls=",
+        "lastModified": 1789126809,
+        "narHash": "sha256-7DLkJyhFLeULKnscFzfpH+CDSIfAVQZonNmjUthn6e4=",
         "owner": "logos-co",
         "repo": "logos-package-downloader-module",
-        "rev": "848e035fac35719ac751b869044ebb9043cfa379",
+        "rev": "37b7fbe7f0cf9d17a96ca4018589582d33922f5e",
         "type": "github"
       },
       "original": {
@@ -33961,11 +39896,11 @@
         "logos-package-manager": "logos-package-manager_22"
       },
       "locked": {
-        "lastModified": 1789066157,
-        "narHash": "sha256-JQLIOHj6dZ2/qY/ESf9un2SEC+cIH3z/Dw+wjuMFbuA=",
+        "lastModified": 1789070428,
+        "narHash": "sha256-TaZagYs2tuMXpMCCx871X30QwA6azHxMxibdrqHrYUQ=",
         "owner": "logos-co",
         "repo": "logos-package-manager-module",
-        "rev": "e991615120228844003fa5be78db76b8dce44924",
+        "rev": "2c3bb9af991be014d202fe0635bd774f1e04fa6f",
         "type": "github"
       },
       "original": {
@@ -33977,7 +39912,7 @@
     "logos-package-manager-ui": {
       "inputs": {
         "logos-module-builder": "logos-module-builder_15",
-        "logos-package": "logos-package_69",
+        "logos-package": "logos-package_68",
         "package_downloader": [
           "logos-package-downloader-module"
         ],
@@ -33986,11 +39921,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788817200,
-        "narHash": "sha256-brOubDJwVePfC+m01WbKAfrLwK8L0ew4+EyDOimfwcQ=",
+        "lastModified": 1789128665,
+        "narHash": "sha256-kAm8/aVITHEuT53jJGm46WPBpDHZRrym/HwucL2eXWg=",
         "owner": "logos-co",
         "repo": "logos-package-manager-ui",
-        "rev": "b557332a605e1920fbb025860d0446703c1ec82f",
+        "rev": "45935fbf3b568b2e492298730f6151f3044129d9",
         "type": "github"
       },
       "original": {
@@ -34001,8 +39936,13 @@
     },
     "logos-package-manager_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_319",
         "logos-package": "logos-package_28",
+=======
+        "logos-nix": "logos-nix_310",
+        "logos-package": "logos-package_29",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_21",
         "nix-bundle-dir": "nix-bundle-dir_46",
         "nixpkgs": [
@@ -34038,8 +39978,13 @@
     },
     "logos-package-manager_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_332",
         "logos-package": "logos-package_30",
+=======
+        "logos-nix": "logos-nix_323",
+        "logos-package": "logos-package_31",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_22",
         "nix-bundle-dir": "nix-bundle-dir_49",
         "nixpkgs": [
@@ -34072,8 +40017,13 @@
     },
     "logos-package-manager_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_352",
         "logos-package": "logos-package_32",
+=======
+        "logos-nix": "logos-nix_343",
+        "logos-package": "logos-package_33",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_23",
         "nix-bundle-dir": "nix-bundle-dir_52",
         "nixpkgs": [
@@ -34105,8 +40055,13 @@
     },
     "logos-package-manager_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_361",
         "logos-package": "logos-package_34",
+=======
+        "logos-nix": "logos-nix_352",
+        "logos-package": "logos-package_35",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_24",
         "nix-bundle-dir": "nix-bundle-dir_55",
         "nixpkgs": [
@@ -34120,11 +40075,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1787865382,
+        "narHash": "sha256-mM6TxIbIxsFSHUe6Hd+718qksL2RSVyIJlOBifVJnDY=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d88abaa1f3f5d4a4268d7cdfbec98d816e0a0385",
         "type": "github"
       },
       "original": {
@@ -34135,8 +40090,13 @@
     },
     "logos-package-manager_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_385",
         "logos-package": "logos-package_36",
+=======
+        "logos-nix": "logos-nix_372",
+        "logos-package": "logos-package_37",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_25",
         "nix-bundle-dir": "nix-bundle-dir_58",
         "nixpkgs": [
@@ -34149,11 +40109,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1788801286,
+        "narHash": "sha256-pNRp9uNNT9fNf1jaV9f0YHm5189GKJopBgT2H8ch/aI=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d3af2972f51d9c542537d80d60ad8d20282ddcd1",
         "type": "github"
       },
       "original": {
@@ -34164,10 +40124,14 @@
     },
     "logos-package-manager_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_398",
+=======
+        "logos-nix": "logos-nix_382",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_39",
         "nix-bundle-appimage": "nix-bundle-appimage_27",
-        "nix-bundle-dir": "nix-bundle-dir_63",
+        "nix-bundle-dir": "nix-bundle-dir_62",
         "nixpkgs": [
           "logos-package-manager",
           "logos-nix",
@@ -34190,10 +40154,14 @@
     },
     "logos-package-manager_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_443",
+=======
+        "logos-nix": "logos-nix_423",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_41",
         "nix-bundle-appimage": "nix-bundle-appimage_30",
-        "nix-bundle-dir": "nix-bundle-dir_68",
+        "nix-bundle-dir": "nix-bundle-dir_67",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34223,10 +40191,14 @@
     },
     "logos-package-manager_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_491",
+=======
+        "logos-nix": "logos-nix_471",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_44",
         "nix-bundle-appimage": "nix-bundle-appimage_33",
-        "nix-bundle-dir": "nix-bundle-dir_74",
+        "nix-bundle-dir": "nix-bundle-dir_73",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34260,10 +40232,14 @@
     },
     "logos-package-manager_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_504",
+=======
+        "logos-nix": "logos-nix_484",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_46",
         "nix-bundle-appimage": "nix-bundle-appimage_34",
-        "nix-bundle-dir": "nix-bundle-dir_77",
+        "nix-bundle-dir": "nix-bundle-dir_76",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34294,10 +40270,14 @@
     },
     "logos-package-manager_19": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_524",
+=======
+        "logos-nix": "logos-nix_504",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_48",
         "nix-bundle-appimage": "nix-bundle-appimage_35",
-        "nix-bundle-dir": "nix-bundle-dir_80",
+        "nix-bundle-dir": "nix-bundle-dir_79",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34357,10 +40337,14 @@
     },
     "logos-package-manager_20": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_533",
+=======
+        "logos-nix": "logos-nix_513",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_50",
         "nix-bundle-appimage": "nix-bundle-appimage_36",
-        "nix-bundle-dir": "nix-bundle-dir_83",
+        "nix-bundle-dir": "nix-bundle-dir_82",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34387,10 +40371,14 @@
     },
     "logos-package-manager_21": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_557",
+=======
+        "logos-nix": "logos-nix_537",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_52",
         "nix-bundle-appimage": "nix-bundle-appimage_37",
-        "nix-bundle-dir": "nix-bundle-dir_86",
+        "nix-bundle-dir": "nix-bundle-dir_85",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -34401,11 +40389,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1788801286,
+        "narHash": "sha256-pNRp9uNNT9fNf1jaV9f0YHm5189GKJopBgT2H8ch/aI=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d3af2972f51d9c542537d80d60ad8d20282ddcd1",
         "type": "github"
       },
       "original": {
@@ -34416,10 +40404,15 @@
     },
     "logos-package-manager_22": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_565",
         "logos-package": "logos-package_54",
+=======
+        "logos-nix": "logos-nix_542",
+        "logos-package": "logos-package_53",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_38",
-        "nix-bundle-dir": "nix-bundle-dir_89",
+        "nix-bundle-dir": "nix-bundle-dir_87",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -34443,10 +40436,15 @@
     },
     "logos-package-manager_23": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_609",
         "logos-package": "logos-package_56",
+=======
+        "logos-nix": "logos-nix_579",
+        "logos-package": "logos-package_55",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_41",
-        "nix-bundle-dir": "nix-bundle-dir_94",
+        "nix-bundle-dir": "nix-bundle-dir_92",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34476,10 +40474,14 @@
     },
     "logos-package-manager_24": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_657",
+=======
+        "logos-nix": "logos-nix_626",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_59",
         "nix-bundle-appimage": "nix-bundle-appimage_44",
-        "nix-bundle-dir": "nix-bundle-dir_100",
+        "nix-bundle-dir": "nix-bundle-dir_98",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34513,10 +40515,14 @@
     },
     "logos-package-manager_25": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_670",
+=======
+        "logos-nix": "logos-nix_639",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_61",
         "nix-bundle-appimage": "nix-bundle-appimage_45",
-        "nix-bundle-dir": "nix-bundle-dir_103",
+        "nix-bundle-dir": "nix-bundle-dir_101",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34547,10 +40553,14 @@
     },
     "logos-package-manager_26": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_690",
+=======
+        "logos-nix": "logos-nix_659",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_63",
         "nix-bundle-appimage": "nix-bundle-appimage_46",
-        "nix-bundle-dir": "nix-bundle-dir_106",
+        "nix-bundle-dir": "nix-bundle-dir_104",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34580,10 +40590,14 @@
     },
     "logos-package-manager_27": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_699",
+=======
+        "logos-nix": "logos-nix_668",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_65",
         "nix-bundle-appimage": "nix-bundle-appimage_47",
-        "nix-bundle-dir": "nix-bundle-dir_109",
+        "nix-bundle-dir": "nix-bundle-dir_107",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34595,11 +40609,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1787865382,
+        "narHash": "sha256-mM6TxIbIxsFSHUe6Hd+718qksL2RSVyIJlOBifVJnDY=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d88abaa1f3f5d4a4268d7cdfbec98d816e0a0385",
         "type": "github"
       },
       "original": {
@@ -34610,10 +40624,14 @@
     },
     "logos-package-manager_28": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_723",
+=======
+        "logos-nix": "logos-nix_688",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_67",
         "nix-bundle-appimage": "nix-bundle-appimage_48",
-        "nix-bundle-dir": "nix-bundle-dir_112",
+        "nix-bundle-dir": "nix-bundle-dir_110",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -34624,11 +40642,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1788801286,
+        "narHash": "sha256-pNRp9uNNT9fNf1jaV9f0YHm5189GKJopBgT2H8ch/aI=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d3af2972f51d9c542537d80d60ad8d20282ddcd1",
         "type": "github"
       },
       "original": {
@@ -34639,10 +40657,15 @@
     },
     "logos-package-manager_29": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_742",
         "logos-package": "logos-package_70",
+=======
+        "logos-nix": "logos-nix_704",
+        "logos-package": "logos-package_69",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-appimage": "nix-bundle-appimage_50",
-        "nix-bundle-dir": "nix-bundle-dir_117",
+        "nix-bundle-dir": "nix-bundle-dir_114",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -34651,11 +40674,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819921,
-        "narHash": "sha256-orlnFDgBvqP1QnaWNmK6QppoBwCpZRx/CPrjA1lLtO8=",
+        "lastModified": 1788801286,
+        "narHash": "sha256-pNRp9uNNT9fNf1jaV9f0YHm5189GKJopBgT2H8ch/aI=",
         "owner": "logos-co",
         "repo": "logos-package-manager",
-        "rev": "fb8fb6a8cf76d996f0cc5f8fbac03c6dec3be2b1",
+        "rev": "d3af2972f51d9c542537d80d60ad8d20282ddcd1",
         "type": "github"
       },
       "original": {
@@ -34853,7 +40876,11 @@
     },
     "logos-package-manager_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_271",
+=======
+        "logos-nix": "logos-nix_263",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_25",
         "nix-bundle-appimage": "nix-bundle-appimage_18",
         "nix-bundle-dir": "nix-bundle-dir_40",
@@ -35307,7 +41334,11 @@
     },
     "logos-package_24": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_268",
+=======
+        "logos-nix": "logos-nix_260",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35337,7 +41368,11 @@
     },
     "logos-package_25": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_272",
+=======
+        "logos-nix": "logos-nix_264",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35368,7 +41403,11 @@
     },
     "logos-package_26": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_277",
+=======
+        "logos-nix": "logos-nix_269",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35399,7 +41438,46 @@
     },
     "logos-package_27": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_316",
+=======
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787930147,
+        "narHash": "sha256-NFsVZMfGO0FNQWD+JplmZwRe4nwZOKVd0iBOF1y5GQQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "542305b1040771997251418a6bd1d4ac4f457950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_28": {
+      "inputs": {
+        "logos-nix": "logos-nix_307",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35431,6 +41509,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-package_28": {
       "inputs": {
         "logos-nix": "logos-nix_320",
@@ -35469,6 +41548,11 @@
     "logos-package_29": {
       "inputs": {
         "logos-nix": "logos-nix_325",
+=======
+    "logos-package_29": {
+      "inputs": {
+        "logos-nix": "logos-nix_311",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35481,7 +41565,7 @@
           "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -35530,7 +41614,11 @@
     },
     "logos-package_30": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_333",
+=======
+        "logos-nix": "logos-nix_316",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35540,7 +41628,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-package-manager",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -35562,7 +41653,11 @@
     },
     "logos-package_31": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_349",
+=======
+        "logos-nix": "logos-nix_324",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35570,7 +41665,9 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
@@ -35592,7 +41689,44 @@
     },
     "logos-package_32": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_353",
+=======
+        "logos-nix": "logos-nix_340",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786463662,
+        "narHash": "sha256-h2ex453W73qjkN8n6Bo9ywU5X22bssmyCMpQjR5LRzY=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "3cb520c8eadde3d6d7810dee74bdd243f73f34e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_33": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_358",
+=======
+        "logos-nix": "logos-nix_344",
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35621,9 +41755,10 @@
         "type": "github"
       }
     },
-    "logos-package_33": {
+    "logos-package_34": {
       "inputs": {
-        "logos-nix": "logos-nix_358",
+        "logos-nix": "logos-nix_349",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35652,9 +41787,13 @@
         "type": "github"
       }
     },
-    "logos-package_34": {
+    "logos-package_35": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_362",
+=======
+        "logos-nix": "logos-nix_353",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35667,10 +41806,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1787833864,
+        "narHash": "sha256-v0Nbhy4YXm1d/luboCbIL4yNIgcfkRXVTs1jXucLoVY=",
         "owner": "logos-co",
         "repo": "logos-package",
+<<<<<<< HEAD
         "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
@@ -35698,6 +41838,9 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+=======
+        "rev": "49151f003690333764d73f956d64e1245e2a0c38",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -35708,7 +41851,37 @@
     },
     "logos-package_36": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_386",
+=======
+        "logos-nix": "logos-nix_369",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
+    "logos-package_37": {
+      "inputs": {
+        "logos-nix": "logos-nix_373",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -35720,10 +41893,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
+<<<<<<< HEAD
         "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
         "type": "github"
       },
@@ -35752,6 +41926,9 @@
         "owner": "logos-co",
         "repo": "logos-package",
         "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+=======
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -35762,7 +41939,11 @@
     },
     "logos-package_38": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_394",
+=======
+        "logos-nix": "logos-nix_378",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -35787,7 +41968,11 @@
     },
     "logos-package_39": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_399",
+=======
+        "logos-nix": "logos-nix_383",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "logos-package",
@@ -35838,7 +42023,11 @@
     },
     "logos-package_40": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_440",
+=======
+        "logos-nix": "logos-nix_420",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35868,7 +42057,11 @@
     },
     "logos-package_41": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_444",
+=======
+        "logos-nix": "logos-nix_424",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35899,7 +42092,11 @@
     },
     "logos-package_42": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_449",
+=======
+        "logos-nix": "logos-nix_429",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35930,7 +42127,11 @@
     },
     "logos-package_43": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_488",
+=======
+        "logos-nix": "logos-nix_468",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35964,7 +42165,11 @@
     },
     "logos-package_44": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_492",
+=======
+        "logos-nix": "logos-nix_472",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -35999,7 +42204,11 @@
     },
     "logos-package_45": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_497",
+=======
+        "logos-nix": "logos-nix_477",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36034,7 +42243,11 @@
     },
     "logos-package_46": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_505",
+=======
+        "logos-nix": "logos-nix_485",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36066,7 +42279,11 @@
     },
     "logos-package_47": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_521",
+=======
+        "logos-nix": "logos-nix_501",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36096,7 +42313,11 @@
     },
     "logos-package_48": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_525",
+=======
+        "logos-nix": "logos-nix_505",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36127,7 +42348,11 @@
     },
     "logos-package_49": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_530",
+=======
+        "logos-nix": "logos-nix_510",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36186,7 +42411,11 @@
     },
     "logos-package_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_534",
+=======
+        "logos-nix": "logos-nix_514",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36214,7 +42443,11 @@
     },
     "logos-package_51": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_554",
+=======
+        "logos-nix": "logos-nix_534",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36225,11 +42458,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36240,7 +42473,11 @@
     },
     "logos-package_52": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_558",
+=======
+        "logos-nix": "logos-nix_538",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -36252,11 +42489,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36267,6 +42504,7 @@
     },
     "logos-package_53": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_563",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -36295,6 +42533,9 @@
     "logos-package_54": {
       "inputs": {
         "logos-nix": "logos-nix_566",
+=======
+        "logos-nix": "logos-nix_543",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -36317,9 +42558,13 @@
         "type": "github"
       }
     },
-    "logos-package_55": {
+    "logos-package_54": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_606",
+=======
+        "logos-nix": "logos-nix_576",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36347,9 +42592,13 @@
         "type": "github"
       }
     },
-    "logos-package_56": {
+    "logos-package_55": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_610",
+=======
+        "logos-nix": "logos-nix_580",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36378,9 +42627,13 @@
         "type": "github"
       }
     },
-    "logos-package_57": {
+    "logos-package_56": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_615",
+=======
+        "logos-nix": "logos-nix_585",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36409,9 +42662,48 @@
         "type": "github"
       }
     },
+    "logos-package_57": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-module",
+          "logos-package",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787930147,
+        "narHash": "sha256-NFsVZMfGO0FNQWD+JplmZwRe4nwZOKVd0iBOF1y5GQQ=",
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "rev": "542305b1040771997251418a6bd1d4ac4f457950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-package",
+        "type": "github"
+      }
+    },
     "logos-package_58": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_654",
+=======
+        "logos-nix": "logos-nix_623",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36445,7 +42737,11 @@
     },
     "logos-package_59": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_658",
+=======
+        "logos-nix": "logos-nix_627",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36508,7 +42804,11 @@
     },
     "logos-package_60": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_663",
+=======
+        "logos-nix": "logos-nix_632",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36543,7 +42843,11 @@
     },
     "logos-package_61": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_671",
+=======
+        "logos-nix": "logos-nix_640",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36575,7 +42879,11 @@
     },
     "logos-package_62": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_687",
+=======
+        "logos-nix": "logos-nix_656",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36605,7 +42913,11 @@
     },
     "logos-package_63": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_691",
+=======
+        "logos-nix": "logos-nix_660",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36636,7 +42948,11 @@
     },
     "logos-package_64": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_696",
+=======
+        "logos-nix": "logos-nix_665",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36667,7 +42983,11 @@
     },
     "logos-package_65": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_700",
+=======
+        "logos-nix": "logos-nix_669",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36680,11 +43000,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1787833864,
+        "narHash": "sha256-v0Nbhy4YXm1d/luboCbIL4yNIgcfkRXVTs1jXucLoVY=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "49151f003690333764d73f956d64e1245e2a0c38",
         "type": "github"
       },
       "original": {
@@ -36695,7 +43015,11 @@
     },
     "logos-package_66": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_720",
+=======
+        "logos-nix": "logos-nix_685",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36706,11 +43030,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36721,7 +43045,11 @@
     },
     "logos-package_67": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_724",
+=======
+        "logos-nix": "logos-nix_689",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -36733,11 +43061,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36748,23 +43076,24 @@
     },
     "logos-package_68": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_729",
+=======
+        "logos-nix": "logos-nix_693",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36775,20 +43104,25 @@
     },
     "logos-package_69": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_731",
+=======
+        "logos-nix": "logos-nix_705",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
-          "logos-package-manager-ui",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "logos-package",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787949461,
-        "narHash": "sha256-LFeE2oLEz+It4WsMwNp4WVVQ1SgU1DbmvR4J7/LGbLk=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "2119af8524d0d131ad4d7d8f7414b003c381b3a6",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36828,6 +43162,7 @@
     },
     "logos-package_70": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_743",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
@@ -36854,6 +43189,9 @@
     "logos-package_71": {
       "inputs": {
         "logos-nix": "logos-nix_748",
+=======
+        "logos-nix": "logos-nix_710",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -36863,11 +43201,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819133,
-        "narHash": "sha256-3ZuVhlfBA/dZvJeS9oxr4g4ASkGchYCrieZq/jG7Mk0=",
+        "lastModified": 1788798694,
+        "narHash": "sha256-EMV9DfMNBkcNoBQSFsfppl6yYA1Rh7Q3XA5Nt4HauYg=",
         "owner": "logos-co",
         "repo": "logos-package",
-        "rev": "1eae01c2972dbd42cd11ad4c64a243ca45be8099",
+        "rev": "4cdb302051ebcd231eeaeeaa2011fcf857541ce4",
         "type": "github"
       },
       "original": {
@@ -36973,9 +43311,15 @@
     },
     "logos-plugin-core_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_93",
         "logos-module": "logos-module_68",
         "logos-nix": "logos-nix_305",
+=======
+        "logos-lidl": "logos-lidl_90",
+        "logos-module": "logos-module_66",
+        "logos-nix": "logos-nix_296",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37021,9 +43365,15 @@
     },
     "logos-plugin-core_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_117",
         "logos-module": "logos-module_84",
         "logos-nix": "logos-nix_408",
+=======
+        "logos-lidl": "logos-lidl_113",
+        "logos-module": "logos-module_80",
+        "logos-nix": "logos-nix_391",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37038,11 +43388,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "lastModified": 1788230090,
+        "narHash": "sha256-SHO7g0AqKt2trDMRag0VZHTbIA2EYTZuW1tuKu/YQSc=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "rev": "5ef95a4172bf9d0f541f37e7573598f395fb49ef",
         "type": "github"
       },
       "original": {
@@ -37053,9 +43403,15 @@
     },
     "logos-plugin-core_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_125",
         "logos-module": "logos-module_90",
         "logos-nix": "logos-nix_429",
+=======
+        "logos-lidl": "logos-lidl_121",
+        "logos-module": "logos-module_85",
+        "logos-nix": "logos-nix_409",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37093,9 +43449,15 @@
     },
     "logos-plugin-core_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_135",
         "logos-module": "logos-module_97",
         "logos-nix": "logos-nix_460",
+=======
+        "logos-lidl": "logos-lidl_131",
+        "logos-module": "logos-module_92",
+        "logos-nix": "logos-nix_440",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37133,9 +43495,15 @@
     },
     "logos-plugin-core_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_141",
         "logos-module": "logos-module_102",
         "logos-nix": "logos-nix_477",
+=======
+        "logos-lidl": "logos-lidl_137",
+        "logos-module": "logos-module_97",
+        "logos-nix": "logos-nix_457",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -37181,9 +43549,15 @@
     },
     "logos-plugin-core_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_165",
         "logos-module": "logos-module_118",
         "logos-nix": "logos-nix_575",
+=======
+        "logos-lidl": "logos-lidl_161",
+        "logos-module": "logos-module_113",
+        "logos-nix": "logos-nix_551",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37198,11 +43572,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788230090,
-        "narHash": "sha256-SHO7g0AqKt2trDMRag0VZHTbIA2EYTZuW1tuKu/YQSc=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "5ef95a4172bf9d0f541f37e7573598f395fb49ef",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -37213,9 +43587,15 @@
     },
     "logos-plugin-core_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_173",
         "logos-module": "logos-module_123",
         "logos-nix": "logos-nix_595",
+=======
+        "logos-lidl": "logos-lidl_167",
+        "logos-module": "logos-module_117",
+        "logos-nix": "logos-nix_565",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37253,9 +43633,15 @@
     },
     "logos-plugin-core_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_183",
         "logos-module": "logos-module_130",
         "logos-nix": "logos-nix_626",
+=======
+        "logos-lidl": "logos-lidl_176",
+        "logos-module": "logos-module_124",
+        "logos-nix": "logos-nix_595",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37293,9 +43679,15 @@
     },
     "logos-plugin-core_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_189",
         "logos-module": "logos-module_135",
         "logos-nix": "logos-nix_643",
+=======
+        "logos-lidl": "logos-lidl_182",
+        "logos-module": "logos-module_129",
+        "logos-nix": "logos-nix_612",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -37525,7 +43917,11 @@
       "inputs": {
         "logos-lidl": "logos-lidl_69",
         "logos-module": "logos-module_50",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_236",
+=======
+        "logos-nix": "logos-nix_235",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37540,11 +43936,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -37555,9 +43951,15 @@
     },
     "logos-plugin-core_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_77",
         "logos-module": "logos-module_56",
         "logos-nix": "logos-nix_257",
+=======
+        "logos-lidl": "logos-lidl_75",
+        "logos-module": "logos-module_54",
+        "logos-nix": "logos-nix_249",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -37595,9 +43997,15 @@
     },
     "logos-plugin-core_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_87",
         "logos-module": "logos-module_63",
         "logos-nix": "logos-nix_288",
+=======
+        "logos-lidl": "logos-lidl_84",
+        "logos-module": "logos-module_61",
+        "logos-nix": "logos-nix_279",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38065,11 +44473,43 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_19": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_47",
+        "logos-module": "logos-module_35",
+        "logos-nix": "logos-nix_159",
+        "logos-protocol": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
         "type": "github"
       },
       "original": {
@@ -38544,7 +44984,15 @@
       "inputs": {
         "logos-lidl": "logos-lidl_70",
         "logos-module": "logos-module_51",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_238",
+=======
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38559,11 +45007,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787775220,
         "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+=======
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -38611,15 +45067,70 @@
     },
     "logos-plugin-qt_30": {
       "inputs": {
+<<<<<<< HEAD
+=======
+        "logos-lidl": "logos-lidl_76",
+        "logos-module": "logos-module_55",
+        "logos-nix": "logos-nix_251",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_31": {
+      "inputs": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_52",
+=======
+        "logos-module": "logos-module_56",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
@@ -38627,11 +45138,19 @@
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -38711,6 +45230,7 @@
     },
     "logos-plugin-qt_32": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_78",
         "logos-module": "logos-module_57",
         "logos-nix": "logos-nix_259",
@@ -38813,6 +45333,10 @@
       "inputs": {
         "logos-lidl": "logos-lidl_81",
         "logos-module": "logos-module_59",
+=======
+        "logos-lidl": "logos-lidl_79",
+        "logos-module": "logos-module_57",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38858,10 +45382,17 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_35": {
       "inputs": {
         "logos-lidl": "logos-lidl_84",
         "logos-module": "logos-module_60",
+=======
+    "logos-plugin-qt_33": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_82",
+        "logos-module": "logos-module_58",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38907,11 +45438,19 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_36": {
       "inputs": {
         "logos-lidl": "logos-lidl_88",
         "logos-module": "logos-module_64",
         "logos-nix": "logos-nix_290",
+=======
+    "logos-plugin-qt_34": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_85",
+        "logos-module": "logos-module_62",
+        "logos-nix": "logos-nix_281",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38947,7 +45486,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_37": {
+=======
+    "logos-plugin-qt_35": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-downloader-module",
@@ -38959,7 +45502,11 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_65",
+=======
+        "logos-module": "logos-module_63",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -38986,6 +45533,156 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-plugin-qt_38": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_94",
+        "logos-module": "logos-module_69",
+        "logos-nix": "logos-nix_307",
+=======
+    "logos-plugin-qt_36": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_91",
+        "logos-module": "logos-module_67",
+        "logos-nix": "logos-nix_298",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-plugin-qt_39": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+=======
+    "logos-plugin-qt_37": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_68",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -39011,7 +45708,20 @@
       "inputs": {
         "logos-lidl": "logos-lidl_94",
         "logos-module": "logos-module_69",
-        "logos-nix": "logos-nix_307",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39023,6 +45733,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39036,8 +45747,7 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -39057,20 +45767,8 @@
     },
     "logos-plugin-qt_39": {
       "inputs": {
-        "logos-lidl": [
-          "logos-package-downloader-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-qt-sdk",
-          "logos-lidl"
-        ],
+        "logos-lidl": "logos-lidl_97",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_70",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39083,7 +45781,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39097,7 +45799,11 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39111,9 +45817,13 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
+=======
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -39167,6 +45877,7 @@
     },
     "logos-plugin-qt_40": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_97",
         "logos-module": "logos-module_71",
         "logos-nix": [
@@ -39229,6 +45940,9 @@
     "logos-plugin-qt_41": {
       "inputs": {
         "logos-lidl": "logos-lidl_100",
+=======
+        "logos-lidl": "logos-lidl_99",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_72",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39239,9 +45953,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39253,9 +45970,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39267,18 +45987,70 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787165449,
-        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_41": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_101",
+        "logos-module": "logos-module_73",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
         "type": "github"
       },
       "original": {
@@ -39298,8 +46070,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -39309,8 +46085,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -39320,8 +46100,12 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -39341,7 +46125,7 @@
     },
     "logos-plugin-qt_43": {
       "inputs": {
-        "logos-lidl": "logos-lidl_104",
+        "logos-lidl": "logos-lidl_105",
         "logos-module": "logos-module_75",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -39350,6 +46134,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-nix"
         ],
@@ -39448,6 +46233,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -39486,6 +46273,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_46": {
       "inputs": {
         "logos-lidl": "logos-lidl_109",
@@ -39535,31 +46323,34 @@
           "logos-qt-sdk",
           "logos-nix"
         ],
+=======
+    "logos-plugin-qt_44": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_107",
+        "logos-module": "logos-module_76",
+        "logos-nix": "logos-nix_361",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -39568,6 +46359,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_48": {
       "inputs": {
         "logos-lidl": "logos-lidl_111",
@@ -39601,6 +46393,12 @@
       "inputs": {
         "logos-lidl": "logos-lidl_112",
         "logos-module": "logos-module_81",
+=======
+    "logos-plugin-qt_45": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_108",
+        "logos-module": "logos-module_77",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39634,6 +46432,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_5": {
       "inputs": {
         "logos-lidl": [
@@ -39686,6 +46485,12 @@
       "inputs": {
         "logos-lidl": "logos-lidl_115",
         "logos-module": "logos-module_82",
+=======
+    "logos-plugin-qt_46": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_111",
+        "logos-module": "logos-module_78",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -39706,6 +46511,98 @@
         ]
       },
       "locked": {
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_47": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_114",
+        "logos-module": "logos-module_81",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788230090,
+        "narHash": "sha256-SHO7g0AqKt2trDMRag0VZHTbIA2EYTZuW1tuKu/YQSc=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "5ef95a4172bf9d0f541f37e7573598f395fb49ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_48": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_83",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
         "lastModified": 1787592243,
         "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
@@ -39719,18 +46616,34 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_51": {
       "inputs": {
         "logos-lidl": "logos-lidl_118",
         "logos-module": "logos-module_85",
         "logos-nix": "logos-nix_410",
+=======
+    "logos-plugin-qt_49": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_122",
+        "logos-module": "logos-module_86",
+        "logos-nix": "logos-nix_411",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-plugin-qt",
           "logos-nix",
@@ -39751,29 +46664,41 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_52": {
+=======
+    "logos-plugin-qt_5": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
-          "logos-package-manager-module",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_86",
+=======
+        "logos-module": "logos-module_10",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
-          "logos-package-manager-module",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-plugin-qt",
@@ -39795,122 +46720,42 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_53": {
+=======
+    "logos-plugin-qt_50": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "default-module-loader",
           "logos-qt-sdk",
           "logos-lidl"
         ],
         "logos-module": "logos-module_88",
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix"
-        ],
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_54": {
-      "inputs": {
-        "logos-lidl": "logos-lidl_126",
-        "logos-module": "logos-module_91",
-        "logos-nix": "logos-nix_431",
-        "logos-protocol": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-protocol"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-plugin-qt",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-plugin-qt",
-        "type": "github"
-      }
-    },
-    "logos-plugin-qt_55": {
-      "inputs": {
-        "logos-lidl": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
+=======
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-lidl"
         ],
-        "logos-module": "logos-module_92",
+        "logos-module": "logos-module_87",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
+          "default-module-loader",
+=======
           "logos-capability-module",
           "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-nix"
         ],
@@ -39919,8 +46764,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
+          "default-module-loader",
+=======
           "logos-capability-module",
           "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-protocol"
         ],
@@ -39929,8 +46778,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
+          "default-module-loader",
+=======
           "logos-capability-module",
           "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
@@ -39951,10 +46804,17 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_56": {
+<<<<<<< HEAD
+    "logos-plugin-qt_54": {
       "inputs": {
-        "logos-lidl": "logos-lidl_129",
-        "logos-module": "logos-module_93",
+        "logos-lidl": "logos-lidl_126",
+        "logos-module": "logos-module_91",
+        "logos-nix": "logos-nix_431",
+=======
+    "logos-plugin-qt_51": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_125",
+        "logos-module": "logos-module_88",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40000,10 +46860,10 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_57": {
+    "logos-plugin-qt_52": {
       "inputs": {
-        "logos-lidl": "logos-lidl_132",
-        "logos-module": "logos-module_94",
+        "logos-lidl": "logos-lidl_128",
+        "logos-module": "logos-module_89",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40036,6 +46896,368 @@
         ]
       },
       "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_53": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_132",
+        "logos-module": "logos-module_93",
+        "logos-nix": "logos-nix_442",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_54": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_94",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_55": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_138",
+        "logos-module": "logos-module_98",
+        "logos-nix": "logos-nix_459",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_55": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+<<<<<<< HEAD
+        "logos-module": "logos-module_92",
+=======
+        "logos-module": "logos-module_99",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_56": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_129",
+        "logos-module": "logos-module_93",
+=======
+        "logos-lidl": "logos-lidl_141",
+        "logos-module": "logos-module_100",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_57": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_132",
+        "logos-module": "logos-module_94",
+=======
+        "logos-lidl": "logos-lidl_144",
+        "logos-module": "logos-module_101",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+<<<<<<< HEAD
         "lastModified": 1787592243,
         "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
@@ -40224,6 +47446,8 @@
         ]
       },
       "locked": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "lastModified": 1787165449,
         "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
         "owner": "logos-co",
@@ -40237,8 +47461,9 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_61": {
+    "logos-plugin-qt_59": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40254,6 +47479,10 @@
           "logos-lidl"
         ],
         "logos-module": "logos-module_104",
+=======
+        "logos-lidl": "logos-lidl_146",
+        "logos-module": "logos-module_103",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40263,9 +47492,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-nix"
         ],
         "logos-protocol": [
@@ -40277,9 +47509,12 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -40291,11 +47526,150 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_6": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_16",
+        "logos-module": "logos-module_11",
+        "logos-nix": [
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
+=======
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_60": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_148",
+        "logos-module": "logos-module_104",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_61": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_149",
+        "logos-module": "logos-module_105",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
@@ -40315,6 +47689,7 @@
     },
     "logos-plugin-qt_62": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_145",
         "logos-module": "logos-module_105",
         "logos-nix": [
@@ -40589,6 +47964,10 @@
       "inputs": {
         "logos-lidl": "logos-lidl_156",
         "logos-module": "logos-module_111",
+=======
+        "logos-lidl": "logos-lidl_152",
+        "logos-module": "logos-module_106",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40634,12 +48013,21 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_68": {
       "inputs": {
         "logos-lidl": "logos-lidl_157",
         "logos-module": "logos-module_112",
         "logos-nix": "logos-nix_539",
         "logos-protocol": "logos-protocol_86",
+=======
+    "logos-plugin-qt_63": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_153",
+        "logos-module": "logos-module_107",
+        "logos-nix": "logos-nix_519",
+        "logos-protocol": "logos-protocol_79",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -40664,6 +48052,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_69": {
       "inputs": {
         "logos-lidl": [
@@ -40721,6 +48110,247 @@
         "logos-lidl": "logos-lidl_19",
         "logos-module": "logos-module_12",
         "logos-nix": [
+=======
+    "logos-plugin-qt_64": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_108",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_65": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_155",
+        "logos-module": "logos-module_109",
+        "logos-nix": "logos-nix_526",
+        "logos-protocol": "logos-protocol_82",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_66": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_156",
+        "logos-module": "logos-module_110",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+<<<<<<< HEAD
+          "logos-view-module-runtime",
+=======
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_67": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_159",
+        "logos-module": "logos-module_111",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_68": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_162",
+        "logos-module": "logos-module_114",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_69": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_168",
+        "logos-module": "logos-module_118",
+        "logos-nix": "logos-nix_567",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775220,
+        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_7": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_19",
+        "logos-module": "logos-module_12",
+        "logos-nix": [
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
@@ -40758,25 +48388,57 @@
     },
     "logos-plugin-qt_70": {
       "inputs": {
-        "logos-lidl": "logos-lidl_159",
-        "logos-module": "logos-module_114",
-        "logos-nix": "logos-nix_546",
-        "logos-protocol": "logos-protocol_89",
-        "nixpkgs": [
-          "logos-package-manager-module",
+        "logos-lidl": [
+          "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_119",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787775220,
-        "narHash": "sha256-9Eof2dz877c0y6nxFlLz/VdzI8QK+L+5EcACen63jA8=",
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "335edec4e2477ef73a39c4f949795faa3228b8cb",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
         "type": "github"
       },
       "original": {
@@ -40785,24 +48447,45 @@
         "type": "github"
       }
     },
-    "logos-plugin-qt_71": {
+    "logos-plugin-qt_70": {
       "inputs": {
-        "logos-lidl": "logos-lidl_160",
-        "logos-module": "logos-module_115",
-        "logos-nix": [
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_159",
+        "logos-module": "logos-module_114",
+        "logos-nix": "logos-nix_546",
+        "logos-protocol": "logos-protocol_89",
+        "nixpkgs": [
           "logos-package-manager-module",
+=======
+        "logos-lidl": "logos-lidl_171",
+        "logos-module": "logos-module_120",
+        "logos-nix": [
+          "logos-package-manager-ui",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-nix"
         ],
         "logos-protocol": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-manager-module",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "nixpkgs"
@@ -40822,8 +48505,63 @@
         "type": "github"
       }
     },
+    "logos-plugin-qt_71": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_160",
+        "logos-module": "logos-module_115",
+=======
+        "logos-lidl": "logos-lidl_174",
+        "logos-module": "logos-module_121",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787592243,
+        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
     "logos-plugin-qt_72": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_163",
         "logos-module": "logos-module_116",
         "logos-nix": [
@@ -41150,6 +48888,11 @@
         "logos-lidl": "logos-lidl_184",
         "logos-module": "logos-module_131",
         "logos-nix": "logos-nix_628",
+=======
+        "logos-lidl": "logos-lidl_177",
+        "logos-module": "logos-module_125",
+        "logos-nix": "logos-nix_597",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41185,6 +48928,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_8": {
       "inputs": {
         "logos-lidl": "logos-lidl_22",
@@ -41220,6 +48964,9 @@
       }
     },
     "logos-plugin-qt_80": {
+=======
+    "logos-plugin-qt_74": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-lidl": [
           "logos-package-manager-ui",
@@ -41231,7 +48978,11 @@
           "logos-qt-sdk",
           "logos-lidl"
         ],
+<<<<<<< HEAD
         "logos-module": "logos-module_132",
+=======
+        "logos-module": "logos-module_126",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41279,11 +49030,19 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_81": {
       "inputs": {
         "logos-lidl": "logos-lidl_190",
         "logos-module": "logos-module_136",
         "logos-nix": "logos-nix_645",
+=======
+    "logos-plugin-qt_75": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_183",
+        "logos-module": "logos-module_130",
+        "logos-nix": "logos-nix_614",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41327,6 +49086,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_82": {
       "inputs": {
         "logos-lidl": [
@@ -41406,6 +49166,393 @@
     "logos-plugin-qt_83": {
       "inputs": {
         "logos-lidl": "logos-lidl_193",
+=======
+    "logos-plugin-qt_76": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_131",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_77": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_186",
+        "logos-module": "logos-module_132",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_78": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_189",
+        "logos-module": "logos-module_133",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_79": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_191",
+        "logos-module": "logos-module_135",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_8": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_22",
+        "logos-module": "logos-module_16",
+        "logos-nix": "logos-nix_71",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787747885,
+        "narHash": "sha256-fY/2DnP6HmeMzZTODXKpE5NPd5/+X+kHUWXgdQkJhw8=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "f668ef212f36daffdfbd45634527a761dd12585b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_80": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_193",
+        "logos-module": "logos-module_136",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787275742,
+        "narHash": "sha256-/5FwGSIV80CNdc52qYIb1lx1VXWaOZcnnU8zAbKlfSw=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "1aa3e31c029062a8288e5ef4da1f25ca14a8a0dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_81": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_194",
+        "logos-module": "logos-module_137",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_82": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_197",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-module": "logos-module_138",
         "logos-nix": [
           "logos-package-manager-ui",
@@ -41414,6 +49561,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-capability-module",
@@ -41686,6 +49834,8 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -41724,6 +49874,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_89": {
       "inputs": {
         "logos-lidl": "logos-lidl_205",
@@ -41821,31 +49972,34 @@
           "logos-qt-sdk",
           "logos-nix"
         ],
+=======
+    "logos-plugin-qt_83": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_199",
+        "logos-module": "logos-module_139",
+        "logos-nix": "logos-nix_677",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-protocol"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-liblogos",
-          "logos-qt-sdk",
           "logos-plugin-qt",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -41854,6 +50008,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_91": {
       "inputs": {
         "logos-lidl": "logos-lidl_207",
@@ -41887,6 +50042,12 @@
       "inputs": {
         "logos-lidl": "logos-lidl_208",
         "logos-module": "logos-module_148",
+=======
+    "logos-plugin-qt_84": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_200",
+        "logos-module": "logos-module_140",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41920,10 +50081,17 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_93": {
       "inputs": {
         "logos-lidl": "logos-lidl_211",
         "logos-module": "logos-module_149",
+=======
+    "logos-plugin-qt_85": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_203",
+        "logos-module": "logos-module_141",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -41944,11 +50112,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787592243,
-        "narHash": "sha256-ky7MnwW4c5/c/tkfKty+Dpb1nvyM3BkFxcV+I1kCg4s=",
+        "lastModified": 1789101842,
+        "narHash": "sha256-2JbAxFIVRtCikVgn5wOSR0zwqPdvLH7i0jgctKJJodo=",
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
-        "rev": "048152f2a17b41a1cab5d1c46f519a29697b3eb5",
+        "rev": "8af5b188225a22043c4380395d668e133fb1c873",
         "type": "github"
       },
       "original": {
@@ -41957,11 +50125,19 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-plugin-qt_94": {
       "inputs": {
         "logos-lidl": "logos-lidl_212",
         "logos-module": "logos-module_150",
         "logos-nix": "logos-nix_733",
+=======
+    "logos-plugin-qt_86": {
+      "inputs": {
+        "logos-lidl": "logos-lidl_204",
+        "logos-module": "logos-module_142",
+        "logos-nix": "logos-nix_695",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-protocol"
         ],
@@ -41977,6 +50153,57 @@
         "owner": "logos-co",
         "repo": "logos-plugin-qt",
         "rev": "8af5b188225a22043c4380395d668e133fb1c873",
+<<<<<<< HEAD
+=======
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "type": "github"
+      }
+    },
+    "logos-plugin-qt_9": {
+      "inputs": {
+        "logos-lidl": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-lidl"
+        ],
+        "logos-module": "logos-module_17",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-plugin-qt",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787165449,
+        "narHash": "sha256-X/TaIJA+5o1VLfizu3NLPp/fhisIph8sXG0h0yHDlpo=",
+        "owner": "logos-co",
+        "repo": "logos-plugin-qt",
+        "rev": "9b2c64e5a480245b5333e20183a4a3c572d543cc",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -42024,6 +50251,8 @@
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
+<<<<<<< HEAD
+=======
           "nixpkgs"
         ]
       },
@@ -42043,6 +50272,53 @@
     },
     "logos-protocol_100": {
       "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_100": {
+      "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42466,6 +50742,9 @@
     "logos-protocol_110": {
       "inputs": {
         "logos-nix": "logos-nix_676",
+=======
+        "logos-nix": "logos-nix_645",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42494,7 +50773,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_111": {
+=======
+    "logos-protocol_102": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42531,7 +50814,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_112": {
+=======
+    "logos-protocol_103": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42568,7 +50855,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_113": {
+=======
+    "logos-protocol_104": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42609,7 +50900,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_114": {
+=======
+    "logos-protocol_105": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42646,6 +50941,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_115": {
       "inputs": {
         "logos-nix": [
@@ -42779,6 +51075,11 @@
     "logos-protocol_119": {
       "inputs": {
         "logos-nix": "logos-nix_713",
+=======
+    "logos-protocol_106": {
+      "inputs": {
+        "logos-nix": "logos-nix_678",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -42789,11 +51090,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787771627,
         "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+=======
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -42802,6 +51111,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_12": {
       "inputs": {
         "logos-nix": [
@@ -42836,6 +51146,9 @@
       }
     },
     "logos-protocol_120": {
+=======
+    "logos-protocol_107": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -42864,31 +51177,31 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_121": {
+=======
+    "logos-protocol_108": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-view-module-runtime",
-          "logos-cpp-sdk",
-          "logos-protocol",
-          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786452265,
-        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
         "type": "github"
       },
       "original": {
@@ -42897,38 +51210,13 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_122": {
+=======
+    "logos-protocol_109": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-view-module-runtime",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_123": {
-      "inputs": {
-        "logos-nix": "logos-nix_734",
+        "logos-nix": "logos-nix_696",
         "nixpkgs": [
           "logos-protocol",
           "logos-nix",
@@ -42949,6 +51237,79 @@
         "type": "github"
       }
     },
+    "logos-protocol_11": {
+      "inputs": {
+        "logos-nix": "logos-nix_72",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-protocol_123": {
+      "inputs": {
+        "logos-nix": "logos-nix_734",
+=======
+    "logos-protocol_12": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+<<<<<<< HEAD
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
+=======
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_13": {
       "inputs": {
         "logos-nix": [
@@ -42959,6 +51320,8 @@
           "logos-cpp-sdk",
           "logos-nix"
         ],
+<<<<<<< HEAD
+=======
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -42987,6 +51350,7 @@
     "logos-protocol_14": {
       "inputs": {
         "logos-nix": "logos-nix_89",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-liblogos",
           "logos-modules-state-module",
@@ -42997,6 +51361,49 @@
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_14": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_89",
+=======
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
@@ -43333,11 +51740,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
         "type": "github"
       },
       "original": {
@@ -43757,9 +52164,77 @@
     },
     "logos-protocol_36": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_239",
+=======
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_37": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788377511,
+        "narHash": "sha256-ausAm190Qj1ZtcZcMhxT10h+m/hGgFkHB6FB7SUWDyU=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "677c660692c8f9a9aace8596ee6abbeb86ff2fb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_38": {
+      "inputs": {
+        "logos-nix": "logos-nix_252",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-protocol",
           "logos-nix",
@@ -43780,6 +52255,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_37": {
       "inputs": {
         "logos-nix": [
@@ -43812,19 +52288,28 @@
       }
     },
     "logos-protocol_38": {
+=======
+    "logos-protocol_39": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
-          "logos-cpp-sdk",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -43907,6 +52392,7 @@
     },
     "logos-protocol_40": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_260",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -43975,6 +52461,8 @@
     },
     "logos-protocol_42": {
       "inputs": {
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44010,7 +52498,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_43": {
+=======
+    "logos-protocol_41": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44051,6 +52543,75 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+    "logos-protocol_44": {
+=======
+    "logos-protocol_42": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_43": {
+      "inputs": {
+        "logos-nix": "logos-nix_282",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_44": {
       "inputs": {
         "logos-nix": [
@@ -44058,6 +52619,47 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_45": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+<<<<<<< HEAD
           "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
@@ -44163,6 +52765,8 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
@@ -44197,9 +52801,15 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_48": {
       "inputs": {
         "logos-nix": "logos-nix_308",
+=======
+    "logos-protocol_46": {
+      "inputs": {
+        "logos-nix": "logos-nix_299",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44230,7 +52840,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_49": {
+=======
+    "logos-protocol_47": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44275,6 +52889,103 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "logos-protocol_48": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_49": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-protocol_5": {
       "inputs": {
         "logos-nix": [
@@ -44306,6 +53017,7 @@
     },
     "logos-protocol_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44401,6 +53113,9 @@
     "logos-protocol_52": {
       "inputs": {
         "logos-nix": "logos-nix_338",
+=======
+        "logos-nix": "logos-nix_329",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44429,7 +53144,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_53": {
+=======
+    "logos-protocol_51": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44466,7 +53185,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_54": {
+=======
+    "logos-protocol_52": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44503,7 +53226,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_55": {
+=======
+    "logos-protocol_53": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44544,7 +53271,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_56": {
+=======
+    "logos-protocol_54": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44581,6 +53312,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_57": {
       "inputs": {
         "logos-nix": [
@@ -44740,6 +53472,11 @@
     "logos-protocol_61": {
       "inputs": {
         "logos-nix": "logos-nix_375",
+=======
+    "logos-protocol_55": {
+      "inputs": {
+        "logos-nix": "logos-nix_362",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -44750,11 +53487,19 @@
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787771627,
         "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
         "owner": "logos-co",
         "repo": "logos-protocol",
         "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+=======
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -44763,7 +53508,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_62": {
+=======
+    "logos-protocol_56": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
@@ -44792,17 +53541,310 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_63": {
+=======
+    "logos-protocol_57": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_58": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788870198,
+        "narHash": "sha256-VNpIg41IEeJZQkTHFld83DOViSs33vrfE6a8P79YsKU=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "463863446894764e21dafee34268cbfc1048c64b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_59": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788377511,
+        "narHash": "sha256-ausAm190Qj1ZtcZcMhxT10h+m/hGgFkHB6FB7SUWDyU=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "677c660692c8f9a9aace8596ee6abbeb86ff2fb8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_6": {
+      "inputs": {
+        "logos-nix": "logos-nix_42",
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_60": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_61": {
+      "inputs": {
+        "logos-nix": "logos-nix_401",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_62": {
+      "inputs": {
+        "logos-nix": "logos-nix_412",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_63": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_64": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_65": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-cpp-sdk",
@@ -44825,16 +53867,28 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_64": {
+=======
+    "logos-protocol_66": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "logos-nix"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-view-module-runtime",
           "nixpkgs"
@@ -44854,6 +53908,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_65": {
       "inputs": {
         "logos-nix": "logos-nix_411",
@@ -44880,17 +53935,18 @@
       }
     },
     "logos-protocol_66": {
+=======
+    "logos-protocol_67": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
+        "logos-nix": "logos-nix_443",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
-          "logos-rust-sdk",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44945,13 +54001,27 @@
     },
     "logos-protocol_68": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_421",
+=======
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
           "logos-protocol",
           "logos-nix",
           "nixpkgs"
@@ -44973,9 +54043,94 @@
     },
     "logos-protocol_69": {
       "inputs": {
-        "logos-nix": "logos-nix_432",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_7": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-protocol_69": {
+      "inputs": {
+        "logos-nix": "logos-nix_432",
+=======
+    "logos-protocol_70": {
+      "inputs": {
+        "logos-nix": "logos-nix_460",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -44987,11 +54142,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787771627,
-        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
         "type": "github"
       },
       "original": {
@@ -45040,42 +54195,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-nix"
-        ],
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "logos-rust-sdk",
-          "logos-protocol",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1787580993,
-        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "logos-protocol",
-        "type": "github"
-      }
-    },
-    "logos-protocol_71": {
-      "inputs": {
-        "logos-nix": [
-          "logos-package-manager-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -45086,6 +54206,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -45109,10 +54233,14 @@
         "type": "github"
       }
     },
-    "logos-protocol_72": {
+    "logos-protocol_71": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -45124,6 +54252,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -45150,8 +54282,54 @@
         "type": "github"
       }
     },
+    "logos-protocol_72": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_73": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45502,6 +54680,9 @@
     "logos-protocol_81": {
       "inputs": {
         "logos-nix": "logos-nix_510",
+=======
+        "logos-nix": "logos-nix_490",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -45530,7 +54711,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_82": {
+=======
+    "logos-protocol_75": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45567,7 +54752,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_83": {
+=======
+    "logos-protocol_76": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45604,7 +54793,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_84": {
+=======
+    "logos-protocol_77": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -45645,11 +54838,302 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+    "logos-protocol_85": {
+=======
+    "logos-protocol_78": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787344378,
+        "narHash": "sha256-B+o4VsDlFcFC9izYI9cpQ4e0tPdoePQdCV/kEEMbXJA=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "79894727e59a94d8f63c9e725987be5e3b154f15",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_79": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_8": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_80": {
+      "inputs": {
+        "logos-nix": "logos-nix_520",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_81": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-qt-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_82": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-plugin-qt",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_83": {
+      "inputs": {
+        "logos-nix": "logos-nix_527",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787771627,
+        "narHash": "sha256-2mjoRYIWlV7n0pDnkwFB80zUN1MKYbk1sARbGCUXwNE=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "303ab08d4c7ad583c9a789104501db57c8255399",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_84": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
     "logos-protocol_85": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_86": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
@@ -45940,6 +55424,8 @@
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-view-module-runtime",
           "logos-nix"
         ],
@@ -45964,9 +55450,19 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_94": {
       "inputs": {
         "logos-nix": "logos-nix_578",
+=======
+    "logos-protocol_87": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -45976,11 +55472,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788367777,
-        "narHash": "sha256-80DDvYUPLNSB914movtntx30Dy4lqf54ViSWTH6KhMo=",
+        "lastModified": 1789101259,
+        "narHash": "sha256-OMMzR9jmxMe5AmeH3X3Trwaufw6+dDMJTjrmFxRwpvM=",
         "owner": "logos-co",
         "repo": "logos-protocol",
-        "rev": "3d132f4bc8f1d73078a41682dc68221ff5b516e9",
+        "rev": "fdc09ff585ee3ae46e59b2e9ad45aa03e00d06fd",
         "type": "github"
       },
       "original": {
@@ -45989,7 +55485,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_95": {
+=======
+    "logos-protocol_88": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -46020,6 +55520,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_96": {
       "inputs": {
         "logos-nix": [
@@ -46084,6 +55585,11 @@
     "logos-protocol_98": {
       "inputs": {
         "logos-nix": "logos-nix_598",
+=======
+    "logos-protocol_89": {
+      "inputs": {
+        "logos-nix": "logos-nix_568",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46110,7 +55616,46 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-protocol_99": {
+=======
+    "logos-protocol_9": {
+      "inputs": {
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_90": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-nix": [
           "logos-package-manager-ui",
@@ -46149,6 +55694,360 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
+=======
+    "logos-protocol_91": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_92": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_93": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_94": {
+      "inputs": {
+        "logos-nix": "logos-nix_598",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_95": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-rust-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787580993,
+        "narHash": "sha256-9XA6Dg+xkchtnY/AUcpm4Gb/hZ5d9fRKd6eewWIIh0s=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "42460e5b2a30c0f97ea95c679e5a8e8a08a4af1f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_96": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_97": {
+      "inputs": {
+        "logos-nix": "logos-nix_615",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_98": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787107309,
+        "narHash": "sha256-oNfr0T6OrD1D56rf1brXH+9hJoJvTaPpvUdy/d62SPs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "f4407ff4854bdaf486182547af5b55f4a0f55229",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+    "logos-protocol_99": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-view-module-runtime",
+          "logos-cpp-sdk",
+          "logos-protocol",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786452265,
+        "narHash": "sha256-yEBT+tG6jD26tcVixy3OYGO+gYmcyzrwR5uZVGqVTOs=",
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "rev": "03842db5c1496f5ab29ba35ac0016b6b1f5048ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-protocol",
+        "type": "github"
+      }
+    },
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "logos-qt-mcp": {
       "inputs": {
         "logos-nix": "logos-nix_124",
@@ -46204,7 +56103,11 @@
     },
     "logos-qt-mcp_3": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_343",
+=======
+        "logos-nix": "logos-nix_334",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46234,7 +56137,11 @@
     },
     "logos-qt-mcp_4": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_376",
+=======
+        "logos-nix": "logos-nix_363",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46260,7 +56167,11 @@
     },
     "logos-qt-mcp_5": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_515",
+=======
+        "logos-nix": "logos-nix_495",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46290,7 +56201,11 @@
     },
     "logos-qt-mcp_6": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_548",
+=======
+        "logos-nix": "logos-nix_528",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -46316,7 +56231,11 @@
     },
     "logos-qt-mcp_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_681",
+=======
+        "logos-nix": "logos-nix_650",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46346,7 +56265,11 @@
     },
     "logos-qt-mcp_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_714",
+=======
+        "logos-nix": "logos-nix_679",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -46372,7 +56295,11 @@
     },
     "logos-qt-mcp_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_735",
+=======
+        "logos-nix": "logos-nix_697",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-qt-mcp",
           "logos-nix",
@@ -46455,11 +56382,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
         "type": "github"
       },
       "original": {
@@ -46720,8 +56647,17 @@
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_71",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_240",
         "logos-plugin-qt": "logos-plugin-qt_30",
+=======
+        "logos-nix": "logos-nix_237",
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-plugin-qt"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -46729,6 +56665,55 @@
         ],
         "nixpkgs": [
           "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_17": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_77",
+        "logos-nix": "logos-nix_253",
+        "logos-plugin-qt": "logos-plugin-qt_31",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -46756,18 +56741,46 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_75",
         "logos-nix": "logos-nix_250",
         "logos-plugin-qt": "logos-plugin-qt_31",
+=======
+        "logos-lidl": "logos-lidl_80",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -46775,18 +56788,18 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
-          "logos-qt-sdk",
-          "logos-nix",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -46802,19 +56815,25 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_79",
         "logos-nix": "logos-nix_261",
         "logos-plugin-qt": "logos-plugin-qt_33",
+=======
+        "logos-lidl": "logos-lidl_86",
+        "logos-nix": "logos-nix_283",
+        "logos-plugin-qt": "logos-plugin-qt_35",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-protocol"
         ],
@@ -46823,7 +56842,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
@@ -46831,11 +56850,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -46967,6 +56986,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+<<<<<<< HEAD
           "logos-modules-state-module",
           "logos-module-builder",
           "logos-cpp-sdk"
@@ -47167,12 +57187,167 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_92",
+        "logos-nix": "logos-nix_300",
+        "logos-plugin-qt": "logos-plugin-qt_37",
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_21": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_103",
         "logos-nix": "logos-nix_339",
+=======
+        "logos-lidl": "logos-lidl_95",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_22": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_100",
+        "logos-nix": "logos-nix_330",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47212,7 +57387,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_24": {
+=======
+    "logos-qt-sdk_23": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-downloader-module",
@@ -47224,7 +57403,11 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_106",
+=======
+        "logos-lidl": "logos-lidl_103",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47280,6 +57463,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_25": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_31",
@@ -47287,6 +57471,28 @@
         "logos-nix": "logos-nix_369",
         "logos-plugin-qt": "logos-plugin-qt_47",
         "logos-protocol": "logos-protocol_59",
+        "nixpkgs": [
+          "logos-package-downloader-module",
+=======
+    "logos-qt-sdk_24": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_29",
+        "logos-lidl": "logos-lidl_106",
+        "logos-nix": "logos-nix_357",
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -47298,11 +57504,59 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_25": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_109",
+        "logos-nix": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -47314,11 +57568,56 @@
     "logos-qt-sdk_26": {
       "inputs": {
         "logos-cpp-sdk": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
           "logos-cpp-sdk"
         ],
+        "logos-lidl": "logos-lidl_115",
+        "logos-nix": "logos-nix_393",
+        "logos-plugin-qt": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788893653,
+        "narHash": "sha256-UtvB/BxMGnkS+NBcudbYXZtZX96WuX9ifZxR1lYR084=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "b2ebecc0b7fb6a801dfbde9df60525a0c6dc0a82",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_26": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-cpp-sdk"
+        ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_113",
         "logos-nix": [
           "logos-package-downloader-module",
@@ -47332,25 +57631,36 @@
           "logos-test-framework",
           "logos-plugin-qt"
         ],
+=======
+        "logos-lidl": "logos-lidl_119",
+        "logos-nix": "logos-nix_402",
+        "logos-plugin-qt": "logos-plugin-qt_48",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
           "logos-protocol"
         ],
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "logos-test-framework",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "default-module-loader",
+          "logos-qt-sdk",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787168233,
-        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "lastModified": 1787668712,
+        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
         "type": "github"
       },
       "original": {
@@ -47401,6 +57711,7 @@
         "logos-cpp-sdk": [
           "logos-package-manager-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "default-module-loader",
@@ -47538,12 +57849,69 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+=======
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_123",
+        "logos-nix": "logos-nix_413",
+        "logos-plugin-qt": "logos-plugin-qt_50",
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_29": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_130",
+=======
+        "logos-lidl": "logos-lidl_126",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47599,7 +57967,51 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_31": {
+=======
+    "logos-qt-sdk_3": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_14",
+        "logos-nix": "logos-nix_43",
+        "logos-plugin-qt": "logos-plugin-qt_5",
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_30": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47610,9 +58022,15 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_137",
         "logos-nix": "logos-nix_464",
         "logos-plugin-qt": "logos-plugin-qt_59",
+=======
+        "logos-lidl": "logos-lidl_133",
+        "logos-nix": "logos-nix_444",
+        "logos-plugin-qt": "logos-plugin-qt_54",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47648,7 +58066,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_32": {
+=======
+    "logos-qt-sdk_31": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47663,9 +58085,15 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_143",
         "logos-nix": "logos-nix_481",
         "logos-plugin-qt": "logos-plugin-qt_61",
+=======
+        "logos-lidl": "logos-lidl_139",
+        "logos-nix": "logos-nix_461",
+        "logos-plugin-qt": "logos-plugin-qt_56",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47709,6 +58137,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_33": {
       "inputs": {
         "logos-cpp-sdk": [
@@ -47798,6 +58227,9 @@
       }
     },
     "logos-qt-sdk_34": {
+=======
+    "logos-qt-sdk_32": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47810,8 +58242,98 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_151",
         "logos-nix": "logos-nix_511",
+=======
+        "logos-lidl": "logos-lidl_142",
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_33": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_147",
+        "logos-nix": "logos-nix_491",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47851,7 +58373,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_35": {
+=======
+    "logos-qt-sdk_34": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47863,7 +58389,11 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_154",
+=======
+        "logos-lidl": "logos-lidl_150",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47919,6 +58449,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_36": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_45",
@@ -47926,6 +58457,14 @@
         "logos-nix": "logos-nix_541",
         "logos-plugin-qt": "logos-plugin-qt_69",
         "logos-protocol": "logos-protocol_88",
+=======
+    "logos-qt-sdk_35": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_43",
+        "logos-lidl": "logos-lidl_154",
+        "logos-nix": "logos-nix_521",
+        "logos-plugin-qt": "logos-plugin-qt_64",
+        "logos-protocol": "logos-protocol_81",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47950,7 +58489,7 @@
         "type": "github"
       }
     },
-    "logos-qt-sdk_37": {
+    "logos-qt-sdk_36": {
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-module",
@@ -47958,7 +58497,7 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
-        "logos-lidl": "logos-lidl_161",
+        "logos-lidl": "logos-lidl_157",
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -47998,6 +58537,174 @@
         "type": "github"
       }
     },
+    "logos-qt-sdk_37": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_163",
+        "logos-nix": "logos-nix_553",
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_38": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_169",
+        "logos-nix": "logos-nix_569",
+        "logos-plugin-qt": "logos-plugin-qt_70",
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-qt-sdk",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787775873,
+        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
+    "logos-qt-sdk_37": {
+=======
+    "logos-qt-sdk_39": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_161",
+=======
+        "logos-lidl": "logos-lidl_172",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+<<<<<<< HEAD
     "logos-qt-sdk_38": {
       "inputs": {
         "logos-cpp-sdk": [
@@ -48022,15 +58729,61 @@
           "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
+=======
+    "logos-qt-sdk_4": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_17",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nixpkgs"
         ]
       },
       "locked": {
+<<<<<<< HEAD
         "lastModified": 1787775873,
         "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
         "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+=======
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "type": "github"
       },
       "original": {
@@ -48039,25 +58792,36 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_39": {
+=======
+    "logos-qt-sdk_40": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_171",
         "logos-nix": "logos-nix_588",
+=======
+        "logos-lidl": "logos-lidl_178",
+        "logos-nix": "logos-nix_599",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": "logos-plugin-qt_74",
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-protocol"
         ],
         "nixpkgs": [
@@ -48065,18 +58829,19 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "default-module-loader",
+          "logos-modules-state-module",
+          "logos-module-builder",
           "logos-qt-sdk",
           "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1787668712,
-        "narHash": "sha256-6iaCeHXq8gmjzQXMUWlRfPyt5/5lm3UfXJuwEx4YfRk=",
+        "lastModified": 1787538017,
+        "narHash": "sha256-F8fTy5N0gxvyau5KN5WUGNpXM4N+CHhYxypjyYoGrpo=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "86130d6ac870261f3de4020ec9315e2db8a65970",
+        "rev": "6a570b3057c77b0da882c0cdef72e97e0397675e",
         "type": "github"
       },
       "original": {
@@ -48145,15 +58910,28 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_175",
         "logos-nix": "logos-nix_599",
+=======
+        "logos-lidl": "logos-lidl_184",
+        "logos-nix": "logos-nix_616",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": "logos-plugin-qt_76",
         "logos-protocol": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -48166,6 +58944,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-qt-sdk",
@@ -48174,11 +58956,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
         "type": "github"
       },
       "original": {
@@ -48194,14 +58976,26 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_178",
+=======
+        "logos-lidl": "logos-lidl_187",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -48215,6 +59009,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -48225,6 +59023,10 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
           "logos-test-framework",
@@ -48232,6 +59034,10 @@
         ],
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -48264,6 +59070,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-cpp-sdk"
         ],
         "logos-lidl": "logos-lidl_185",
@@ -48462,12 +59269,19 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "logos-standalone-app",
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_199",
         "logos-nix": "logos-nix_677",
+=======
+        "logos-lidl": "logos-lidl_192",
+        "logos-nix": "logos-nix_646",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-protocol": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48507,7 +59321,11 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_46": {
+=======
+    "logos-qt-sdk_44": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-package-manager-ui",
@@ -48519,7 +59337,11 @@
           "logos-test-framework",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_202",
+=======
+        "logos-lidl": "logos-lidl_195",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48575,6 +59397,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_47": {
       "inputs": {
         "logos-cpp-sdk": "logos-cpp-sdk_59",
@@ -48582,6 +59405,27 @@
         "logos-nix": "logos-nix_707",
         "logos-plugin-qt": "logos-plugin-qt_90",
         "logos-protocol": "logos-protocol_117",
+=======
+    "logos-qt-sdk_45": {
+      "inputs": {
+        "logos-cpp-sdk": "logos-cpp-sdk_55",
+        "logos-lidl": "logos-lidl_198",
+        "logos-nix": "logos-nix_673",
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-protocol"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -48593,11 +59437,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787775873,
-        "narHash": "sha256-pl+L609C+iyrL68a7aBIpjZldayYgs1bJe55CevFaGs=",
+        "lastModified": 1789107476,
+        "narHash": "sha256-x5g0p+K5zbkuM+I2PhZ4hZtPr+uL0hEFlFeiFjPUhlg=",
         "owner": "logos-co",
         "repo": "logos-qt-sdk",
-        "rev": "5c0945430a71137b89c6527b2a49f2f0c4c9af94",
+        "rev": "dffe05e2492c056fabee516f64c027a904dd1ab9",
         "type": "github"
       },
       "original": {
@@ -48606,6 +59450,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "logos-qt-sdk_48": {
       "inputs": {
         "logos-cpp-sdk": [
@@ -48655,12 +59500,65 @@
       }
     },
     "logos-qt-sdk_49": {
+=======
+    "logos-qt-sdk_46": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_213",
         "logos-nix": "logos-nix_736",
+=======
+        "logos-lidl": "logos-lidl_201",
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_47": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-cpp-sdk"
+        ],
+        "logos-lidl": "logos-lidl_205",
+        "logos-nix": "logos-nix_698",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -48780,6 +59678,8 @@
       }
     },
     "logos-qt-sdk_7": {
+<<<<<<< HEAD
+=======
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -48853,6 +59753,7 @@
       }
     },
     "logos-qt-sdk_8": {
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
       "inputs": {
         "logos-cpp-sdk": [
           "logos-liblogos",
@@ -48862,6 +59763,79 @@
           "logos-liblogos",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
+        "logos-lidl": "logos-lidl_32",
+        "logos-nix": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-nix"
+        ],
+        "logos-plugin-qt": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-plugin-qt"
+        ],
+        "logos-protocol": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "logos-protocol"
+        ],
+        "nixpkgs": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-test-framework",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787168233,
+        "narHash": "sha256-Mk8rBoRItqNQP3lN4dFETK+rerVBAYN1oMYQk5zkbfU=",
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "rev": "19c844f28b339695a34236f815de71a9836d3bdd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "logos-qt-sdk",
+        "type": "github"
+      }
+    },
+    "logos-qt-sdk_8": {
+      "inputs": {
+        "logos-cpp-sdk": [
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-cpp-sdk"
+        ],
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-lidl": "logos-lidl_37",
         "logos-nix": "logos-nix_120",
         "logos-protocol": [
@@ -48993,7 +59967,11 @@
     },
     "logos-rust-sdk_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_96",
+=======
+        "logos-lidl": "logos-lidl_93",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -49065,7 +60043,11 @@
     },
     "logos-rust-sdk_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_120",
+=======
+        "logos-lidl": "logos-lidl_116",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49081,7 +60063,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_66",
+=======
+        "logos-protocol": "logos-protocol_59",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49091,11 +60077,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605292,
-        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
+        "lastModified": 1789046709,
+        "narHash": "sha256-oA39e7o4Fe7HfV0SHx4QzBDQy2+1fwSoFSEnHFYGaBE=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
+        "rev": "888302ef0f2664d9b17e31da22bce067e9f96e12",
         "type": "github"
       },
       "original": {
@@ -49106,7 +60092,11 @@
     },
     "logos-rust-sdk_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_128",
+=======
+        "logos-lidl": "logos-lidl_124",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49134,7 +60124,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_70",
+=======
+        "logos-protocol": "logos-protocol_63",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49163,7 +60157,11 @@
     },
     "logos-rust-sdk_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_138",
+=======
+        "logos-lidl": "logos-lidl_134",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49191,7 +60189,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_75",
+=======
+        "logos-protocol": "logos-protocol_68",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49220,7 +60222,11 @@
     },
     "logos-rust-sdk_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_144",
+=======
+        "logos-lidl": "logos-lidl_140",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -49292,7 +60298,11 @@
     },
     "logos-rust-sdk_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_168",
+=======
+        "logos-lidl": "logos-lidl_164",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49308,7 +60318,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_95",
+=======
+        "logos-protocol": "logos-protocol_88",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49318,11 +60332,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1788384510,
-        "narHash": "sha256-3KhQg7gKvuaKXXdnA4yOcXa18fYQNfWT5eW+5KtEFFk=",
+        "lastModified": 1789046709,
+        "narHash": "sha256-oA39e7o4Fe7HfV0SHx4QzBDQy2+1fwSoFSEnHFYGaBE=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "6462fd15254afc694b41e8cddcdf076e3326839c",
+        "rev": "888302ef0f2664d9b17e31da22bce067e9f96e12",
         "type": "github"
       },
       "original": {
@@ -49333,7 +60347,11 @@
     },
     "logos-rust-sdk_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_176",
+=======
+        "logos-lidl": "logos-lidl_170",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49361,7 +60379,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_99",
+=======
+        "logos-protocol": "logos-protocol_90",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49390,7 +60412,11 @@
     },
     "logos-rust-sdk_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_186",
+=======
+        "logos-lidl": "logos-lidl_179",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49418,7 +60444,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_104",
+=======
+        "logos-protocol": "logos-protocol_95",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49447,7 +60477,11 @@
     },
     "logos-rust-sdk_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_192",
+=======
+        "logos-lidl": "logos-lidl_185",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -49792,11 +60826,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787605292,
-        "narHash": "sha256-RZVrBHwWadN6FRS46cm4khfgTHR6zt9V8IBZukJu2ec=",
+        "lastModified": 1789046709,
+        "narHash": "sha256-oA39e7o4Fe7HfV0SHx4QzBDQy2+1fwSoFSEnHFYGaBE=",
         "owner": "logos-co",
         "repo": "logos-rust-sdk",
-        "rev": "7d2192c8881728e8378fee0ef97d64108901858b",
+        "rev": "888302ef0f2664d9b17e31da22bce067e9f96e12",
         "type": "github"
       },
       "original": {
@@ -49807,7 +60841,11 @@
     },
     "logos-rust-sdk_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_80",
+=======
+        "logos-lidl": "logos-lidl_78",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -49835,7 +60873,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_41",
+=======
+        "logos-protocol": "logos-protocol_39",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -49864,7 +60906,11 @@
     },
     "logos-rust-sdk_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-lidl": "logos-lidl_90",
+=======
+        "logos-lidl": "logos-lidl_87",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-logoscore-cli": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -49892,7 +60938,11 @@
           "logos-module-builder",
           "logos-nix"
         ],
+<<<<<<< HEAD
         "logos-protocol": "logos-protocol_46",
+=======
+        "logos-protocol": "logos-protocol_44",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50011,9 +61061,15 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_4",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_372",
         "logos-plugin-qt": "logos-plugin-qt_48",
         "logos-protocol": "logos-protocol_61",
+=======
+        "logos-nix": "logos-nix_359",
+        "logos-plugin-qt": "logos-plugin-qt_44",
+        "logos-protocol": "logos-protocol_55",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_4",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -50029,11 +61085,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787829985,
-        "narHash": "sha256-z5CMTnMiiIBMBVFaW5lWOAST//cW4voc3iv1Y7zKZNU=",
+        "lastModified": 1789124023,
+        "narHash": "sha256-BLudvMV+j152l9yJwR5kl/abLeeXnRnmUl5XZAzFqMQ=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "2e101b05156d5eeda659e1e5566b9bbf93a9fb4b",
+        "rev": "a697b54549b080111c262547f388a6de1b3fd06d",
         "type": "github"
       },
       "original": {
@@ -50044,7 +61100,11 @@
     },
     "logos-standalone-app_4": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_26",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_24",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50055,9 +61115,15 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_5",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_341",
         "logos-plugin-qt": "logos-plugin-qt_43",
         "logos-protocol": "logos-protocol_53",
+=======
+        "logos-nix": "logos-nix_332",
+        "logos-plugin-qt": "logos-plugin-qt_41",
+        "logos-protocol": "logos-protocol_51",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_3",
         "logos-view-module-runtime": [
           "logos-package-downloader-module",
@@ -50096,16 +61162,26 @@
     },
     "logos-standalone-app_5": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_34",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_32",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_6",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_544",
         "logos-plugin-qt": "logos-plugin-qt_70",
         "logos-protocol": "logos-protocol_90",
+=======
+        "logos-nix": "logos-nix_524",
+        "logos-plugin-qt": "logos-plugin-qt_65",
+        "logos-protocol": "logos-protocol_83",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_6",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -50136,7 +61212,11 @@
     },
     "logos-standalone-app_6": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_40",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_38",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50147,9 +61227,15 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_7",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_513",
         "logos-plugin-qt": "logos-plugin-qt_65",
         "logos-protocol": "logos-protocol_82",
+=======
+        "logos-nix": "logos-nix_493",
+        "logos-plugin-qt": "logos-plugin-qt_60",
+        "logos-protocol": "logos-protocol_75",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_5",
         "logos-view-module-runtime": [
           "logos-package-manager-module",
@@ -50188,16 +61274,26 @@
     },
     "logos-standalone-app_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_48",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_46",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_8",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_710",
         "logos-plugin-qt": "logos-plugin-qt_91",
         "logos-protocol": "logos-protocol_119",
+=======
+        "logos-nix": "logos-nix_675",
+        "logos-plugin-qt": "logos-plugin-qt_83",
+        "logos-protocol": "logos-protocol_106",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_8",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -50213,11 +61309,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787829985,
-        "narHash": "sha256-z5CMTnMiiIBMBVFaW5lWOAST//cW4voc3iv1Y7zKZNU=",
+        "lastModified": 1789124023,
+        "narHash": "sha256-BLudvMV+j152l9yJwR5kl/abLeeXnRnmUl5XZAzFqMQ=",
         "owner": "logos-co",
         "repo": "logos-standalone-app",
-        "rev": "2e101b05156d5eeda659e1e5566b9bbf93a9fb4b",
+        "rev": "a697b54549b080111c262547f388a6de1b3fd06d",
         "type": "github"
       },
       "original": {
@@ -50228,7 +61324,11 @@
     },
     "logos-standalone-app_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_54",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_50",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-design-system": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50239,9 +61339,15 @@
           "logos-design-system"
         ],
         "logos-liblogos": "logos-liblogos_9",
+<<<<<<< HEAD
         "logos-nix": "logos-nix_679",
         "logos-plugin-qt": "logos-plugin-qt_86",
         "logos-protocol": "logos-protocol_111",
+=======
+        "logos-nix": "logos-nix_648",
+        "logos-plugin-qt": "logos-plugin-qt_80",
+        "logos-protocol": "logos-protocol_102",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-qt-mcp": "logos-qt-mcp_7",
         "logos-view-module-runtime": [
           "logos-package-manager-ui",
@@ -50318,10 +61424,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_377",
         "logos-plugin-qt": "logos-plugin-qt_49",
         "logos-protocol": "logos-protocol_62",
         "logos-qt-sdk": "logos-qt-sdk_26",
+=======
+        "logos-nix": "logos-nix_364",
+        "logos-plugin-qt": "logos-plugin-qt_45",
+        "logos-protocol": "logos-protocol_56",
+        "logos-qt-sdk": "logos-qt-sdk_25",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50355,10 +61468,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_435",
         "logos-plugin-qt": "logos-plugin-qt_56",
         "logos-protocol": "logos-protocol_71",
         "logos-qt-sdk": "logos-qt-sdk_30",
+=======
+        "logos-nix": "logos-nix_415",
+        "logos-plugin-qt": "logos-plugin-qt_51",
+        "logos-protocol": "logos-protocol_64",
+        "logos-qt-sdk": "logos-qt-sdk_29",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50400,10 +61520,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_483",
         "logos-plugin-qt": "logos-plugin-qt_62",
         "logos-protocol": "logos-protocol_78",
         "logos-qt-sdk": "logos-qt-sdk_33",
+=======
+        "logos-nix": "logos-nix_463",
+        "logos-plugin-qt": "logos-plugin-qt_57",
+        "logos-protocol": "logos-protocol_71",
+        "logos-qt-sdk": "logos-qt-sdk_32",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50445,10 +61572,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_516",
         "logos-plugin-qt": "logos-plugin-qt_66",
         "logos-protocol": "logos-protocol_83",
         "logos-qt-sdk": "logos-qt-sdk_35",
+=======
+        "logos-nix": "logos-nix_496",
+        "logos-plugin-qt": "logos-plugin-qt_61",
+        "logos-protocol": "logos-protocol_76",
+        "logos-qt-sdk": "logos-qt-sdk_34",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50482,10 +61616,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_549",
         "logos-plugin-qt": "logos-plugin-qt_71",
         "logos-protocol": "logos-protocol_91",
         "logos-qt-sdk": "logos-qt-sdk_37",
+=======
+        "logos-nix": "logos-nix_529",
+        "logos-plugin-qt": "logos-plugin-qt_66",
+        "logos-protocol": "logos-protocol_84",
+        "logos-qt-sdk": "logos-qt-sdk_36",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -50519,10 +61660,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_601",
         "logos-plugin-qt": "logos-plugin-qt_77",
         "logos-protocol": "logos-protocol_100",
         "logos-qt-sdk": "logos-qt-sdk_41",
+=======
+        "logos-nix": "logos-nix_571",
+        "logos-plugin-qt": "logos-plugin-qt_71",
+        "logos-protocol": "logos-protocol_91",
+        "logos-qt-sdk": "logos-qt-sdk_39",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50564,10 +61712,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_649",
         "logos-plugin-qt": "logos-plugin-qt_83",
         "logos-protocol": "logos-protocol_107",
         "logos-qt-sdk": "logos-qt-sdk_44",
+=======
+        "logos-nix": "logos-nix_618",
+        "logos-plugin-qt": "logos-plugin-qt_77",
+        "logos-protocol": "logos-protocol_98",
+        "logos-qt-sdk": "logos-qt-sdk_42",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50609,10 +61764,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_682",
         "logos-plugin-qt": "logos-plugin-qt_87",
         "logos-protocol": "logos-protocol_112",
         "logos-qt-sdk": "logos-qt-sdk_46",
+=======
+        "logos-nix": "logos-nix_651",
+        "logos-plugin-qt": "logos-plugin-qt_81",
+        "logos-protocol": "logos-protocol_103",
+        "logos-qt-sdk": "logos-qt-sdk_44",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50646,10 +61808,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_715",
         "logos-plugin-qt": "logos-plugin-qt_92",
         "logos-protocol": "logos-protocol_120",
         "logos-qt-sdk": "logos-qt-sdk_48",
+=======
+        "logos-nix": "logos-nix_680",
+        "logos-plugin-qt": "logos-plugin-qt_84",
+        "logos-protocol": "logos-protocol_107",
+        "logos-qt-sdk": "logos-qt-sdk_46",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -50870,10 +62039,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_263",
         "logos-plugin-qt": "logos-plugin-qt_34",
         "logos-protocol": "logos-protocol_42",
         "logos-qt-sdk": "logos-qt-sdk_19",
+=======
+        "logos-nix": "logos-nix_255",
+        "logos-plugin-qt": "logos-plugin-qt_32",
+        "logos-protocol": "logos-protocol_40",
+        "logos-qt-sdk": "logos-qt-sdk_18",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50915,10 +62091,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_311",
         "logos-plugin-qt": "logos-plugin-qt_40",
         "logos-protocol": "logos-protocol_49",
         "logos-qt-sdk": "logos-qt-sdk_22",
+=======
+        "logos-nix": "logos-nix_302",
+        "logos-plugin-qt": "logos-plugin-qt_38",
+        "logos-protocol": "logos-protocol_47",
+        "logos-qt-sdk": "logos-qt-sdk_21",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -50960,10 +62143,17 @@
           "logos-module-builder",
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_344",
         "logos-plugin-qt": "logos-plugin-qt_44",
         "logos-protocol": "logos-protocol_54",
         "logos-qt-sdk": "logos-qt-sdk_24",
+=======
+        "logos-nix": "logos-nix_335",
+        "logos-plugin-qt": "logos-plugin-qt_42",
+        "logos-protocol": "logos-protocol_52",
+        "logos-qt-sdk": "logos-qt-sdk_23",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51049,10 +62239,17 @@
     },
     "logos-view-module-runtime_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_32",
         "logos-nix": "logos-nix_379",
         "logos-plugin-qt": "logos-plugin-qt_50",
         "logos-protocol": "logos-protocol_64",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_30",
+        "logos-nix": "logos-nix_366",
+        "logos-plugin-qt": "logos-plugin-qt_46",
+        "logos-protocol": "logos-protocol_57",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51062,11 +62259,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787818733,
-        "narHash": "sha256-+cRFdDCpKAARSGIpSP3qZmsu5LWZeK+v6SblJIc3Z0g=",
+        "lastModified": 1789108083,
+        "narHash": "sha256-GojrQymBMY/fy9ib9B7dR/OVfAR5tVLw4j4yuT7Q5yo=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "3ab072eadf516fd2c335305d8f330c7a7621e95d",
+        "rev": "db31d118c0f57876e843cb8d946a5a4d8461f70d",
         "type": "github"
       },
       "original": {
@@ -51077,10 +62274,17 @@
     },
     "logos-view-module-runtime_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_37",
         "logos-nix": "logos-nix_437",
         "logos-plugin-qt": "logos-plugin-qt_57",
         "logos-protocol": "logos-protocol_73",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_35",
+        "logos-nix": "logos-nix_417",
+        "logos-plugin-qt": "logos-plugin-qt_52",
+        "logos-protocol": "logos-protocol_66",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51109,10 +62313,17 @@
     },
     "logos-view-module-runtime_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_42",
         "logos-nix": "logos-nix_485",
         "logos-plugin-qt": "logos-plugin-qt_63",
         "logos-protocol": "logos-protocol_80",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_40",
+        "logos-nix": "logos-nix_465",
+        "logos-plugin-qt": "logos-plugin-qt_58",
+        "logos-protocol": "logos-protocol_73",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51145,10 +62356,17 @@
     },
     "logos-view-module-runtime_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_44",
         "logos-nix": "logos-nix_518",
         "logos-plugin-qt": "logos-plugin-qt_67",
         "logos-protocol": "logos-protocol_85",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_42",
+        "logos-nix": "logos-nix_498",
+        "logos-plugin-qt": "logos-plugin-qt_62",
+        "logos-protocol": "logos-protocol_78",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51177,10 +62395,17 @@
     },
     "logos-view-module-runtime_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_46",
         "logos-nix": "logos-nix_551",
         "logos-plugin-qt": "logos-plugin-qt_72",
         "logos-protocol": "logos-protocol_93",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_44",
+        "logos-nix": "logos-nix_531",
+        "logos-plugin-qt": "logos-plugin-qt_67",
+        "logos-protocol": "logos-protocol_86",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -51205,10 +62430,17 @@
     },
     "logos-view-module-runtime_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_51",
         "logos-nix": "logos-nix_603",
         "logos-plugin-qt": "logos-plugin-qt_78",
         "logos-protocol": "logos-protocol_102",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_48",
+        "logos-nix": "logos-nix_573",
+        "logos-plugin-qt": "logos-plugin-qt_72",
+        "logos-protocol": "logos-protocol_93",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51237,10 +62469,17 @@
     },
     "logos-view-module-runtime_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_56",
         "logos-nix": "logos-nix_651",
         "logos-plugin-qt": "logos-plugin-qt_84",
         "logos-protocol": "logos-protocol_109",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_52",
+        "logos-nix": "logos-nix_620",
+        "logos-plugin-qt": "logos-plugin-qt_78",
+        "logos-protocol": "logos-protocol_100",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51273,10 +62512,17 @@
     },
     "logos-view-module-runtime_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_58",
         "logos-nix": "logos-nix_684",
         "logos-plugin-qt": "logos-plugin-qt_88",
         "logos-protocol": "logos-protocol_114",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_54",
+        "logos-nix": "logos-nix_653",
+        "logos-plugin-qt": "logos-plugin-qt_82",
+        "logos-protocol": "logos-protocol_105",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51305,10 +62551,17 @@
     },
     "logos-view-module-runtime_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_60",
         "logos-nix": "logos-nix_717",
         "logos-plugin-qt": "logos-plugin-qt_93",
         "logos-protocol": "logos-protocol_122",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_56",
+        "logos-nix": "logos-nix_682",
+        "logos-plugin-qt": "logos-plugin-qt_85",
+        "logos-protocol": "logos-protocol_108",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -51318,11 +62571,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787818733,
-        "narHash": "sha256-+cRFdDCpKAARSGIpSP3qZmsu5LWZeK+v6SblJIc3Z0g=",
+        "lastModified": 1789108083,
+        "narHash": "sha256-GojrQymBMY/fy9ib9B7dR/OVfAR5tVLw4j4yuT7Q5yo=",
         "owner": "logos-co",
         "repo": "logos-view-module-runtime",
-        "rev": "3ab072eadf516fd2c335305d8f330c7a7621e95d",
+        "rev": "db31d118c0f57876e843cb8d946a5a4d8461f70d",
         "type": "github"
       },
       "original": {
@@ -51336,7 +62589,11 @@
         "logos-cpp-sdk": [
           "logos-cpp-sdk"
         ],
+<<<<<<< HEAD
         "logos-nix": "logos-nix_737",
+=======
+        "logos-nix": "logos-nix_699",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-plugin-qt": [
           "logos-plugin-qt"
         ],
@@ -51516,10 +62773,17 @@
     },
     "logos-view-module-runtime_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_23",
         "logos-nix": "logos-nix_265",
         "logos-plugin-qt": "logos-plugin-qt_35",
         "logos-protocol": "logos-protocol_44",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_22",
+        "logos-nix": "logos-nix_257",
+        "logos-plugin-qt": "logos-plugin-qt_33",
+        "logos-protocol": "logos-protocol_42",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51548,10 +62812,17 @@
     },
     "logos-view-module-runtime_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_28",
         "logos-nix": "logos-nix_313",
         "logos-plugin-qt": "logos-plugin-qt_41",
         "logos-protocol": "logos-protocol_51",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_26",
+        "logos-nix": "logos-nix_304",
+        "logos-plugin-qt": "logos-plugin-qt_39",
+        "logos-protocol": "logos-protocol_49",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -51584,10 +62855,17 @@
     },
     "logos-view-module-runtime_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-cpp-sdk": "logos-cpp-sdk_30",
         "logos-nix": "logos-nix_346",
         "logos-plugin-qt": "logos-plugin-qt_45",
         "logos-protocol": "logos-protocol_56",
+=======
+        "logos-cpp-sdk": "logos-cpp-sdk_28",
+        "logos-nix": "logos-nix_337",
+        "logos-plugin-qt": "logos-plugin-qt_43",
+        "logos-protocol": "logos-protocol_54",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -52544,7 +63822,11 @@
     },
     "nix-bundle-appimage_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_273",
+=======
+        "logos-nix": "logos-nix_265",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_39",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52710,7 +63992,11 @@
     },
     "nix-bundle-appimage_21": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_321",
+=======
+        "logos-nix": "logos-nix_312",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_45",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52746,7 +64032,11 @@
     },
     "nix-bundle-appimage_22": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_334",
+=======
+        "logos-nix": "logos-nix_325",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_48",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52779,7 +64069,11 @@
     },
     "nix-bundle-appimage_23": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_354",
+=======
+        "logos-nix": "logos-nix_345",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_51",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52811,7 +64105,11 @@
     },
     "nix-bundle-appimage_24": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_363",
+=======
+        "logos-nix": "logos-nix_354",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_54",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52840,7 +64138,11 @@
     },
     "nix-bundle-appimage_25": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_387",
+=======
+        "logos-nix": "logos-nix_374",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_57",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -52868,8 +64170,13 @@
     },
     "nix-bundle-appimage_26": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_395",
         "nix-bundle-dir": "nix-bundle-dir_60",
+=======
+        "logos-nix": "logos-nix_379",
+        "nix-bundle-dir": "nix-bundle-dir_59",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
@@ -52894,8 +64201,13 @@
     },
     "nix-bundle-appimage_27": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_400",
         "nix-bundle-dir": "nix-bundle-dir_62",
+=======
+        "logos-nix": "logos-nix_384",
+        "nix-bundle-dir": "nix-bundle-dir_61",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -53030,8 +64342,13 @@
     },
     "nix-bundle-appimage_30": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_445",
         "nix-bundle-dir": "nix-bundle-dir_67",
+=======
+        "logos-nix": "logos-nix_425",
+        "nix-bundle-dir": "nix-bundle-dir_66",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53168,8 +64485,13 @@
     },
     "nix-bundle-appimage_33": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_493",
         "nix-bundle-dir": "nix-bundle-dir_73",
+=======
+        "logos-nix": "logos-nix_473",
+        "nix-bundle-dir": "nix-bundle-dir_72",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53204,8 +64526,13 @@
     },
     "nix-bundle-appimage_34": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_506",
         "nix-bundle-dir": "nix-bundle-dir_76",
+=======
+        "logos-nix": "logos-nix_486",
+        "nix-bundle-dir": "nix-bundle-dir_75",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53237,8 +64564,13 @@
     },
     "nix-bundle-appimage_35": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_526",
         "nix-bundle-dir": "nix-bundle-dir_79",
+=======
+        "logos-nix": "logos-nix_506",
+        "nix-bundle-dir": "nix-bundle-dir_78",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53269,8 +64601,13 @@
     },
     "nix-bundle-appimage_36": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_535",
         "nix-bundle-dir": "nix-bundle-dir_82",
+=======
+        "logos-nix": "logos-nix_515",
+        "nix-bundle-dir": "nix-bundle-dir_81",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53298,8 +64635,13 @@
     },
     "nix-bundle-appimage_37": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_559",
         "nix-bundle-dir": "nix-bundle-dir_85",
+=======
+        "logos-nix": "logos-nix_539",
+        "nix-bundle-dir": "nix-bundle-dir_84",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -53326,8 +64668,13 @@
     },
     "nix-bundle-appimage_38": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_567",
         "nix-bundle-dir": "nix-bundle-dir_88",
+=======
+        "logos-nix": "logos-nix_544",
+        "nix-bundle-dir": "nix-bundle-dir_86",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-package-manager",
@@ -53472,8 +64819,13 @@
     },
     "nix-bundle-appimage_41": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_611",
         "nix-bundle-dir": "nix-bundle-dir_93",
+=======
+        "logos-nix": "logos-nix_581",
+        "nix-bundle-dir": "nix-bundle-dir_91",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53610,8 +64962,13 @@
     },
     "nix-bundle-appimage_44": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_659",
         "nix-bundle-dir": "nix-bundle-dir_99",
+=======
+        "logos-nix": "logos-nix_628",
+        "nix-bundle-dir": "nix-bundle-dir_97",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53646,8 +65003,13 @@
     },
     "nix-bundle-appimage_45": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_672",
         "nix-bundle-dir": "nix-bundle-dir_102",
+=======
+        "logos-nix": "logos-nix_641",
+        "nix-bundle-dir": "nix-bundle-dir_100",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53679,8 +65041,13 @@
     },
     "nix-bundle-appimage_46": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_692",
         "nix-bundle-dir": "nix-bundle-dir_105",
+=======
+        "logos-nix": "logos-nix_661",
+        "nix-bundle-dir": "nix-bundle-dir_103",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53711,8 +65078,13 @@
     },
     "nix-bundle-appimage_47": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_701",
         "nix-bundle-dir": "nix-bundle-dir_108",
+=======
+        "logos-nix": "logos-nix_670",
+        "nix-bundle-dir": "nix-bundle-dir_106",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53740,8 +65112,13 @@
     },
     "nix-bundle-appimage_48": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_725",
         "nix-bundle-dir": "nix-bundle-dir_111",
+=======
+        "logos-nix": "logos-nix_690",
+        "nix-bundle-dir": "nix-bundle-dir_109",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -53768,8 +65145,13 @@
     },
     "nix-bundle-appimage_49": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_738",
         "nix-bundle-dir": "nix-bundle-dir_114",
+=======
+        "logos-nix": "logos-nix_700",
+        "nix-bundle-dir": "nix-bundle-dir_111",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-appimage",
           "logos-nix",
@@ -53821,8 +65203,13 @@
     },
     "nix-bundle-appimage_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_744",
         "nix-bundle-dir": "nix-bundle-dir_116",
+=======
+        "logos-nix": "logos-nix_706",
+        "nix-bundle-dir": "nix-bundle-dir_113",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-package-manager",
@@ -54055,7 +65442,11 @@
     },
     "nix-bundle-dir_100": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_661",
+=======
+        "logos-nix": "logos-nix_642",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54065,21 +65456,17 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
         "type": "github"
       },
       "original": {
@@ -54090,7 +65477,11 @@
     },
     "nix-bundle-dir_101": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_664",
+=======
+        "logos-nix": "logos-nix_643",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54100,10 +65491,7 @@
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -54125,7 +65513,11 @@
     },
     "nix-bundle-dir_102": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_673",
+=======
+        "logos-nix": "logos-nix_657",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54133,6 +65525,7 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+<<<<<<< HEAD
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
@@ -54167,6 +65560,9 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-package-manager",
+=======
+          "nix-bundle-lgx",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -54186,9 +65582,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_104": {
+    "nix-bundle-dir_103": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_688",
+=======
+        "logos-nix": "logos-nix_662",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54196,7 +65596,38 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "nix-bundle-lgx",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1773961179,
+        "narHash": "sha256-bpaTvz//R8WFP5xnnDLv3a9l7unDmBwJjCewx3wCjzM=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_104": {
+      "inputs": {
+        "logos-nix": "logos-nix_663",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
           "nixpkgs"
@@ -54218,6 +65649,7 @@
     },
     "nix-bundle-dir_105": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_693",
         "nixpkgs": [
           "logos-package-manager-ui",
@@ -54280,6 +65712,9 @@
     "nix-bundle-dir_107": {
       "inputs": {
         "logos-nix": "logos-nix_697",
+=======
+        "logos-nix": "logos-nix_666",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54308,9 +65743,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_108": {
+    "nix-bundle-dir_106": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_702",
+=======
+        "logos-nix": "logos-nix_671",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54335,9 +65774,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_109": {
+    "nix-bundle-dir_107": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_703",
+=======
+        "logos-nix": "logos-nix_672",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54355,6 +65798,58 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_108": {
+      "inputs": {
+        "logos-nix": "logos-nix_686",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_109": {
+      "inputs": {
+        "logos-nix": "logos-nix_691",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
         "type": "github"
       },
       "original": {
@@ -54393,59 +65888,11 @@
     },
     "nix-bundle-dir_110": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_721",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_111": {
-      "inputs": {
-        "logos-nix": "logos-nix_726",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-appimage",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_112": {
-      "inputs": {
-        "logos-nix": "logos-nix_727",
+=======
+        "logos-nix": "logos-nix_692",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -54470,36 +65917,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_113": {
+    "nix-bundle-dir_111": {
       "inputs": {
-        "logos-nix": "logos-nix_730",
-        "nixpkgs": [
-          "logos-package-manager-ui",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_114": {
-      "inputs": {
-        "logos-nix": "logos-nix_739",
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_726",
+=======
+        "logos-nix": "logos-nix_701",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-appimage",
           "nixpkgs"
@@ -54519,8 +65943,93 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_112": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_727",
+=======
+        "logos-nix": "logos-nix_702",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_113": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_730",
+=======
+        "logos-nix": "logos-nix_707",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_114": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_739",
+=======
+        "logos-nix": "logos-nix_708",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_115": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_740",
         "nixpkgs": [
           "nix-bundle-dir",
@@ -54594,6 +66103,9 @@
     "nix-bundle-dir_118": {
       "inputs": {
         "logos-nix": "logos-nix_749",
+=======
+        "logos-nix": "logos-nix_711",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -55448,7 +66960,11 @@
     },
     "nix-bundle-dir_38": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_269",
+=======
+        "logos-nix": "logos-nix_261",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55478,7 +66994,11 @@
     },
     "nix-bundle-dir_39": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_274",
+=======
+        "logos-nix": "logos-nix_266",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55535,7 +67055,11 @@
     },
     "nix-bundle-dir_40": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_275",
+=======
+        "logos-nix": "logos-nix_267",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55566,7 +67090,11 @@
     },
     "nix-bundle-dir_41": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_278",
+=======
+        "logos-nix": "logos-nix_270",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55679,7 +67207,11 @@
     },
     "nix-bundle-dir_44": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_317",
+=======
+        "logos-nix": "logos-nix_308",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55713,7 +67245,11 @@
     },
     "nix-bundle-dir_45": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_322",
+=======
+        "logos-nix": "logos-nix_313",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55747,7 +67283,11 @@
     },
     "nix-bundle-dir_46": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_323",
+=======
+        "logos-nix": "logos-nix_314",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55782,7 +67322,11 @@
     },
     "nix-bundle-dir_47": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_326",
+=======
+        "logos-nix": "logos-nix_317",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55817,7 +67361,11 @@
     },
     "nix-bundle-dir_48": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_335",
+=======
+        "logos-nix": "logos-nix_326",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55848,7 +67396,11 @@
     },
     "nix-bundle-dir_49": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_336",
+=======
+        "logos-nix": "logos-nix_327",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55907,7 +67459,11 @@
     },
     "nix-bundle-dir_50": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_350",
+=======
+        "logos-nix": "logos-nix_341",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55937,7 +67493,11 @@
     },
     "nix-bundle-dir_51": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_355",
+=======
+        "logos-nix": "logos-nix_346",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55967,7 +67527,11 @@
     },
     "nix-bundle-dir_52": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_356",
+=======
+        "logos-nix": "logos-nix_347",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -55998,7 +67562,11 @@
     },
     "nix-bundle-dir_53": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_359",
+=======
+        "logos-nix": "logos-nix_350",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56029,7 +67597,11 @@
     },
     "nix-bundle-dir_54": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_364",
+=======
+        "logos-nix": "logos-nix_355",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56056,7 +67628,11 @@
     },
     "nix-bundle-dir_55": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_365",
+=======
+        "logos-nix": "logos-nix_356",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56084,7 +67660,11 @@
     },
     "nix-bundle-dir_56": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_383",
+=======
+        "logos-nix": "logos-nix_370",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56110,7 +67690,11 @@
     },
     "nix-bundle-dir_57": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_388",
+=======
+        "logos-nix": "logos-nix_375",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56136,7 +67720,11 @@
     },
     "nix-bundle-dir_58": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_389",
+=======
+        "logos-nix": "logos-nix_376",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -56163,23 +67751,24 @@
     },
     "nix-bundle-dir_59": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_392",
+=======
+        "logos-nix": "logos-nix_380",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-package-downloader",
+          "nix-bundle-appimage",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
         "type": "github"
       },
       "original": {
@@ -56215,20 +67804,25 @@
     },
     "nix-bundle-dir_60": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_396",
+=======
+        "logos-nix": "logos-nix_381",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-package-downloader",
-          "nix-bundle-appimage",
+          "nix-bundle-dir",
+          "logos-nix",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1785790585,
-        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
         "type": "github"
       },
       "original": {
@@ -56239,6 +67833,7 @@
     },
     "nix-bundle-dir_61": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_397",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -56265,6 +67860,9 @@
     "nix-bundle-dir_62": {
       "inputs": {
         "logos-nix": "logos-nix_401",
+=======
+        "logos-nix": "logos-nix_385",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-appimage",
@@ -56285,9 +67883,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_63": {
+    "nix-bundle-dir_62": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_402",
+=======
+        "logos-nix": "logos-nix_386",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager",
           "nix-bundle-dir",
@@ -56309,7 +67911,7 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_64": {
+    "nix-bundle-dir_63": {
       "inputs": {
         "logos-nix": [
           "logos-package-manager-module",
@@ -56338,8 +67940,46 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_64": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_65": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56378,6 +68018,9 @@
     "nix-bundle-dir_66": {
       "inputs": {
         "logos-nix": "logos-nix_441",
+=======
+        "logos-nix": "logos-nix_421",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56405,9 +68048,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_67": {
+    "nix-bundle-dir_66": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_446",
+=======
+        "logos-nix": "logos-nix_426",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56435,9 +68082,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_68": {
+    "nix-bundle-dir_67": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_447",
+=======
+        "logos-nix": "logos-nix_427",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56466,9 +68117,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_69": {
+    "nix-bundle-dir_68": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_450",
+=======
+        "logos-nix": "logos-nix_430",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56480,6 +68135,43 @@
           "nix-bundle-lgx",
           "nix-bundle-dir",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_69": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -56537,6 +68229,10 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "logos-design-system",
           "logos-nix"
         ],
@@ -56546,6 +68242,10 @@
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
           "logos-module-builder",
           "logos-design-system",
           "nixpkgs"
@@ -56567,6 +68267,7 @@
     },
     "nix-bundle-dir_71": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56613,6 +68314,9 @@
     "nix-bundle-dir_72": {
       "inputs": {
         "logos-nix": "logos-nix_489",
+=======
+        "logos-nix": "logos-nix_469",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56644,9 +68348,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_73": {
+    "nix-bundle-dir_72": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_494",
+=======
+        "logos-nix": "logos-nix_474",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56678,9 +68386,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_74": {
+    "nix-bundle-dir_73": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_495",
+=======
+        "logos-nix": "logos-nix_475",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56713,8 +68425,44 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_74": {
+      "inputs": {
+        "logos-nix": "logos-nix_478",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_75": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_498",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -56751,6 +68499,9 @@
     "nix-bundle-dir_76": {
       "inputs": {
         "logos-nix": "logos-nix_507",
+=======
+        "logos-nix": "logos-nix_487",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56779,9 +68530,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_77": {
+    "nix-bundle-dir_76": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_508",
+=======
+        "logos-nix": "logos-nix_488",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56811,8 +68566,39 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_77": {
+      "inputs": {
+        "logos-nix": "logos-nix_502",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_78": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_522",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -56844,6 +68630,9 @@
     "nix-bundle-dir_79": {
       "inputs": {
         "logos-nix": "logos-nix_527",
+=======
+        "logos-nix": "logos-nix_507",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56863,6 +68652,37 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_79": {
+      "inputs": {
+        "logos-nix": "logos-nix_508",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -56900,38 +68720,11 @@
     },
     "nix-bundle-dir_80": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_528",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786415152,
-        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-dir",
-        "type": "github"
-      }
-    },
-    "nix-bundle-dir_81": {
-      "inputs": {
-        "logos-nix": "logos-nix_531",
+=======
+        "logos-nix": "logos-nix_511",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56960,9 +68753,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_82": {
+    "nix-bundle-dir_81": {
       "inputs": {
-        "logos-nix": "logos-nix_536",
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_531",
+=======
+        "logos-nix": "logos-nix_516",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -56987,9 +68784,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_83": {
+    "nix-bundle-dir_82": {
       "inputs": {
-        "logos-nix": "logos-nix_537",
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_536",
+=======
+        "logos-nix": "logos-nix_517",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57015,9 +68816,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_84": {
+    "nix-bundle-dir_83": {
       "inputs": {
-        "logos-nix": "logos-nix_555",
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_537",
+=======
+        "logos-nix": "logos-nix_535",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57041,8 +68846,39 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_84": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_555",
+=======
+        "logos-nix": "logos-nix_540",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_85": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_560",
         "nixpkgs": [
           "logos-package-manager-module",
@@ -57070,6 +68906,9 @@
     "nix-bundle-dir_86": {
       "inputs": {
         "logos-nix": "logos-nix_561",
+=======
+        "logos-nix": "logos-nix_541",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57094,16 +68933,71 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_87": {
+    "nix-bundle-dir_86": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_564",
+=======
+        "logos-nix": "logos-nix_545",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
-          "nix-bundle-lgx",
+          "logos-package-manager",
+          "nix-bundle-appimage",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1785790585,
+        "narHash": "sha256-Twwl3any+BHvTlEuKXcbr2eGny+BLO4oj8AxfKH40Xo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "cb9afc8c8c8a0037cf27f7467132f9e01e476588",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_87": {
+      "inputs": {
+        "logos-nix": "logos-nix_546",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-package-manager",
           "nix-bundle-dir",
           "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786576773,
+        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_88": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
@@ -57121,6 +69015,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nix-bundle-dir_88": {
       "inputs": {
         "logos-nix": "logos-nix_568",
@@ -57148,20 +69043,37 @@
     "nix-bundle-dir_89": {
       "inputs": {
         "logos-nix": "logos-nix_569",
+=======
+    "nix-bundle-dir_89": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-package-manager",
-          "nix-bundle-dir",
-          "logos-nix",
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1786576773,
-        "narHash": "sha256-iduzqfzw+KWeyt87Cnqmv07hFN7gZEL0gMM3pUNQHpA=",
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
-        "rev": "ffc410b7f2bab32b1c2ceb347c56902e7321049c",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -57199,6 +69111,7 @@
     },
     "nix-bundle-dir_90": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57266,6 +69179,9 @@
     "nix-bundle-dir_92": {
       "inputs": {
         "logos-nix": "logos-nix_607",
+=======
+        "logos-nix": "logos-nix_577",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57293,9 +69209,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_93": {
+    "nix-bundle-dir_91": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_612",
+=======
+        "logos-nix": "logos-nix_582",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57323,9 +69243,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_94": {
+    "nix-bundle-dir_92": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_613",
+=======
+        "logos-nix": "logos-nix_583",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57354,9 +69278,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_95": {
+    "nix-bundle-dir_93": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_616",
+=======
+        "logos-nix": "logos-nix_586",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57385,8 +69313,91 @@
         "type": "github"
       }
     },
+    "nix-bundle-dir_94": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_95": {
+      "inputs": {
+        "logos-nix": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "logos-nix"
+        ],
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "logos-design-system",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
     "nix-bundle-dir_96": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57470,6 +69481,9 @@
     "nix-bundle-dir_98": {
       "inputs": {
         "logos-nix": "logos-nix_655",
+=======
+        "logos-nix": "logos-nix_624",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57501,9 +69515,13 @@
         "type": "github"
       }
     },
-    "nix-bundle-dir_99": {
+    "nix-bundle-dir_97": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_660",
+=======
+        "logos-nix": "logos-nix_629",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -57527,6 +69545,76 @@
         "owner": "logos-co",
         "repo": "nix-bundle-dir",
         "rev": "cd214dbf15487d80967389847ae2210468be6ebf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_98": {
+      "inputs": {
+        "logos-nix": "logos-nix_630",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "logos-package-manager",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "type": "github"
+      }
+    },
+    "nix-bundle-dir_99": {
+      "inputs": {
+        "logos-nix": "logos-nix_633",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "nix-bundle-dir",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786415152,
+        "narHash": "sha256-0JUD+57+VTO25IfJjy92av5T88pmMSod8wMygW9OK3s=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-dir",
+        "rev": "f843b8ec76974881ccf8619157ae63bfa2017a5e",
         "type": "github"
       },
       "original": {
@@ -57651,7 +69739,11 @@
     },
     "nix-bundle-lgx_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_267",
+=======
+        "logos-nix": "logos-nix_259",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_24",
         "nix-bundle-dir": "nix-bundle-dir_38",
         "nixpkgs": [
@@ -57682,7 +69774,11 @@
     },
     "nix-bundle-lgx_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_276",
+=======
+        "logos-nix": "logos-nix_268",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_26",
         "nix-bundle-dir": "nix-bundle-dir_41",
         "nixpkgs": [
@@ -57714,8 +69810,13 @@
     },
     "nix-bundle-lgx_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_315",
         "logos-package": "logos-package_27",
+=======
+        "logos-nix": "logos-nix_306",
+        "logos-package": "logos-package_28",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_44",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -57749,8 +69850,13 @@
     },
     "nix-bundle-lgx_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_324",
         "logos-package": "logos-package_29",
+=======
+        "logos-nix": "logos-nix_315",
+        "logos-package": "logos-package_30",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_47",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -57785,8 +69891,13 @@
     },
     "nix-bundle-lgx_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_348",
         "logos-package": "logos-package_31",
+=======
+        "logos-nix": "logos-nix_339",
+        "logos-package": "logos-package_32",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_50",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -57816,8 +69927,13 @@
     },
     "nix-bundle-lgx_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_357",
         "logos-package": "logos-package_33",
+=======
+        "logos-nix": "logos-nix_348",
+        "logos-package": "logos-package_34",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_53",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -57848,8 +69964,13 @@
     },
     "nix-bundle-lgx_19": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_381",
         "logos-package": "logos-package_35",
+=======
+        "logos-nix": "logos-nix_368",
+        "logos-package": "logos-package_36",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": "nix-bundle-dir_56",
         "nixpkgs": [
           "logos-package-downloader-module",
@@ -57860,11 +69981,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
+        "lastModified": 1788801608,
+        "narHash": "sha256-jOJRUcZOvKoOe04t2h1uJATdmFEOYyzxjZVIGlq2KJo=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
+        "rev": "d0828e0bf28f9714d066f260bad281681293686d",
         "type": "github"
       },
       "original": {
@@ -57903,13 +70024,22 @@
     },
     "nix-bundle-lgx_20": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_390",
         "logos-package": "logos-package_37",
         "nix-bundle-dir": "nix-bundle-dir_59",
+=======
+        "logos-nix": "logos-nix_419",
+        "logos-package": "logos-package_40",
+        "nix-bundle-dir": "nix-bundle-dir_65",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
-          "logos-package-downloader-module",
+          "logos-package-manager-module",
           "logos-module-builder",
-          "nix-bundle-logos-module-install",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
@@ -57931,6 +70061,7 @@
     },
     "nix-bundle-lgx_21": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_439",
         "logos-package": "logos-package_40",
         "nix-bundle-dir": "nix-bundle-dir_66",
@@ -57963,8 +70094,11 @@
     "nix-bundle-lgx_22": {
       "inputs": {
         "logos-nix": "logos-nix_448",
+=======
+        "logos-nix": "logos-nix_428",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_42",
-        "nix-bundle-dir": "nix-bundle-dir_69",
+        "nix-bundle-dir": "nix-bundle-dir_68",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -57992,11 +70126,15 @@
         "type": "github"
       }
     },
-    "nix-bundle-lgx_23": {
+    "nix-bundle-lgx_22": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_487",
+=======
+        "logos-nix": "logos-nix_467",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package": "logos-package_43",
-        "nix-bundle-dir": "nix-bundle-dir_72",
+        "nix-bundle-dir": "nix-bundle-dir_71",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58008,6 +70146,42 @@
           "logos-liblogos",
           "logos-capability-module",
           "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_23": {
+      "inputs": {
+        "logos-nix": "logos-nix_476",
+        "logos-package": "logos-package_45",
+        "nix-bundle-dir": "nix-bundle-dir_74",
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
@@ -58029,9 +70203,15 @@
     },
     "nix-bundle-lgx_24": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_496",
         "logos-package": "logos-package_45",
         "nix-bundle-dir": "nix-bundle-dir_75",
+=======
+        "logos-nix": "logos-nix_500",
+        "logos-package": "logos-package_47",
+        "nix-bundle-dir": "nix-bundle-dir_77",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58039,11 +70219,6 @@
           "logos-liblogos",
           "logos-modules-state-module",
           "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
-          "logos-module-builder",
-          "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
           "logos-nix",
           "nixpkgs"
@@ -58065,40 +70240,15 @@
     },
     "nix-bundle-lgx_25": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_520",
         "logos-package": "logos-package_47",
         "nix-bundle-dir": "nix-bundle-dir_78",
-        "nixpkgs": [
-          "logos-package-manager-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
-          "logos-module-builder",
-          "nix-bundle-lgx",
-          "logos-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
-        "type": "github"
-      },
-      "original": {
-        "owner": "logos-co",
-        "repo": "nix-bundle-lgx",
-        "type": "github"
-      }
-    },
-    "nix-bundle-lgx_26": {
-      "inputs": {
-        "logos-nix": "logos-nix_529",
+=======
+        "logos-nix": "logos-nix_509",
         "logos-package": "logos-package_49",
-        "nix-bundle-dir": "nix-bundle-dir_81",
+        "nix-bundle-dir": "nix-bundle-dir_80",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58126,8 +70276,42 @@
         "type": "github"
       }
     },
+    "nix-bundle-lgx_26": {
+      "inputs": {
+<<<<<<< HEAD
+        "logos-nix": "logos-nix_529",
+        "logos-package": "logos-package_49",
+        "nix-bundle-dir": "nix-bundle-dir_81",
+=======
+        "logos-nix": "logos-nix_533",
+        "logos-package": "logos-package_51",
+        "nix-bundle-dir": "nix-bundle-dir_83",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
+        "nixpkgs": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1788801608,
+        "narHash": "sha256-jOJRUcZOvKoOe04t2h1uJATdmFEOYyzxjZVIGlq2KJo=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "d0828e0bf28f9714d066f260bad281681293686d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
     "nix-bundle-lgx_27": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_553",
         "logos-package": "logos-package_51",
         "nix-bundle-dir": "nix-bundle-dir_84",
@@ -58186,6 +70370,11 @@
         "logos-nix": "logos-nix_605",
         "logos-package": "logos-package_55",
         "nix-bundle-dir": "nix-bundle-dir_92",
+=======
+        "logos-nix": "logos-nix_575",
+        "logos-package": "logos-package_54",
+        "nix-bundle-dir": "nix-bundle-dir_90",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58204,6 +70393,73 @@
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
         "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_28": {
+      "inputs": {
+        "logos-nix": "logos-nix_584",
+        "logos-package": "logos-package_56",
+        "nix-bundle-dir": "nix-bundle-dir_93",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-logos-module-install",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1787819509,
+        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "type": "github"
+      }
+    },
+    "nix-bundle-lgx_29": {
+      "inputs": {
+        "logos-nix": "logos-nix_622",
+        "logos-package": "logos-package_58",
+        "nix-bundle-dir": "nix-bundle-dir_96",
+        "nixpkgs": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-capability-module",
+          "logos-module-builder",
+          "nix-bundle-lgx",
+          "logos-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "owner": "logos-co",
+        "repo": "nix-bundle-lgx",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
         "type": "github"
       },
       "original": {
@@ -58242,11 +70498,21 @@
     },
     "nix-bundle-lgx_30": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_614",
         "logos-package": "logos-package_57",
         "nix-bundle-dir": "nix-bundle-dir_95",
+=======
+        "logos-nix": "logos-nix_631",
+        "logos-package": "logos-package_60",
+        "nix-bundle-dir": "nix-bundle-dir_99",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
+          "logos-module-builder",
+          "logos-standalone-app",
+          "logos-liblogos",
+          "logos-modules-state-module",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
@@ -58259,11 +70525,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
+        "lastModified": 1786468088,
+        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
+        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
         "type": "github"
       },
       "original": {
@@ -58274,19 +70540,21 @@
     },
     "nix-bundle-lgx_31": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_653",
         "logos-package": "logos-package_58",
         "nix-bundle-dir": "nix-bundle-dir_98",
+=======
+        "logos-nix": "logos-nix_655",
+        "logos-package": "logos-package_62",
+        "nix-bundle-dir": "nix-bundle-dir_102",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -58309,19 +70577,21 @@
     },
     "nix-bundle-lgx_32": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_662",
         "logos-package": "logos-package_60",
         "nix-bundle-dir": "nix-bundle-dir_101",
+=======
+        "logos-nix": "logos-nix_664",
+        "logos-package": "logos-package_64",
+        "nix-bundle-dir": "nix-bundle-dir_105",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
           "logos-standalone-app",
           "logos-liblogos",
           "logos-modules-state-module",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-capability-module",
           "logos-module-builder",
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -58345,15 +70615,17 @@
     },
     "nix-bundle-lgx_33": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_686",
         "logos-package": "logos-package_62",
         "nix-bundle-dir": "nix-bundle-dir_104",
+=======
+        "logos-nix": "logos-nix_684",
+        "logos-package": "logos-package_66",
+        "nix-bundle-dir": "nix-bundle-dir_108",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
-          "logos-module-builder",
-          "logos-standalone-app",
-          "logos-liblogos",
-          "logos-modules-state-module",
           "logos-module-builder",
           "nix-bundle-lgx",
           "logos-nix",
@@ -58361,11 +70633,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1786468088,
-        "narHash": "sha256-WzEQtWbusgoDFuGGHz2L3/ZlXfcUnUxwT+p1/4ilJzc=",
+        "lastModified": 1788801608,
+        "narHash": "sha256-jOJRUcZOvKoOe04t2h1uJATdmFEOYyzxjZVIGlq2KJo=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "62277ea64abed4165f3cf6028f3fc3e95a919384",
+        "rev": "d0828e0bf28f9714d066f260bad281681293686d",
         "type": "github"
       },
       "original": {
@@ -58376,6 +70648,7 @@
     },
     "nix-bundle-lgx_34": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_695",
         "logos-package": "logos-package_64",
         "nix-bundle-dir": "nix-bundle-dir_107",
@@ -58466,6 +70739,11 @@
         "logos-nix": "logos-nix_747",
         "logos-package": "logos-package_71",
         "nix-bundle-dir": "nix-bundle-dir_118",
+=======
+        "logos-nix": "logos-nix_709",
+        "logos-package": "logos-package_70",
+        "nix-bundle-dir": "nix-bundle-dir_115",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "nix-bundle-lgx",
@@ -58474,11 +70752,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787819509,
-        "narHash": "sha256-/PSHTTtlg3t3dqK7d6hHhpKLA8wStfTwdEu+s4qcVgk=",
+        "lastModified": 1788801608,
+        "narHash": "sha256-jOJRUcZOvKoOe04t2h1uJATdmFEOYyzxjZVIGlq2KJo=",
         "owner": "logos-co",
         "repo": "nix-bundle-lgx",
-        "rev": "5fc265b8639e87f3cb78930c9760f7d8719f26cb",
+        "rev": "d0828e0bf28f9714d066f260bad281681293686d",
         "type": "github"
       },
       "original": {
@@ -58698,9 +70976,17 @@
     },
     "nix-bundle-logos-module-install_10": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_384",
+=======
+        "logos-nix": "logos-nix_371",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_14",
-        "nix-bundle-lgx": "nix-bundle-lgx_20",
+        "nix-bundle-lgx": [
+          "logos-package-downloader-module",
+          "logos-module-builder",
+          "nix-bundle-lgx"
+        ],
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -58710,11 +70996,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787820205,
-        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
+        "lastModified": 1789064587,
+        "narHash": "sha256-KnNh8XNeTRc+Z/XGPcmKlsvGNTrVaQFA04bUCjivozg=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "63815316970587b730f626f3541045bf09c08cfa",
+        "rev": "2c626edeb4489b9a5264d39cd385f383bbe3e29b",
         "type": "github"
       },
       "original": {
@@ -58725,9 +71011,13 @@
     },
     "nix-bundle-logos-module-install_11": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_442",
+=======
+        "logos-nix": "logos-nix_422",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_16",
-        "nix-bundle-lgx": "nix-bundle-lgx_22",
+        "nix-bundle-lgx": "nix-bundle-lgx_21",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58756,9 +71046,13 @@
     },
     "nix-bundle-logos-module-install_12": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_490",
+=======
+        "logos-nix": "logos-nix_470",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_17",
-        "nix-bundle-lgx": "nix-bundle-lgx_24",
+        "nix-bundle-lgx": "nix-bundle-lgx_23",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58791,9 +71085,13 @@
     },
     "nix-bundle-logos-module-install_13": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_523",
+=======
+        "logos-nix": "logos-nix_503",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_19",
-        "nix-bundle-lgx": "nix-bundle-lgx_26",
+        "nix-bundle-lgx": "nix-bundle-lgx_25",
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58822,9 +71120,17 @@
     },
     "nix-bundle-logos-module-install_14": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_556",
+=======
+        "logos-nix": "logos-nix_536",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_21",
-        "nix-bundle-lgx": "nix-bundle-lgx_28",
+        "nix-bundle-lgx": [
+          "logos-package-manager-module",
+          "logos-module-builder",
+          "nix-bundle-lgx"
+        ],
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -58834,11 +71140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787820205,
-        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
+        "lastModified": 1789064587,
+        "narHash": "sha256-KnNh8XNeTRc+Z/XGPcmKlsvGNTrVaQFA04bUCjivozg=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "63815316970587b730f626f3541045bf09c08cfa",
+        "rev": "2c626edeb4489b9a5264d39cd385f383bbe3e29b",
         "type": "github"
       },
       "original": {
@@ -58849,9 +71155,13 @@
     },
     "nix-bundle-logos-module-install_15": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_608",
+=======
+        "logos-nix": "logos-nix_578",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_23",
-        "nix-bundle-lgx": "nix-bundle-lgx_30",
+        "nix-bundle-lgx": "nix-bundle-lgx_28",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58880,9 +71190,13 @@
     },
     "nix-bundle-logos-module-install_16": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_656",
+=======
+        "logos-nix": "logos-nix_625",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_24",
-        "nix-bundle-lgx": "nix-bundle-lgx_32",
+        "nix-bundle-lgx": "nix-bundle-lgx_30",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58915,9 +71229,13 @@
     },
     "nix-bundle-logos-module-install_17": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_689",
+=======
+        "logos-nix": "logos-nix_658",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_26",
-        "nix-bundle-lgx": "nix-bundle-lgx_34",
+        "nix-bundle-lgx": "nix-bundle-lgx_32",
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58946,9 +71264,17 @@
     },
     "nix-bundle-logos-module-install_18": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_722",
+=======
+        "logos-nix": "logos-nix_687",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_28",
-        "nix-bundle-lgx": "nix-bundle-lgx_36",
+        "nix-bundle-lgx": [
+          "logos-package-manager-ui",
+          "logos-module-builder",
+          "nix-bundle-lgx"
+        ],
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -58958,11 +71284,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787820205,
-        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
+        "lastModified": 1789064587,
+        "narHash": "sha256-KnNh8XNeTRc+Z/XGPcmKlsvGNTrVaQFA04bUCjivozg=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "63815316970587b730f626f3541045bf09c08cfa",
+        "rev": "2c626edeb4489b9a5264d39cd385f383bbe3e29b",
         "type": "github"
       },
       "original": {
@@ -58973,9 +71299,13 @@
     },
     "nix-bundle-logos-module-install_19": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_741",
+=======
+        "logos-nix": "logos-nix_703",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_29",
-        "nix-bundle-lgx": "nix-bundle-lgx_37",
+        "nix-bundle-lgx": "nix-bundle-lgx_34",
         "nixpkgs": [
           "nix-bundle-logos-module-install",
           "logos-nix",
@@ -58983,11 +71313,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1787820205,
-        "narHash": "sha256-Qd2gAKecZgw51jF8ERwweG/vOMBtGdzxhLp55OHXybc=",
+        "lastModified": 1789064587,
+        "narHash": "sha256-KnNh8XNeTRc+Z/XGPcmKlsvGNTrVaQFA04bUCjivozg=",
         "owner": "logos-co",
         "repo": "nix-bundle-logos-module-install",
-        "rev": "63815316970587b730f626f3541045bf09c08cfa",
+        "rev": "2c626edeb4489b9a5264d39cd385f383bbe3e29b",
         "type": "github"
       },
       "original": {
@@ -59144,7 +71474,11 @@
     },
     "nix-bundle-logos-module-install_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_270",
+=======
+        "logos-nix": "logos-nix_262",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_9",
         "nix-bundle-lgx": "nix-bundle-lgx_14",
         "nixpkgs": [
@@ -59175,7 +71509,11 @@
     },
     "nix-bundle-logos-module-install_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_318",
+=======
+        "logos-nix": "logos-nix_309",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_10",
         "nix-bundle-lgx": "nix-bundle-lgx_16",
         "nixpkgs": [
@@ -59210,7 +71548,11 @@
     },
     "nix-bundle-logos-module-install_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_351",
+=======
+        "logos-nix": "logos-nix_342",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-package-manager": "logos-package-manager_12",
         "nix-bundle-lgx": "nix-bundle-lgx_18",
         "nixpkgs": [
@@ -59787,7 +72129,11 @@
     },
     "nix-bundle-macos-app_20": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_750",
+=======
+        "logos-nix": "logos-nix_712",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nix-bundle-dir": [
           "nix-bundle-dir"
         ],
@@ -69747,311 +82093,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-windows_641": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_642": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_643": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_644": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_645": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_646": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_647": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_648": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_649": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
     "nixpkgs-windows_65": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_650": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_651": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_652": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_653": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_654": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_655": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_656": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_657": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_658": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_659": {
       "locked": {
         "lastModified": 1782723713,
         "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
@@ -70083,166 +82125,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-windows_660": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_661": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_662": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_663": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_664": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_665": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_666": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_667": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_668": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
-    "nixpkgs-windows_669": {
-      "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
-        "type": "github"
-      }
-    },
     "nixpkgs-windows_67": {
       "locked": {
         "lastModified": 1782723713,
@@ -70259,6 +82141,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs-windows_670": {
       "locked": {
         "lastModified": 1782723713,
@@ -70403,6 +82286,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "nixpkgs-windows_68": {
       "locked": {
         "lastModified": 1782723713,
@@ -81859,279 +93744,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_713": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_714": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_715": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_716": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_717": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_718": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_719": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_72": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_720": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_721": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_722": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_723": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_724": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_725": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_726": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_727": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_728": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_729": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -82163,327 +93776,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_730": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_731": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_732": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_733": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_734": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_735": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_736": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_737": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_738": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_739": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_74": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_740": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_741": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_742": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_743": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_744": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_745": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_746": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_747": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_748": {
-      "locked": {
-        "lastModified": 1759036355,
-        "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e9f00bd893984bc8ce46c895c3bf7cac95331127",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_749": {
       "locked": {
         "lastModified": 1759036355,
         "narHash": "sha256-0m27AKv6ka+q270dw48KflE0LwQYrO7Fm4/2//KCVWg=",
@@ -82515,6 +93808,7 @@
         "type": "github"
       }
     },
+<<<<<<< HEAD
     "nixpkgs_750": {
       "locked": {
         "lastModified": 1759036355,
@@ -82531,6 +93825,8 @@
         "type": "github"
       }
     },
+=======
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
     "nixpkgs_76": {
       "locked": {
         "lastModified": 1759036355,
@@ -83028,7 +94324,11 @@
     },
     "process-stats_4": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_340",
+=======
+        "logos-nix": "logos-nix_331",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -83059,7 +94359,11 @@
     },
     "process-stats_5": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_371",
+=======
+        "logos-nix": "logos-nix_358",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-downloader-module",
           "logos-module-builder",
@@ -83086,7 +94390,11 @@
     },
     "process-stats_6": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_512",
+=======
+        "logos-nix": "logos-nix_492",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -83117,7 +94425,11 @@
     },
     "process-stats_7": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_543",
+=======
+        "logos-nix": "logos-nix_523",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-module",
           "logos-module-builder",
@@ -83144,7 +94456,11 @@
     },
     "process-stats_8": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_678",
+=======
+        "logos-nix": "logos-nix_647",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -83175,7 +94491,11 @@
     },
     "process-stats_9": {
       "inputs": {
+<<<<<<< HEAD
         "logos-nix": "logos-nix_709",
+=======
+        "logos-nix": "logos-nix_674",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "nixpkgs": [
           "logos-package-manager-ui",
           "logos-module-builder",
@@ -83215,13 +94535,20 @@
         "logos-package-manager": "logos-package-manager_15",
         "logos-package-manager-module": "logos-package-manager-module",
         "logos-package-manager-ui": "logos-package-manager-ui",
+<<<<<<< HEAD
         "logos-plugin-qt": "logos-plugin-qt_94",
         "logos-protocol": "logos-protocol_123",
         "logos-qt-mcp": "logos-qt-mcp_9",
         "logos-qt-sdk": "logos-qt-sdk_49",
+=======
+        "logos-plugin-qt": "logos-plugin-qt_86",
+        "logos-protocol": "logos-protocol_109",
+        "logos-qt-mcp": "logos-qt-mcp_9",
+        "logos-qt-sdk": "logos-qt-sdk_47",
+>>>>>>> 5f81af4 (feat: tell same-named repositories apart in the UI)
         "logos-view-module-runtime": "logos-view-module-runtime_19",
         "nix-bundle-appimage": "nix-bundle-appimage_49",
-        "nix-bundle-dir": "nix-bundle-dir_115",
+        "nix-bundle-dir": "nix-bundle-dir_112",
         "nix-bundle-logos-module-install": "nix-bundle-logos-module-install_19",
         "nix-bundle-macos-app": "nix-bundle-macos-app_20",
         "nixpkgs": [

--- a/src/Basecamp/AppManager/AppManagerView.qml
+++ b/src/Basecamp/AppManager/AppManagerView.qml
@@ -260,12 +260,11 @@ Rectangle {
                                         excludeMainUi: false
                                     }
 
-                                    title: modelData.isDefault === true
-                                        ? qsTr("Starter Apps")
-                                        : (modelData.displayName
+                                    title: modelData.displayLabel
+                                           || modelData.displayName
                                            || modelData.name
                                            || modelData.url
-                                           || qsTr("Repository"))
+                                           || qsTr("Repository")
                                     count: repoFilter.visibleCount
                                     modulesSource: repoFilter
                                     viewMode: d.viewMode

--- a/src/Basecamp/Settings/RepositoriesView.qml
+++ b/src/Basecamp/Settings/RepositoriesView.qml
@@ -31,6 +31,39 @@ Item {
         property string newRepoUrl: ""
         property string lastError: ""
         property string pendingRemoveUrl: ""
+
+        // Display names claimed by more than one configured repository.
+        readonly property var duplicateNames: {
+            const counts = ({})
+            const originals = ({})
+            const repos = root.repositories || []
+            for (let i = 0; i < repos.length; ++i) {
+                const label = String(repos[i].displayName || repos[i].name || "")
+                if (label.length === 0) continue
+                const key = label.toLowerCase()
+                counts[key] = (counts[key] || 0) + 1
+                if (originals[key] === undefined) originals[key] = label
+            }
+            const dupes = []
+            for (const key in counts)
+                if (counts[key] > 1) dupes.push(originals[key])
+            dupes.sort()
+            return dupes
+        }
+
+        function isDuplicateName(label) {
+            const l = String(label || "").toLowerCase()
+            if (l.length === 0) return false
+            for (let i = 0; i < duplicateNames.length; ++i)
+                if (String(duplicateNames[i]).toLowerCase() === l) return true
+            return false
+        }
+
+        readonly property string duplicateSignature: duplicateNames.join("\u0001")
+        property string dismissedDuplicateSignature: ""
+        readonly property bool showDuplicateWarning:
+            duplicateNames.length > 0
+            && duplicateSignature !== dismissedDuplicateSignature
     }
 
     LogosScrollView {
@@ -113,6 +146,36 @@ Item {
                 }
             }
 
+            // Duplicate-name warning. Derived from the current repository
+            // list rather than raised once on add, so it stays visible for
+            // as long as the clash exists and can't be missed by an add
+            // that completes while the user is elsewhere.
+            LogosNotice {
+                id: duplicateNameNotice
+                objectName: "repositories.duplicateNameWarning"
+                Layout.fillWidth: true
+                severity: LogosNotice.Warning
+                closable: true
+                shown: false
+                title: d.duplicateNames.length === 1
+                       ? qsTr("More than one repository calls itself “%1”.")
+                             .arg(d.duplicateNames[0])
+                       : qsTr("These names are each claimed by more than one repository: %1.")
+                             .arg(d.duplicateNames.join(qsTr(", ")))
+                message: qsTr("A repository's name comes from its own logos-repo.json, so any "
+                            + "repository can claim any name. Check the URLs below to tell "
+                            + "them apart before installing.")
+                onDismissed: d.dismissedDuplicateSignature = d.duplicateSignature
+                Component.onCompleted: shown = d.showDuplicateWarning
+            }
+
+            Connections {
+                target: d
+                function onShowDuplicateWarningChanged() {
+                    duplicateNameNotice.shown = d.showDuplicateWarning
+                }
+            }
+
             // Add a repository form.
             ColumnLayout {
                 Layout.fillWidth: true
@@ -169,7 +232,8 @@ Item {
                     required property var modelData
 
                     readonly property string url:          modelData.url || ""
-                    readonly property string displayName:  modelData.displayName || modelData.name || ""
+                    readonly property string displayName:  modelData.displayLabel || modelData.displayName || modelData.name || ""
+                    readonly property string claimedName:  modelData.displayName || modelData.name || ""
                     readonly property string description:  modelData.description || ""
                     readonly property string resolveError: modelData.resolveError || ""
                     readonly property bool   isDefault:    modelData.isDefault === true
@@ -210,6 +274,12 @@ Item {
                                 visible: !isEnabled
                                 text: qsTr("Disabled")
                                 color: Theme.palette.textTertiary
+                            }
+                            LogosBadge {
+                                objectName: "repositories.duplicateNameBadge." + url
+                                visible: d.isDuplicateName(claimedName)
+                                text: qsTr("Name reused")
+                                color: Theme.palette.warning
                             }
                             LogosBadge {
                                 visible: resolveError.length > 0


### PR DESCRIPTION
Two repositories can publish the same display name — a fork of the official one in the wild does exactly that — which left them indistinguishable in the app manager and in Settings, and made an install from one repo appear to be running in the other.

- Label a repository with its source when more than one claims the same name: "Logos Official (logos-co)" vs "(0x-r4bbit)". Derived once in PackageCoordinator so every view shows the same name.
- Warn in Settings when a configured repository claims a name that another one already uses.
- Scope in-flight install state (stage, progress, errors) to the repository the operation targets, so only the row acted on shows it.
- Bump the package-downloader module for the source fields the labels are built from.

<!--
Thanks for the PR. A short template so triage and review don't stall.
Delete sections that don't apply — don't leave placeholder text.
-->

## Summary

<!-- One or two sentences: what changes and why. -->

## Linked issues

<!-- e.g. Closes #123, Refs #456. Leave blank if none. -->

## Screenshots / recordings

<!-- Required for any user-visible UI change. Before/after if it's a fix. -->

## Test plan

<!-- How you validated the change. Tick what applies. -->

- [ ] `nix build .#app` succeeds
- [ ] `nix build .#smoke-test -L` passes
- [ ] `nix build .#integration-test -L` passes (if UI-visible)
- [ ] Doctests pass (`nix build .#doctests -L` if touched)
- [ ] Manual verification on:
  - [ ] Linux (AppImage)
  - [ ] Linux (Nix local build)
  - [ ] macOS
- [ ] N/A — docs/CI/tooling only

## Release notes

<!-- One line for the changelog. Prefix with fix:/feat:/chore:/docs:/test:/ci:
     to match the commit-style already used on master. -->

## Checklist

- [ ] Branch prefixed `fix/`, `feat/`, `chore/`, `docs/`, `test/`, or `ci/`
- [ ] No unrelated changes bundled in
- [ ] `CLAUDE.md` / `README.md` / `docs/` updated if behaviour or build steps changed
- [ ] Uncommitted binaries, screenshots, or `.DS_Store` files removed
